### PR TITLE
Modify Helm template to support multiple etcdhost, add anti-affinity

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,14 +44,15 @@ helm uninstall apisix ./chart/apisix -n default
 
 1. How to install APISIX only?
 
-The Charts will install etcd 3.4.14 by default. If you want to install Apache APISIX only, please set `etcd.enabled=false` and set `etcd.host=http://your_etcd_address:2379`.
+The Charts will install etcd 3.4.14 by default. If you want to install Apache APISIX only, please set `etcd.enabled=false` and set `etcd.host={http://your_etcd_address:2379}`.
 
 Please use the FQDN address or the IP of the etcd.
 
 ```shell
+# if etcd export by kubernetes service need spell fully qualified name
 $ helm install apisix ./chart/apisix -n default \
     --set etcd.enabled=false \
-    --set etcd.host=http://your_etcd_address:2379
+    --set etcd.host={http://etcd_node_1:2379\,http://etcd_node_2:2379}
 ```
 
 2. Why get 403 when I access Apache APISIX admin api?

--- a/chart/apisix/templates/configmap.yaml
+++ b/chart/apisix/templates/configmap.yaml
@@ -91,13 +91,12 @@ data:
       # Disabling this configuration item means that the Admin API does not
       # require any authentication.
       admin_key:
-        -
-          name: "admin"
+        # admin: can everything for configuration data
+        - name: "admin"
           key: {{ .Values.admin.credentials.admin }}
           role: admin
-                                      # viewer: only can view configuration data
-        -
-          name: "viewer"
+        # viewer: only can view configuration data
+        - name: "viewer"
           key: {{ .Values.admin.credentials.viewer }}
           role: viewer
       router:
@@ -147,10 +146,12 @@ data:
     etcd:
     {{- if .Values.etcd.enabled }}
       host:                                 # it's possible to define multiple etcd hosts addresses of the same etcd cluster.
-        - "http://{{ .Release.Name }}-etcd.{{ .Release.Namespace }}.svc.{{ .Values.gateway.k8s_domain }}:{{ .Values.etcd.port }}"
+        - "http://{{ .Release.Name }}-etcd.{{ .Release.Namespace }}.svc.{{ .Values.gateway.k8s_domain }}:{{ .Values.etcd.defaultPort }}"
     {{- else }}
       host:                                 # it's possible to define multiple etcd hosts addresses of the same etcd cluster.
-        - "http://{{ .Values.etcd.host }}:{{ .Values.etcd.port }}"         # multiple etcd address
+        {{- range $value := .Values.etcd.host }}
+        - "{{ $value }}"             # multiple etcd address
+        {{- end}}
     {{- end }}
       prefix: {{ .Values.etcd.prefix | quote }}     # apisix configurations prefix
       timeout: {{ .Values.etcd.timeout }}   # 30 seconds

--- a/chart/apisix/templates/deployment.yaml
+++ b/chart/apisix/templates/deployment.yaml
@@ -87,7 +87,7 @@ spec:
       initContainers:
       - name: wait-etcd
         image: busybox:1.28
-        command: ['sh', '-c', "until nc -z {{ .Release.Name }}-etcd.{{ .Release.Namespace }}.svc.{{ .Values.gateway.k8s_domain }} {{ .Values.etcd.port }}; do echo waiting for etcd `date`; sleep 2; done;"]
+        command: ['sh', '-c', "until nc -z {{ .Release.Name }}-etcd.{{ .Release.Namespace }}.svc.{{ .Values.gateway.k8s_domain }} {{ .Values.etcd.defaultPort }}; do echo waiting for etcd `date`; sleep 2; done;"]
       {{- end }}
       volumes:
         - configMap:
@@ -97,9 +97,19 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.affinity }}
+      {{- if .Values.affinity.enable }}
       affinity:
-        {{- toYaml . | nindent 8 }}
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app.kubernetes.io/name
+                  operator: In
+                  values:
+                  - {{ include "apisix.name" . }}
+              topologyKey: kubernetes.io/hostname
+            weight: 100'
       {{- end }}
       {{- with .Values.tolerations }}
       tolerations:

--- a/chart/apisix/values.yaml
+++ b/chart/apisix/values.yaml
@@ -191,4 +191,4 @@ nodeSelector: {}
 tolerations: []
 
 affinity: 
-  enabled: true
+  enabled: false

--- a/chart/apisix/values.yaml
+++ b/chart/apisix/values.yaml
@@ -21,17 +21,18 @@ image:
   # Overrides the image tag whose default is the chart appVersion.
   tag: 2.1-alpine
 
-
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
 podAnnotations: {}
 
-podSecurityContext: {}
+podSecurityContext:
+  {}
   # fsGroup: 2000
 
-securityContext: {}
+securityContext:
+  {}
   # capabilities:
   #   drop:
   #   - ALL
@@ -74,10 +75,11 @@ gateway:
 etcd:
   # install etcd(v3) by default, set false if do not want to install etcd(v3) together
   enabled: true
-  host: etcd.host # host or ip e.g.172.20.128.89
+  host:
+    - http://etcd.host:2379 # host or ip e.g. http://172.20.128.89:2379
   prefix: "/apisix"
   timeout: 30
-  port: 2379
+  defaultPort: 2379
   auth:
     rbac:
       # No authentication by default
@@ -163,9 +165,9 @@ stream_plugins:
 
 resources:
   limits:
-    cpu: '2'
+    cpu: "2"
   requests:
-    cpu: '50m'
+    cpu: "50m"
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
@@ -188,5 +190,5 @@ nodeSelector: {}
 
 tolerations: []
 
-affinity: {}
-
+affinity: 
+  enabled: true


### PR DESCRIPTION
1. Suports add multiple etcdhost.
2. `etcd.port` has modified to `etcd.default`.
3. Modifiy README.me.
4. Add default anti-affinity to deployment.yaml template, default false. turn on anti-affinity by `--set affinity.enabled=true`