### PR TITLE
chore: use apisix:2.5-apline image

### DIFF
--- a/charts/apisix/Chart.yaml
+++ b/charts/apisix/Chart.yaml
@@ -31,12 +31,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.1
+version: 0.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 2.3.0
+appVersion: 2.5.0
 
 dependencies:
   - name: etcd

--- a/charts/apisix/values.yaml
+++ b/charts/apisix/values.yaml
@@ -19,7 +19,7 @@ image:
   repository: apache/apisix
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: 2.3-alpine
+  tag: 2.5-alpine
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
Apache APISIX 2.5 had been released several days ago, it's time to update the charts.