### PR TITLE
chore: bump apisix-ingress-controller to v0.6.0

### DIFF
--- a/charts/apisix-ingress-controller/Chart.yaml
+++ b/charts/apisix-ingress-controller/Chart.yaml
@@ -24,8 +24,8 @@ keywords:
   - nginx
   - crd
 type: application
-version: 0.4.1
-appVersion: 0.5.0
+version: 0.4.2
+appVersion: 0.6.0
 
 maintainers:
   - name: tao12345666333

--- a/charts/apisix-ingress-controller/values.yaml
+++ b/charts/apisix-ingress-controller/values.yaml
@@ -42,7 +42,7 @@ replicaCount: 1
 image:
   repository: apache/apisix-ingress-controller
   pullPolicy: IfNotPresent
-  tag: "0.5.0"
+  tag: "0.6.0"
 
 imagePullSecrets: []
 


### PR DESCRIPTION
Signed-off-by: Jintao Zhang <zhangjintao9020@gmail.com>

APISIX Ingress controller v0.6.0 has been released 22 days ago.

full diff https://github.com/apache/apisix-ingress-controller/compare/0.5.0...0.6.0