### PR TITLE
feat(apisix): add service label

### DIFF
--- a/charts/apisix/templates/service-admin.yaml
+++ b/charts/apisix/templates/service-admin.yaml
@@ -25,6 +25,7 @@ metadata:
     {{- end }}
   labels:
     {{- include "apisix.labels" . | nindent 4 }}
+    app.kubernetes.io/service: apisix-admin
 spec:
   type: {{ .Values.admin.type }}
   {{- if eq .Values.admin.type "LoadBalancer" }}

--- a/charts/apisix/templates/service-gateway.yaml
+++ b/charts/apisix/templates/service-gateway.yaml
@@ -26,6 +26,7 @@ metadata:
     {{- end }}
   labels:
     {{- include "apisix.labels" . | nindent 4 }}
+    app.kubernetes.io/service: apisix-gateway
 spec:
   type: {{ .Values.gateway.type }}
   externalTrafficPolicy: {{ .Values.gateway.externalTrafficPolicy }}

--- a/charts/apisix/templates/servicemonitor.yaml
+++ b/charts/apisix/templates/servicemonitor.yaml
@@ -35,6 +35,7 @@ spec:
   selector:
     matchLabels:
       {{- include "apisix.labels" . | nindent 6 }}
+      app.kubernetes.io/service: apisix-gateway
   endpoints:
   - scheme: http
     targetPort: prometheus


### PR DESCRIPTION
The `servicemonitor` matches both `apisix-admin` and `apisix-gateway` services, and Prometheus generates two scrape jobs. Adding a `service` label would be more appropriate.