### PR TITLE
docs(README): unify namespace

### DIFF
--- a/charts/apisix-dashboard/README.md
+++ b/charts/apisix-dashboard/README.md
@@ -20,7 +20,7 @@ helm repo update
 **Important:** only helm3 is supported
 
 ```console
-helm install [RELEASE_NAME] apisix/apisix-dashboard
+helm install [RELEASE_NAME] apisix/apisix-dashboard --namespace ingress-apisix --create-namespace
 ```
 
 The command deploys apisix-dashboard on the Kubernetes cluster in the default configuration.
@@ -32,7 +32,7 @@ _See [helm install](https://helm.sh/docs/helm/helm_install/) for command documen
 ## Uninstall Chart
 
 ```console
-helm uninstall [RELEASE_NAME]
+helm uninstall [RELEASE_NAME] --namespace ingress-apisix
 ```
 
 This removes all the Kubernetes components associated with the chart and deletes the release.
@@ -47,21 +47,20 @@ helm upgrade [RELEASE_NAME] [CHART] --install
 
 _See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command documentation._
 
-
 ## Parameters
 
 The following tables lists the configurable parameters of the apisix-dashboard chart and their default values per section/component:
 
 ### Common parameters
 
-| Name               | Description                                                                             | Value           |
-| ------------------ | --------------------------------------------------------------------------------------- | --------------- |
-| `nameOverride`     | String to partially override apisix-dashboard.fullname template (will maintain the release name) | `nil`           |
-| `fullnameOverride` | String to fully override apisix-dashboard.fullname template                                      | `nil`           |
-| `imagePullSecrets` | Docker registry secret names as an array | `[]`  |
-| `image.repository`                 | Apache APISIX Dashboard image repository                                                          | `apache/apisix-dashboard`    |
-| `image.tag`                        | Apache APISIX Dashboard image tag (immutable tags are recommended)                                | `2.10.1-alpine` |
-| `image.pullPolicy`                 | Apache APISIX Dashboard image pull policy                                                         | `IfNotPresent`       |
+| Name               | Description                                                                                       | Value                    |
+| ------------------ | ------------------------------------------------------------------------------------------------- | ------------------------ |
+| `nameOverride`     | String to partially override apisix-dashboard.fullname template (will maintain the release name)  | `nil`                    |
+| `fullnameOverride` | String to fully override apisix-dashboard.fullname template                                       | `nil`                    |
+| `imagePullSecrets` | Docker registry secret names as an array                                                          | `[]`                     |
+| `image.repository` | Apache APISIX Dashboard image repository                                                          | `apache/apisix-dashboard`|
+| `image.tag`        | Apache APISIX Dashboard image tag (immutable tags are recommended)                                | `2.10.1-alpine`          |
+| `image.pullPolicy` | Apache APISIX Dashboard image pull policy                                                         | `IfNotPresent`           |
 
 ### Apache APISIX Dashboard configurable parameters
 
@@ -80,36 +79,33 @@ The following tables lists the configurable parameters of the apisix-dashboard c
 | `config.conf.log.errorLog.filePath`                  | Error log path | `/dev/stderr` |
 | `config.conf.log.errorLog.level`                  | Error log level. Supports levels, lower to higher: debug, info, warn, error, panic, fatal | `warn` |
 
-
-
 ### Deployment parameters
 
-| Name                                 | Description                                                                               | Value           |
-| ------------------------------------ | ----------------------------------------------------------------------------------------- | --------------- |
-| `replicaCount`                       | Number of Apache APISIX Dashboard nodes                                                                   | `1`             |
-| `podAnnotations`                     | Apache APISIX Dashboard Pod annotations                                                                   | `{}`            |
-| `nodeSelector`                       | Node labels for pod assignment                                                            | `{}`            |
-| `tolerations`                        | Tolerations for pod assignment                                                            | `[]`            |
-| `resources.limits`                   | The resources limits for Apache APISIX Dashboard containers                                               | `{}`            |
-| `resources.requests`                 | The requested resources for Apache APISIX Dashboardcontainers                                            | `{}`            |
-| `podSecurityContext`              | Set the securityContext for Apache APISIX Dashboard pods      | `{}`                                                    |
-| `securityContext`                 | Set the securityContext for Apache APISIX Dashboard container | `{}`                                                    |
-| `autoscaling.enabled`                   | Enable autoscaling for Apache APISIX Dashboard deployment                                                   | `false` |
-| `autoscaling.minReplicas`               | Minimum number of replicas to scale back                                                  | `1`    |
-| `autoscaling.maxReplicas`               | Maximum number of replicas to scale out                                                   | `100`    |
-| `autoscaling.targetCPUUtilizationPercentage`                 | Target CPU utilization percentage                                                         | `80`    |
-| `autoscaling.targetMemoryUtilizationPercentage`              | Target Memory utilization percentage                                                      | `nil`    |
-
+| Name                                            | Description                                                                               | Value           |
+| ----------------------------------------------- | ----------------------------------------------------------------------------------------- | --------------- |
+| `replicaCount`                                  | Number of Apache APISIX Dashboard nodes                                                   | `1`             |
+| `podAnnotations`                                | Apache APISIX Dashboard Pod annotations                                                   | `{}`            |
+| `nodeSelector`                                  | Node labels for pod assignment                                                            | `{}`            |
+| `tolerations`                                   | Tolerations for pod assignment                                                            | `[]`            |
+| `resources.limits`                              | The resources limits for Apache APISIX Dashboard containers                               | `{}`            |
+| `resources.requests`                            | The requested resources for Apache APISIX Dashboardcontainers                             | `{}`            |
+| `podSecurityContext`                            | Set the securityContext for Apache APISIX Dashboard pods                                  | `{}`            |
+| `securityContext`                               | Set the securityContext for Apache APISIX Dashboard container                             | `{}`            |
+| `autoscaling.enabled`                           | Enable autoscaling for Apache APISIX Dashboard deployment                                 | `false`         |
+| `autoscaling.minReplicas`                       | Minimum number of replicas to scale back                                                  | `1`             |
+| `autoscaling.maxReplicas`                       | Maximum number of replicas to scale out                                                   | `100`           |
+| `autoscaling.targetCPUUtilizationPercentage`    | Target CPU utilization percentage                                                         | `80`            |
+| `autoscaling.targetMemoryUtilizationPercentage` | Target Memory utilization percentage                                                      | `nil`           |
 
 ### Traffic Exposure parameters
 
 | Name                            | Description                                                                                            | Value                    |
 | ------------------------------- | ------------------------------------------------------------------------------------------------------ | ------------------------ |
-| `service.type`                  | Service type                                                                                           | `ClusterIP`           |
+| `service.type`                  | Service type                                                                                           | `ClusterIP`              |
 | `service.port`                  | Service HTTP port                                                                                      | `80`                     |
 | `ingress.enabled`               | Set to true to enable ingress record generation                                                        | `false`                  |
 | `ingress.annotations`           | Ingress annotations                                                                                    | `{}`                     |
-| `ingress.hosts`       | The list of hostnames to be covered with this ingress record.                          | `[]`                     |
+| `ingress.hosts`                 | The list of hostnames to be covered with this ingress record.                                          | `[]`                     |
 | `ingress.tls`                   | Create TLS Secret                                                                                      | `false`                  |
 
 ### RBAC parameters

--- a/charts/apisix-ingress-controller/README.md
+++ b/charts/apisix-ingress-controller/README.md
@@ -22,7 +22,7 @@ helm repo update
 **Important:** only helm3 is supported
 
 ```console
-helm install [RELEASE_NAME] apisix/apisix-ingress-controller
+helm install [RELEASE_NAME] apisix/apisix-ingress-controller --namespace ingress-apisix --create-namespace
 ```
 
 The command deploys apisix-ingress-controller on the Kubernetes cluster in the default configuration.
@@ -34,7 +34,7 @@ _See [helm install](https://helm.sh/docs/helm/helm_install/) for command documen
 ## Uninstall Chart
 
 ```console
-helm uninstall [RELEASE_NAME]
+helm uninstall [RELEASE_NAME] --namespace ingress-apisix
 ```
 
 This removes all the Kubernetes components associated with the chart and deletes the release.
@@ -48,7 +48,6 @@ helm upgrade [RELEASE_NAME] [CHART] --install
 ```
 
 _See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command documentation._
-
 
 ## Configuration
 
@@ -66,7 +65,8 @@ Check [here](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23
 
 Check also [here](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) to see a full explanation and some examples to configure the security context.
 
-Right below you have an example of the security context configuration. In this case, we define that all the processes in the container will run with user ID 1000. 
+Right below you have an example of the security context configuration. In this case, we define that all the processes in the container will run with user ID 1000.
+
 ```yaml
 ...
 
@@ -81,16 +81,17 @@ The same for the group definition, where we define the primary group of 3000 for
 
 **It's quite important to know, if the `runAsGroup` is omited, the primary group will be root(0)**, which in some cases goes against some security policies.
 
-
 To define this configuration at the **pod level**, you need to set:
-```
+
+```yaml
     --set podSecurityContext.runAsUser=«VALUE»
     --set podSecurityContext.runAsGroup=«VALUE»
     ...
 ```
 
 The same for container level, you need to set:
-```
+
+```yaml
     --set securityContext.runAsUser=«VALUE»
     --set SecurityContext.runAsGroup=«VALUE»
     ...

--- a/charts/apisix/README.md
+++ b/charts/apisix/README.md
@@ -8,21 +8,10 @@ You can use Apache APISIX to handle traditional north-south traffic, as well as 
 
 This chart bootstraps all the components needed to run Apache APISIX on a Kubernetes Cluster using [Helm](https://helm.sh).
 
-
-## TL;DR
-
-```sh
-helm repo add apisix https://charts.apiseven.com
-helm repo update
-
-helm install apisix/apisix --generate-name
-```
-
 ## Prerequisites
 
 * Kubernetes v1.14+
 * Helm v3+
-
 
 ## Install
 
@@ -32,7 +21,7 @@ To install the chart with the release name `my-apisix`:
 helm repo add apisix https://charts.apiseven.com
 helm repo update
 
-helm install my-apisix apisix/apisix
+helm install [RELEASE_NAME] apisix/apisix --namespace ingress-apisix --create-namespace
 ```
 
 ## Uninstall
@@ -40,7 +29,7 @@ helm install my-apisix apisix/apisix
  To uninstall/delete a Helm release `my-apisix`:
 
  ```sh
-helm delete my-apisix
+helm delete [RELEASE_NAME] --namespace ingress-apisix
  ```
 
 The command removes all the Kubernetes components associated with the chart and deletes the release.
@@ -54,7 +43,6 @@ The following tables lists the configurable parameters of the apisix chart and t
 | Parameter                 | Description                                     | Default                                                 |
 |---------------------------|-------------------------------------------------|---------------------------------------------------------|
 | `global.imagePullSecrets` | Global Docker registry secret names as an array | `[]` (does not add image pull secrets to deployed pods) |
-
 
 ### apisix parameters
 
@@ -89,7 +77,6 @@ The following tables lists the configurable parameters of the apisix chart and t
 | `apisix.luaModuleHook.configMapRef.mounts[].key` | Name of the ConfigMap key, for setting the mapping relationship between ConfigMap key and the lua module code path. | `""` |
 | `apisix.luaModuleHook.configMapRef.mounts[].path` | Filepath of the plugin code, for setting the mapping relationship between ConfigMap key and the lua module code path. | `""` |
 
-
 ### gateway parameters
 
 Apache APISIX service parameters, this determines how users can access itself.
@@ -104,7 +91,6 @@ Apache APISIX service parameters, this determines how users can access itself.
 | `gateway.tls.certCAFilename`    | filename be used in the `gateway.tls.existingCASecret`                                                                                                                                          | `""`       |
 | `gateway.stream`                | Apache APISIX service settings for stream                                                                                                                                           |            |
 | `gateway.ingress`               | Using ingress access Apache APISIX service                                                                                                                                          |            |
-
 
 ### admin parameters
 
@@ -207,7 +193,6 @@ discovery:
 ### dashboard parameters
 
 Configurations for apisix-dashboard sub chart.
-
 
 ### ingress-controller parameters
 


### PR DESCRIPTION
fix #236 

Unify namespace in README.md and fix some formatting errors.