### PR TITLE
fix: asf labels

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -20,9 +20,10 @@ github:
     homepage: https://apisix.apache.org/
     labels:
       - apisix
-      - helm chart
+      - helm
+      - chart
       - k8s
-      - Kubernetes
+      - kubernetes
 
     features:
       issues: true


### PR DESCRIPTION
Fix: 

An error occurred while running github feature in .asf.yaml

.asf.yaml: Invalid GitHub label 'helm chart' - must be lowercase alphanumerical and <= 35 characters