### PR TITLE
feat: support for controller-only deployment

### DIFF
--- a/charts/apisix/values.yaml
+++ b/charts/apisix/values.yaml
@@ -14,6 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+apisix:
+  # Enable or disable Apache APISIX itself
+  # Set it to flase and ingress-controller.enabled=true will deploy only ingress-controller
+  enabled: true
+
 replicaCount: 1
 image:
   repository: apache/apisix


### PR DESCRIPTION
Add new top-level `apisix.enabled` setting to control whether
deploy apisix-ingress controller only.

Signed-off-by: Jintao Zhang <zhangjintao9020@gmail.com>