### PR TITLE
fix: unified subchart value name

### DIFF
--- a/charts/apisix/Chart.yaml
+++ b/charts/apisix/Chart.yaml
@@ -31,7 +31,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 0.2.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -51,5 +51,5 @@ dependencies:
   - name: apisix-ingress-controller
     version: 0.2.0
     repository: file://../apisix-ingress-controller
-    condition: ingressController.enabled
+    condition: ingress-controller.enabled
     alias: ingress-controller

--- a/charts/apisix/values.yaml
+++ b/charts/apisix/values.yaml
@@ -118,7 +118,7 @@ admin:
 dashboard:
   enabled: false
 
-ingressController:
+ingress-controller:
   enabled: false
 
 allow:


### PR DESCRIPTION
before: 
`helm install apisix apisix/apisix --set ingressController.enabled=true --set ingress-controller.replicaCount=2`

after:
`helm install apisix apisix/apisix --set ingress-controller.enabled=true --set ingress-controller.replicaCount=2`
