### PR TITLE
feat: support more APISIX features

### DIFF
--- a/charts/apisix/README.md
+++ b/charts/apisix/README.md
@@ -73,6 +73,16 @@ The following tables lists the configurable parameters of the apisix chart and t
 | `apisix.tolerations`                     | List of node taints to tolerate                     | `{}`                                                    |
 | `apisix.affinity`                        | Set affinity for Apache APISIX deploy               | `{}`                                                    |
 | `apisix.podAntiAffinity.enabled`         | Enable or disable podAntiAffinity                   | `false`                                                 |
+| `apisix.setIDFromPodUID` | Whether to use the Pod UID as the APISIX instance id, see [apache/apisix#5417](https://github.com/apache/apisix/issues/5417) to decide whether you should enable this setting) | `false` |
+| `apisix.customLuaSharedDicts` | Add custom [lua_shared_dict](https://github.com/openresty/lua-nginx-module#toc88) settings, click [here](https://github.com/apache/apisix-helm-chart/blob/master/charts/apisix/values.yaml#L27-L30) to learn the format of a shared dict  | `[]` |
+| `apisix.pluginAttrs` | Set APISIX plugin attributes, see [config-default.yaml](https://github.com/apache/apisix/blob/master/conf/config-default.yaml#L376) for more details | `{}` |
+| `apisix.customPlugins.enabled` | Whether to configure some custom plugins | `false` |
+| `apisix.customPlugins.luaPath` | Configure `LUA_PATH` so that custom plugin codes can be located | `""` |
+| `apisix.customPlugins.plugins[].name` | Custom plugin name | `""` |
+| `apisix.customPlugins.plugins[].attrs` | Custom plugin attributes | `{}` |
+| `apisix.customPlugins.plugins[].configMap.name` | Name of the ConfigMap where the plugin codes store | `""` |
+| `apisix.customPlugins.plugins[].configMap.mounts[].key` | Name of the ConfigMap key, for setting the mapping relationship between ConfigMap key and the plugin code path. | `""` |
+| `apisix.customPlugins.plugins[].configMap.mounts[].path` | Filepath of the plugin code, for setting the mapping relationship between ConfigMap key and the plugin code path. | `""` |
 
 
 ### gateway parameters
@@ -132,8 +142,9 @@ Apache APISIX service parameters, this determines how users can access itself.
 | `etcd.auth.tls.certFilename`    | etcd client cert filename using in `etcd.auth.tls.existingSecret`                                                                                                | `""`                        |
 | `etcd.auth.tls.certKeyFilename` | etcd client cert key filename using in `etcd.auth.tls.existingSecret`                                                                                            | `""`                        |
 | `etcd.auth.tls.verify`          | whether to verify the etcd endpoint certificate when setup a TLS connection to etcd                                                                              | `true`                      |
+| `etcd.auth.tls.sni`            | specify the TLS [Server Name Indication](https://en.wikipedia.org/wiki/Server_Name_Indication) extension,  the ETCD endpoint hostname will be used when this setting is unset. | `""` |
 
-If etcd.enabled is true, set more values of bitnami/etcd helm chart use etcd as prefix
+If etcd.enabled is true, set more values of bitnami/etcd helm chart use etcd as prefix.
 
 ### plugins and stream_plugins parameters 
 

--- a/charts/apisix/templates/configmap.yaml
+++ b/charts/apisix/templates/configmap.yaml
@@ -206,6 +206,7 @@ data:
         cert: "/etcd-ssl/{{ .Values.etcd.auth.tls.certFilename }}"
         key: "/etcd-ssl/{{ .Values.etcd.auth.tls.certKeyFilename }}"
         verify: {{ .Values.etcd.auth.tls.verify }}
+        sni: "{{ .Values.etcd.auth.tls.sni }}"
       {{- end }}
 
     {{- if .Values.plugins }}
@@ -224,10 +225,17 @@ data:
       - {{ $plugin }}
     {{- end }}
 
-    {{- if .Values.customPlugins.enabled }}
+    {{- if or .Values.pluginAttrs .Values.customPlugins.enabled }}
     plugin_attr:
+    {{- if .Values.customPlugins.enabled }}
     {{- range $plugin := .Values.customPlugins.plugins }}
       {{ $plugin.name }}: {{- $plugin.attrs | toYaml | nindent 8 }}
+    {{- end }}
+    {{- end }}
+    {{- if .Values.pluginAttrs }}
+    {{- range $name, $attrs := .Values.pluginAttrs }}
+      {{ $name}}: {{- $attrs | toYaml | nindent 8 }}
+    {{- end }}
     {{- end }}
     {{- end }}
 {{- end }}

--- a/charts/apisix/templates/deployment.yaml
+++ b/charts/apisix/templates/deployment.yaml
@@ -79,6 +79,11 @@ spec:
                 - -c
                 - "sleep 30"
           volumeMounts:
+            {{- if .Values.apisix.setIDFromPodUID }}
+            - mountPath: /usr/local/apisix/conf/apisix.uid
+              name: id
+              subPath: apisix.uid
+            {{- end }}
             - mountPath: /usr/local/apisix/conf/config.yaml
               name: apisix-config
               subPath: config.yaml
@@ -121,6 +126,14 @@ spec:
         - secret:
             secretName: {{ .Values.etcd.auth.tls.existingSecret | quote }}
           name: etcd-ssl
+        {{- end }}
+        {{- if .Values.apisix.setIDFromPodUID }}
+        - downwardAPI:
+            items:
+              - path: "apisix.uid"
+                fieldRef:
+                  fieldPath: metadata.uid
+          name: id
         {{- end }}
       {{- if .Values.customPlugins.enabled }}
       {{- range $plugin := .Values.customPlugins.plugins }}

--- a/charts/apisix/values.yaml
+++ b/charts/apisix/values.yaml
@@ -186,6 +186,8 @@ stream_plugins:
   - ip-restriction
   - limit-conn
 
+pluginAttrs: null
+
 # customPlugins allows you to mount your own HTTP plugins.
 customPlugins:
   enabled: false
@@ -265,6 +267,7 @@ etcd:
       certFilename: ""
       certKeyFilename: ""
       verify: true
+      sni: ""
 
   service:
     port: 2379

--- a/charts/apisix/values.yaml
+++ b/charts/apisix/values.yaml
@@ -188,7 +188,7 @@ stream_plugins:
   - ip-restriction
   - limit-conn
 
-pluginAttrs: null
+pluginAttrs: {}
 
 # customPlugins allows you to mount your own HTTP plugins.
 customPlugins:

--- a/charts/apisix/values.yaml
+++ b/charts/apisix/values.yaml
@@ -23,6 +23,9 @@ apisix:
   # Set it to false and ingress-controller.enabled=true will deploy only ingress-controller
   enabled: true
 
+  # Use Pod metadata.uid as the APISIX id.
+  setIDFromPodUID: false
+
   customLuaSharedDicts: []
     # - name: foo
     #   size: 10k
@@ -66,7 +69,6 @@ apisix:
   # If true, it will sets the anti-affinity of the Pod.
   podAntiAffinity:
     enabled: false
-
 
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
This Pull Request adds some new features for the apisix charts, so that more and more APISIX features can be used.

1. Support to configure ETCD SNI;
2. Support to specify Plugin Attrs;
3. Support to use Pod UID as the APISIX instance id (see https://github.com/apache/apisix/issues/5417 for details).

Signed-off-by: Chao Zhang <tokers@apache.org>