### PR TITLE
Update ingress to support apiVersion networking.k8s.io/v1

### DIFF
--- a/charts/apisix-dashboard/templates/ingress.yaml
+++ b/charts/apisix-dashboard/templates/ingress.yaml
@@ -17,7 +17,9 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "apisix-dashboard.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.Version }}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.Version }}
 apiVersion: networking.k8s.io/v1beta1
 {{- else -}}
 apiVersion: extensions/v1beta1
@@ -53,9 +55,18 @@ spec:
         paths:
           {{- range .paths }}
           - path: {{ . }}
+            {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.Version }}
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: {{ $fullName }}
+                port:
+                  number:  {{ $svcPort }}
+            {{- else -}}
             backend:
               serviceName: {{ $fullName }}
               servicePort: {{ $svcPort }}
+            {{- end }}
           {{- end }}
     {{- end }}
   {{- end }}

--- a/charts/apisix/templates/ingress.yaml
+++ b/charts/apisix/templates/ingress.yaml
@@ -17,7 +17,9 @@
 {{- if (and .Values.apisix.enabled .Values.gateway.ingress.enabled) -}}
 {{- $fullName := include "apisix.fullname" . -}}
 {{- $svcPort := .Values.gateway.http.servicePort -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.Version }}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.Version }}
 apiVersion: networking.k8s.io/v1beta1
 {{- else -}}
 apiVersion: extensions/v1beta1
@@ -49,9 +51,18 @@ spec:
         paths:
           {{- range .paths }}
           - path: {{ . }}
+            {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.Version }}
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: {{ $fullName }}-gateway
+                port:
+                  number:  {{ $svcPort }}
+            {{- else -}}
             backend:
               serviceName: {{ $fullName }}-gateway
               servicePort: {{ $svcPort }}
+            {{- end }}
           {{- end }}
     {{- end }}
   {{- end }}


### PR DESCRIPTION
Ingress apiVersions `extensions/v1beta1` and `networking.k8s.io/v1beta1` will be deprecated in k8s v1.22. [[source]](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#ingress-v122)

Also fixed `KubeVersion` semverCompare, since `.Capabilities.KubeVersion.GitVersion` is only available in Helm v2 [(source)](https://v2.helm.sh/docs/chart_template_guide/#built-in-objects) and Helm v3 uses `.Capabilities.KubeVersion.Version` [(source)](https://helm.sh/docs/chart_template_guide/builtin_objects/)