### PR TITLE
docs: removed navigation title from sidebar to docs dropdown

### DIFF
--- a/docs/en/latest/config.json
+++ b/docs/en/latest/config.json
@@ -2,11 +2,6 @@
   "version": 0.4,
   "sidebar": [
     {
-      "type": "link",
-      "label": "Apache APISIX™ Helm Chart",
-      "href": "https://apisix.apache.org/docs/helm-chart/apisix/"
-    },
-    {
       "type": "category",
       "label": "Installation",
       "items": ["apisix", "apisix-dashboard", "apisix-ingress-controller"]


### PR DESCRIPTION
issue resolved: [#360 from apisix-website](https://github.com/apache/apisix-website/issues/360)