### PR TITLE
feat: allow defining security context on ingress controller helm chart

### DIFF
--- a/charts/apisix-ingress-controller/README.md
+++ b/charts/apisix-ingress-controller/README.md
@@ -57,3 +57,41 @@ See [Customizing the Chart Before Installing](https://helm.sh/docs/intro/using_h
 ```console
 helm show values apisix/apisix-ingress-controller
 ```
+
+### Security context
+
+A security context provides us with a way to define privilege and access control for a Pod or even at the container level.
+
+Check [here](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#securitycontext-v1-core) to see the SecurityContext resource with more detail.
+
+Check also [here](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) to see a full explanation and some examples to configure the security context.
+
+Right below you have an example of the security context configuration. In this case, we define that all the processes in the container will run with user ID 1000. 
+```yaml
+...
+
+spec:
+  securityContext:
+    runAsUser: 1000
+    runAsGroup: 3000
+...
+```
+
+The same for the group definition, where we define the primary group of 3000 for all processes.
+
+**It's quite important to know, if the `runAsGroup` is omited, the primary group will be root(0)**, which in some cases goes against some security policies.
+
+
+To define this configuration at the **pod level**, you need to set:
+```
+    --set podSecurityContext.runAsUser=«VALUE»
+    --set podSecurityContext.runAsGroup=«VALUE»
+    ...
+```
+
+The same for container level, you need to set:
+```
+    --set securityContext.runAsUser=«VALUE»
+    --set SecurityContext.runAsGroup=«VALUE»
+    ...
+```

--- a/charts/apisix-ingress-controller/templates/deployment.yaml
+++ b/charts/apisix-ingress-controller/templates/deployment.yaml
@@ -53,7 +53,7 @@ spec:
           image: {{ .Values.initContainer.image }}:{{ .Values.initContainer.tag }}
           command: ['sh', '-c', "until nc -z {{ .Values.config.apisix.serviceName }}.{{ .Values.config.apisix.serviceNamespace }}.svc.{{ .Values.clusterDomain }} {{ .Values.config.apisix.servicePort }} ; do echo waiting for apisix-admin; sleep 2; done;"]
           securityContext:
-            {{- toYaml .Values.securityContext | nindent 8 }}
+            {{- toYaml .Values.securityContext | nindent 12 }}
       containers:
         - name: {{ .Chart.Name }}
           command:

--- a/charts/apisix-ingress-controller/templates/deployment.yaml
+++ b/charts/apisix-ingress-controller/templates/deployment.yaml
@@ -39,6 +39,8 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "apisix-ingress-controller.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
       volumes:
         - name: configuration
           configMap:
@@ -50,6 +52,8 @@ spec:
         - name: wait-apisix-admin
           image: {{ .Values.initContainer.image }}:{{ .Values.initContainer.tag }}
           command: ['sh', '-c', "until nc -z {{ .Values.config.apisix.serviceName }}.{{ .Values.config.apisix.serviceNamespace }}.svc.{{ .Values.clusterDomain }} {{ .Values.config.apisix.servicePort }} ; do echo waiting for apisix-admin; sleep 2; done;"]
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}
           command:

--- a/charts/apisix-ingress-controller/values.yaml
+++ b/charts/apisix-ingress-controller/values.yaml
@@ -164,4 +164,3 @@ securityContext: {}
   # readOnlyRootFilesystem: true
   # runAsNonRoot: true
   # runAsUser: 1000
-  

--- a/charts/apisix-ingress-controller/values.yaml
+++ b/charts/apisix-ingress-controller/values.yaml
@@ -152,3 +152,15 @@ serviceMonitor:
   labels: {}
   # @param serviceMonitor.annotations ServiceMonitor annotations
   annotations: {}
+
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000

--- a/charts/apisix-ingress-controller/values.yaml
+++ b/charts/apisix-ingress-controller/values.yaml
@@ -164,3 +164,4 @@ securityContext: {}
   # readOnlyRootFilesystem: true
   # runAsNonRoot: true
   # runAsUser: 1000
+  


### PR DESCRIPTION
Allow defining the security context on apisix-ingress-controller as we have for apisix-dashboard and apisix.