### PR TITLE
chore: update the default version of apisix-dashboard

### DIFF
--- a/charts/apisix-dashboard/Chart.yaml
+++ b/charts/apisix-dashboard/Chart.yaml
@@ -31,7 +31,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.2
+version: 0.1.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/apisix-dashboard/values.yaml
+++ b/charts/apisix-dashboard/values.yaml
@@ -24,7 +24,7 @@ image:
   repository: apache/apisix-dashboard
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "2.3"
+  tag: "2.6"
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
Currently, the default installation version of APISIX is `2.5`, but the default installation version of apisix-dashboard is `2.3`, and the versions between them are not compatible. This PR is to update the default installed version of apisix-dashboard to 2.6, which solves the problem of incompatible versions when apisix-dashboard and apisix are installed by default.

https://github.com/apache/apisix-helm-chart/blob/c7edd2da0bac6a1c350478226cbee3c20a9556bc/charts/apisix/values.yaml#L22

https://github.com/apache/apisix-helm-chart/blob/c7edd2da0bac6a1c350478226cbee3c20a9556bc/charts/apisix-dashboard/values.yaml#L27