### PR TITLE
feat: add dashboard and ingress-controller as component of apisix

### DIFF
--- a/charts/apisix/Chart.yaml
+++ b/charts/apisix/Chart.yaml
@@ -31,7 +31,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.2
+version: 0.1.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -43,3 +43,13 @@ dependencies:
     version: 5.2.1
     repository: https://charts.bitnami.com/bitnami
     condition: etcd.enabled
+  - name: apisix-dashboard
+    version: 0.1.0
+    repository: file://../apisix-dashboard
+    condition: dashboard.enabled
+    alias: dashboard
+  - name: apisix-ingress-controller
+    version: 0.1.0
+    repository: file://../apisix-ingress-controller
+    condition: ingressController.enabled
+    alias: ingress-controller

--- a/charts/apisix/values.yaml
+++ b/charts/apisix/values.yaml
@@ -115,6 +115,12 @@ admin:
     admin: edd1c9f034335f136f87ad84b625c8f1
     viewer: 4054f7cf07e344346cd3f287985e76a2
 
+dashboard:
+  enabled: false
+
+ingressController:
+  enabled: false
+
 allow:
   # The ip range for allowing access to Apache APISIX
   ipList:


### PR DESCRIPTION
add dashboard and ingress-controller as component of apisix.

We can deploy `apisix`, `apisix-dashboard` and `apisix-ingress-controller` together.
`helm install apisix --set dashboard.enabled=true --set ingressController.enabled=true`
```
apisix-etcd-0                                1/1     Running   0          22m
apisix-dashboard-94f89d48-r79sf              1/1     Running   3          22m
apisix-d9744dc9f-fg47x                       1/1     Running   0          22m
apisix-ingress-controller-5cf7cc8bbc-wm2wx   1/1     Running   0          3m5s
```