### PR TITLE
feat: add lua module hook support

### DIFF
--- a/charts/apisix/README.md
+++ b/charts/apisix/README.md
@@ -76,13 +76,12 @@ The following tables lists the configurable parameters of the apisix chart and t
 | `apisix.setIDFromPodUID` | Whether to use the Pod UID as the APISIX instance id, see [apache/apisix#5417](https://github.com/apache/apisix/issues/5417) to decide whether you should enable this setting) | `false` |
 | `apisix.customLuaSharedDicts` | Add custom [lua_shared_dict](https://github.com/openresty/lua-nginx-module#toc88) settings, click [here](https://github.com/apache/apisix-helm-chart/blob/master/charts/apisix/values.yaml#L27-L30) to learn the format of a shared dict  | `[]` |
 | `apisix.pluginAttrs` | Set APISIX plugin attributes, see [config-default.yaml](https://github.com/apache/apisix/blob/master/conf/config-default.yaml#L376) for more details | `{}` |
-| `apisix.customPlugins.enabled` | Whether to configure some custom plugins | `false` |
-| `apisix.customPlugins.luaPath` | Configure `LUA_PATH` so that custom plugin codes can be located | `""` |
-| `apisix.customPlugins.plugins[].name` | Custom plugin name | `""` |
-| `apisix.customPlugins.plugins[].attrs` | Custom plugin attributes | `{}` |
-| `apisix.customPlugins.plugins[].configMap.name` | Name of the ConfigMap where the plugin codes store | `""` |
-| `apisix.customPlugins.plugins[].configMap.mounts[].key` | Name of the ConfigMap key, for setting the mapping relationship between ConfigMap key and the plugin code path. | `""` |
-| `apisix.customPlugins.plugins[].configMap.mounts[].path` | Filepath of the plugin code, for setting the mapping relationship between ConfigMap key and the plugin code path. | `""` |
+| `apisix.luaModuleHook.enabled` | Whether to add a custom lua module | `false` |
+| `apisix.luaModuleHook.luaPath` | Configure `LUA_PATH` so that your own lua module codes can be located | `""` |
+| `apisix.luaModuleHook.hookPoint` | The entrypoint of your lua module, use Lua require syntax, like `"module.say_hello"`  | `""` |
+| `apisix.luaModuleHook.configMapRef.name` | Name of the ConfigMap where the lua module codes store | "" |
+| `apisix.luaModuleHook.configMapRef.mounts[].key` | Name of the ConfigMap key, for setting the mapping relationship between ConfigMap key and the lua module code path. | `""` |
+| `apisix.luaModuleHook.configMapRef.mounts[].path` | Filepath of the plugin code, for setting the mapping relationship between ConfigMap key and the lua module code path. | `""` |
 
 
 ### gateway parameters
@@ -149,6 +148,18 @@ If etcd.enabled is true, set more values of bitnami/etcd helm chart use etcd as 
 ### plugins and stream_plugins parameters 
 
 Default enabled plugins. See [configmap template](https://github.com/apache/apisix-helm-chart/blob/master/charts/apisix/templates/configmap.yaml) for details.
+
+### custom plugin parameters
+
+| Parameter                       | Description                                                                                                                                                      | Default                     |
+|---------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------|
+| `apisix.customPlugins.enabled` | Whether to configure some custom plugins | `false` |
+| `apisix.customPlugins.luaPath` | Configure `LUA_PATH` so that custom plugin codes can be located | `""` |
+| `apisix.customPlugins.plugins[].name` | Custom plugin name | `""` |
+| `apisix.customPlugins.plugins[].attrs` | Custom plugin attributes | `{}` |
+| `apisix.customPlugins.plugins[].configMap.name` | Name of the ConfigMap where the plugin codes store | `""` |
+| `apisix.customPlugins.plugins[].configMap.mounts[].key` | Name of the ConfigMap key, for setting the mapping relationship between ConfigMap key and the plugin code path. | `""` |
+| `apisix.customPlugins.plugins[].configMap.mounts[].path` | Filepath of the plugin code, for setting the mapping relationship between ConfigMap key and the plugin code path. | `""` |
 
 ### discovery parameters
 

--- a/charts/apisix/templates/configmap.yaml
+++ b/charts/apisix/templates/configmap.yaml
@@ -49,8 +49,12 @@ data:
       enable_ipv6: true
       config_center: etcd             # etcd: use etcd to store the config value
                                       # yaml: fetch the config value from local yaml file `/your_path/conf/apisix.yaml`
-      {{- if .Values.customPlugins.enabled }}
-      extra_lua_path: {{ .Values.customPlugins.luaPath | quote }}
+      {{- if or .Values.customPlugins.enabled .Values.apisix.luaModuleHook.enabled }}
+      extra_lua_path: {{ .Values.customPlugins.luaPath }};{{ .Values.apisix.luaModuleHook.luaPath }}
+      {{- end }}
+
+      {{- if .Values.apisix.luaModuleHook.enabled }}
+      lua_module_hook: {{ .Values.apisix.luaModuleHook.hookPoint | quote }}
       {{- end }}
 
 
@@ -166,7 +170,7 @@ data:
           - 127.0.0.1
           - 'unix:'
         {{- if .Values.apisix.customLuaSharedDicts }}
-        lua_shared_dicts:              # add custom shared cache to nginx.conf
+        custom_lua_shared_dict:              # add custom shared cache to nginx.conf
         {{- range $dict := .Values.apisix.customLuaSharedDicts }}
           {{ $dict.name }}: {{ $dict.size }}
         {{- end }}

--- a/charts/apisix/templates/deployment.yaml
+++ b/charts/apisix/templates/deployment.yaml
@@ -110,6 +110,13 @@ spec:
           {{- end }}
           {{- end }}
           {{- end }}
+          {{- if .Values.apisix.luaModuleHook.enabled }}
+          {{- range $mount := .Values.apisix.luaModuleHook.configMapRef.mounts }}
+            - mountPath: {{ $mount.path }}
+              name: lua-module-hook
+              subPath: {{ $mount.key }}
+          {{- end }}
+          {{- end }}
           resources:
             {{- toYaml .Values.apisix.resources | nindent 12 }}
       {{- if .Values.etcd.enabled }}
@@ -146,6 +153,11 @@ spec:
           configMap:
             name: {{ $plugin.configMap.name }}
       {{- end }}
+      {{- end }}
+      {{- if .Values.apisix.luaModuleHook.enabled }}
+        - name: lua-module-hook
+          configMap:
+            name: {{ .Values.apisix.luaModuleHook.configMapRef.name }}
       {{- end }}
       {{- with .Values.apisix.nodeSelector }}
       nodeSelector:

--- a/charts/apisix/values.yaml
+++ b/charts/apisix/values.yaml
@@ -33,12 +33,16 @@ apisix:
     #   size: 1m
   luaModuleHook:
     enabled: false
-    luaPath: "" # extend lua_package_path to load third party code
-    hookPoint: "" # the hook module which will be used to inject third party code into APISIX
-                  # use the lua require style like: "module.say_hello"
-    configMapRef: # configmap that stores the codes
+    # extend lua_package_path to load third party code
+    luaPath: ""
+    # the hook module which will be used to inject third party code into APISIX
+    # use the lua require style like: "module.say_hello"
+    hookPoint: ""
+    # configmap that stores the codes
+    configMapRef:
       name: ""
-      mounts: # mounts decides how to mount the codes to the container.
+      # mounts decides how to mount the codes to the container.
+      mounts:
       - key: ""
         path: ""
 

--- a/charts/apisix/values.yaml
+++ b/charts/apisix/values.yaml
@@ -31,6 +31,16 @@ apisix:
     #   size: 10k
     # - name: bar
     #   size: 1m
+  luaModuleHook:
+    enabled: false
+    luaPath: "" # extend lua_package_path to load third party code
+    hookPoint: "" # the hook module which will be used to inject third party code into APISIX
+                  # use the lua require style like: "module.say_hello"
+    configMapRef: # configmap that stores the codes
+      name: ""
+      mounts: # mounts decides how to mount the codes to the container.
+      - key: ""
+        path: ""
 
   image:
     repository: apache/apisix


### PR DESCRIPTION
Also, this PR also removes the deprecated `lua_shared_dicts` field in APISIX's config file, now we use the `custom_lua_shared_dict` field.

Signed-off-by: Chao Zhang <tokers@apache.org>