### PR TITLE
docs: fix broken link in apisix chart README

### DIFF
--- a/charts/apisix/README.md
+++ b/charts/apisix/README.md
@@ -105,8 +105,7 @@ Apache APISIX service parameters, this determines how users can access itself.
 
 ### plugins and stream_plugins parameters 
 
-Default enabled plugins. See [configmap template](charts/apisix/templates/configmap.yaml) for details.
-
+Default enabled plugins. See [configmap template](https://github.com/apache/apisix-helm-chart/blob/master/charts/apisix/templates/configmap.yaml) for details.
 
 ### etcd parameters
 


### PR DESCRIPTION
The link to `configmap template` is incorrect, and this PR is going to fix it.

Signed-off-by: imjoey <majunjie@apache.org>