### PR TITLE
docs: Remove the "$" or "➜" symbol at the beginning of the command

### DIFF
--- a/charts/apisix/README.md
+++ b/charts/apisix/README.md
@@ -12,10 +12,10 @@ This chart bootstraps all the components needed to run Apache APISIX on a Kubern
 ## TL;DR
 
 ```sh
-➜ helm repo add apisix https://charts.apiseven.com
-➜ helm repo update
+helm repo add apisix https://charts.apiseven.com
+helm repo update
 
-➜ helm install apisix/apisix --generate-name
+helm install apisix/apisix --generate-name
 ```
 
 ## Prerequisites
@@ -29,10 +29,10 @@ This chart bootstraps all the components needed to run Apache APISIX on a Kubern
 To install the chart with the release name `my-apisix`:
 
 ```sh
-➜ helm repo add apisix https://charts.apiseven.com
-➜ helm repo update
+helm repo add apisix https://charts.apiseven.com
+helm repo update
 
-➜ helm install my-apisix apisix/apisix
+helm install my-apisix apisix/apisix
 ```
 
 ## Uninstall
@@ -40,7 +40,7 @@ To install the chart with the release name `my-apisix`:
  To uninstall/delete a Helm release `my-apisix`:
 
  ```sh
-➜ helm delete my-apisix
+helm delete my-apisix
  ```
 
 The command removes all the Kubernetes components associated with the chart and deletes the release.

--- a/docs/en/latest/FAQ.md
+++ b/docs/en/latest/FAQ.md
@@ -29,7 +29,7 @@ Please use the FQDN or the IP address of the ETCD cluster.
 
 ```shell
 # if etcd export by kubernetes service need spell fully qualified name
-$ helm install apisix apisix/apisix \
+helm install apisix apisix/apisix \
     --set etcd.enabled=false \
     --set etcd.host={http://etcd_node_1:2379\,http://etcd_node_2:2379}
 ```
@@ -39,7 +39,7 @@ $ helm install apisix apisix/apisix \
 We can define `admin.allow.ipList` in CIDR.
 
 ```shell
-$ helm install apisix apisix/apisix \
+helm install apisix apisix/apisix \
     --set admin.allow.ipList="10.22.100.12/8" \
     --set admin.allow.ipList="172.0.0.0/24"
 ```
@@ -47,6 +47,6 @@ $ helm install apisix apisix/apisix \
 If you want to allow all IPs for a quick test, just set `admin.allow.ipList=""`
 
 ```shell
-$ helm install apisix apisix/apisix \
+helm install apisix apisix/apisix \
     --set admin.allow.ipList=""
 ```

--- a/docs/en/latest/apisix-dashboard.md
+++ b/docs/en/latest/apisix-dashboard.md
@@ -26,9 +26,9 @@ title: Apache APISIX Dashboard Helm Chart
 To install the chart with release name `apisix-dashboard`:
 
 ```shell
-$ helm repo add apisix https://charts.apiseven.com
-$ helm repo update
-$ helm install apisix-dashboard apisix/apisix-dashboard
+helm repo add apisix https://charts.apiseven.com
+helm repo update
+helm install apisix-dashboard apisix/apisix-dashboard
 ```
 
 ## Uninstall
@@ -36,5 +36,5 @@ $ helm install apisix-dashboard apisix/apisix-dashboard
 To uninstall/delete the `apisix-dashboard` release:
 
 ```shell
-$ helm uninstall apisix-dashboard
+helm uninstall apisix-dashboard
 ```

--- a/docs/en/latest/apisix-ingress-controller.md
+++ b/docs/en/latest/apisix-ingress-controller.md
@@ -32,9 +32,9 @@ title: Apache APISIX Ingress Controller Helm Chart
 To install apisix-ingress-controller which release name is `apisix-ingress-controller`:
 
 ```bash
-$ helm repo add apisix https://charts.apiseven.com
-$ helm repo update
-$ helm install apisix-ingress-controller apisix/apisix-ingress-controller --namespace ingress-apisix
+helm repo add apisix https://charts.apiseven.com
+helm repo update
+helm install apisix-ingress-controller apisix/apisix-ingress-controller --namespace ingress-apisix
 ```
 
 ## Uninstall
@@ -74,6 +74,6 @@ CRDs upgrading is special as helm chart will skip to apply these resources when 
 In such a case, you may need to apply these CRDs by yourself.
 
 ```shell
-$ cd /path/to/apisix-ingress-controller
-$ kubectl apply -k samples/deploy/crd/
+cd /path/to/apisix-ingress-controller
+kubectl apply -k samples/deploy/crd/
 ```

--- a/docs/en/latest/apisix.md
+++ b/docs/en/latest/apisix.md
@@ -26,9 +26,9 @@ title: Apache APISIX Helm Chart
 To install the chart with release name `apisix`:
 
 ```shell
-$ helm repo add apisix https://charts.apiseven.com
-$ helm repo update
-$ helm install apisix apisix/apisix
+helm repo add apisix https://charts.apiseven.com
+helm repo update
+helm install apisix apisix/apisix
 ```
 
 ## Uninstall


### PR DESCRIPTION
Remove the "$" or "➜" symbol at the beginning of the command, otherwise the command cannot be executed directly.