### PR TITLE
feat: add extra labels and annotations for service monitor

### DIFF
--- a/charts/apisix-ingress-controller/templates/servicemonitor.yaml
+++ b/charts/apisix-ingress-controller/templates/servicemonitor.yaml
@@ -22,6 +22,12 @@ metadata:
   {{- if .Values.serviceMonitor.namespace }}
   namespace: {{ .Values.serviceMonitor.namespace }}
   {{- end }}
+  {{- if .Values.serviceMonitor.labels }}
+  labels: {{- toYaml .Values.serviceMonitor.labels | nindent 4 }}
+  {{- end }}
+  {{- if .Values.serviceMonitor.annotations }}
+  annotations: {{- toYaml .Values.serviceMonitor.annotations | nindent 4 }}
+  {{- end }}
 spec:
   endpoints:
   - targetPort: http

--- a/charts/apisix-ingress-controller/values.yaml
+++ b/charts/apisix-ingress-controller/values.yaml
@@ -124,3 +124,7 @@ serviceMonitor:
   enabled: false
   namespace: "monitoring"
   interval: 15s
+  # @param serviceMonitor.labels ServiceMonitor extra labels
+  labels: {}
+  # @param serviceMonitor.annotations ServiceMonitor annotations
+  annotations: {}


### PR DESCRIPTION
If [serviceMonitorSelector.matchLabels](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/user-guides/getting-started.md#include-servicemonitors) are enabled, we need some extra labels for service monitor



link: #76 #87