### PR TITLE
feat: add networkpolicy to apisix helm chart

### DIFF
--- a/charts/apisix/templates/_helpers.tpl
+++ b/charts/apisix/templates/_helpers.tpl
@@ -74,3 +74,14 @@ Usage:
         {{- tpl (.value | toYaml) .context }}
     {{- end }}
 {{- end -}}
+
+{{/*
+Return the appropriate apiVersion for networkpolicy.
+*/}}
+{{- define "networkPolicy.apiVersion" -}}
+    {{- if semverCompare ">=1.4-0, <1.7-0" .Capabilities.KubeVersion.GitVersion -}}
+        {{- print "extensions/v1beta1" -}}
+    {{- else -}}
+        {{- print "networking.k8s.io/v1" -}}
+    {{- end -}}
+{{- end -}}

--- a/charts/apisix/templates/networkpolicy.yaml
+++ b/charts/apisix/templates/networkpolicy.yaml
@@ -1,0 +1,77 @@
+{{- if .Values.apisix.networkPolicy.enabled }}
+{{- $fullName := include "apisix.fullname" . -}}
+kind: NetworkPolicy
+apiVersion: {{ template "networkPolicy.apiVersion" . }}
+metadata:
+  name: {{ include "apisix.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels: 
+    {{- include "apisix.labels" . | nindent 4 }}
+  {{- if .Values.apisix.networkPolicy.annotations }}
+    {{- with .Values.apisix.networkPolicy.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
+spec:
+  podSelector:
+    matchLabels: {{- include "apisix.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+  {{- if .Values.apisix.networkPolicy.additionalEgress }}
+    - Egress
+  egress:
+    - ports:
+        - port: 53
+          protocol: UDP
+    - ports:
+        - port: {{ .Values.gateway.http.containerPort -}}
+        {{- if .Values.gateway.tls.enabled }}
+        - port: {{ .Values.gateway.tls.containerPort }}
+        {{end}}
+      to:
+        - podSelector:
+            matchLabels: {{- include "apisix.selectorLabels" . | nindent 14 }}
+    {{- if .Values.apisix.networkPolicy.additionalEgress }}
+      {{- with .Values.apisix.networkPolicy.additionalEgress }}
+        {{- toYaml . | nindent 4 }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
+  ingress:
+    - ports:
+        - port: {{ .Values.gateway.http.containerPort }}
+        {{- if .Values.gateway.tls.enabled }}
+        - port: {{ .Values.gateway.tls.containerPort }}
+        {{- end }}
+        {{- if .Values.admin.enabled }}
+        - port: {{ .Values.admin.port }}
+        {{- end }}
+        {{- if .Values.serviceMonitor.enabled }}
+        - port: {{ .Values.serviceMonitor.containerPort }}
+        {{- end }}
+      {{- if not .Values.apisix.networkPolicy.enableExternal }}
+      from:
+        - podSelector:
+            matchLabels:
+              {{ $fullName }}-client: "true"
+        {{- if .Values.apisix.networkPolicy.ingressNSMatchLabels }}
+        - namespaceSelector:
+            matchLabels:
+              {{- range $key, $value := .Values.apisix.networkPolicy.ingressNSMatchLabels }}
+              {{ $key | quote }}: {{ $value | quote }}
+              {{- end }}
+          {{- if .Values.apisix.networkPolicy.ingressNSPodMatchLabels }}
+          podSelector:
+            matchLabels:
+              {{- range $key, $value := .Values.apisix.networkPolicy.ingressNSPodMatchLabels }}
+              {{ $key | quote }}: {{ $value | quote }}
+              {{- end }}
+          {{- end }}
+        {{- end }}
+      {{- end }}
+    {{- if .Values.apisix.networkPolicy.additionalIngress }}
+      {{- with .Values.apisix.networkPolicy.additionalIngress }}
+        {{- toYaml . | nindent 4 }}
+      {{- end }}    {{- end }}
+{{- end }}

--- a/charts/apisix/values.yaml
+++ b/charts/apisix/values.yaml
@@ -50,6 +50,43 @@ apisix:
     # readOnlyRootFilesystem: true
     # runAsNonRoot: true
     # runAsUser: 1000
+  networkPolicy:
+    enabled: true
+    annotations: {}
+    
+    # Allow all ingress connections
+    # Set it to false to only allow pods with the correct label to access to the ports
+    
+    enableExternal: true
+    
+    # Add additional ingress rules to the NetworkPolicy
+    # e.g:
+    # extraIngress:
+    #   - ports:
+    #       - port: 8080
+    #     from:
+    #       - podSelector:
+    #            matchLabels:
+    #              app: backend
+    #
+    additionalIngress: []
+    
+    # Add additional egress rules to the NetworkPolicy
+    # e.g:
+    # extraEgress:
+    # - ports:
+    #     - port: 8080
+    #   to:
+    #     - podSelector:
+    #           matchLabels:
+    #             app: backend
+    #
+    additionalEgress: []
+    
+    ingressNSMatchLabels: {}
+    # Allow traffic from specific namespaces
+    ingressNSPodMatchLabels: {} 
+    # Allow trafic from specific pods from other namespaces
 
   resources: {}
     # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
Add the ability to create a custom `networkpolicy` for APISIX helm chart.
The etcd helm chart already provides a `networkpolicy` if needed.
If this proves to be a good addition, I can also make the `networkpolicy` for the APISIX-dashboard and ingress controller helm chart.
