### PR TITLE
Update etcd and dashboard

### DIFF
--- a/charts/apisix/Chart.yaml
+++ b/charts/apisix/Chart.yaml
@@ -31,7 +31,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.4
+version: 0.3.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/apisix/values.yaml
+++ b/charts/apisix/values.yaml
@@ -214,6 +214,10 @@ etcd:
   statefulset:
     replicaCount: 3
 
+  persistence:
+    enabled: true
+    size: 8Gi
+    # storageClass: "-"
 
 dashboard:
   enabled: false
@@ -222,8 +226,6 @@ dashboard:
       etcd:
         endpoints:
           - apisix-etcd:2379
-        username: admin
-        password: edd1c9f034335f136f87ad84b625c8f1
 
 ingress-controller:
   enabled: false

--- a/charts/apisix/values.yaml
+++ b/charts/apisix/values.yaml
@@ -219,8 +219,10 @@ etcd:
     size: 8Gi
     # storageClass: "-"
 
+
 dashboard:
   enabled: false
+
 
 ingress-controller:
   enabled: false

--- a/charts/apisix/values.yaml
+++ b/charts/apisix/values.yaml
@@ -211,12 +211,19 @@ etcd:
   service:
     port: 2379
 
-  replicaCount: 3
+  statefulset:
+    replicaCount: 3
 
 
 dashboard:
   enabled: false
-
+  config:
+    conf:
+      etcd:
+        endpoints:
+          - apisix-etcd:2379
+        username: admin
+        password: edd1c9f034335f136f87ad84b625c8f1
 
 ingress-controller:
   enabled: false

--- a/charts/apisix/values.yaml
+++ b/charts/apisix/values.yaml
@@ -221,11 +221,6 @@ etcd:
 
 dashboard:
   enabled: false
-  config:
-    conf:
-      etcd:
-        endpoints:
-          - apisix-etcd:2379
 
 ingress-controller:
   enabled: false


### PR DESCRIPTION
In order to minimize the ability on the initial setup, there're still a few configs should be refined, which are:

1. the `etcd` statefulset replica number
2. the `etcd` persistence instruction - a direct reference to mitigate the usage
3. ~~the `etcd` endpoints for `dashboard` - which sometimes, the different helm release name could make an impact on it~~