### PR TITLE
fix: ingress syntax support for Kubernetes 1.19 and later.

### DIFF
--- a/charts/apisix-dashboard/templates/ingress.yaml
+++ b/charts/apisix-dashboard/templates/ingress.yaml
@@ -16,12 +16,8 @@
 #
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "apisix-dashboard.fullname" . -}}
-{{- $svcPort := .Values.service.port -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion }}
-apiVersion: networking.k8s.io/v1beta1
-{{- else -}}
-apiVersion: extensions/v1beta1
-{{- end }}
+{{- $svcPort := .Values.service.port }}
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   {{- if .Values.ingress.className }}
@@ -53,9 +49,12 @@ spec:
         paths:
           {{- range .paths }}
           - path: {{ . }}
+            pathType: Prefix
             backend:
-              serviceName: {{ $fullName }}
-              servicePort: {{ $svcPort }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
           {{- end }}
     {{- end }}
   {{- end }}

--- a/charts/apisix/templates/ingress.yaml
+++ b/charts/apisix/templates/ingress.yaml
@@ -16,12 +16,8 @@
 
 {{- if (and .Values.apisix.enabled .Values.gateway.ingress.enabled) -}}
 {{- $fullName := include "apisix.fullname" . -}}
-{{- $svcPort := .Values.gateway.http.servicePort -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion }}
-apiVersion: networking.k8s.io/v1beta1
-{{- else -}}
-apiVersion: extensions/v1beta1
-{{- end }}
+{{- $svcPort := .Values.gateway.http.servicePort }}
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -49,9 +45,12 @@ spec:
         paths:
           {{- range .paths }}
           - path: {{ . }}
+            pathType: Prefix
             backend:
-              serviceName: {{ $fullName }}-gateway
-              servicePort: {{ $svcPort }}
+              service:
+                name: {{ $fullName }}-gateway
+                port:
+                  number: {{ $svcPort }}
           {{- end }}
     {{- end }}
   {{- end }}


### PR DESCRIPTION
Fix ingress syntax so that recent Kubernetes versions (>= 1.19) are supported.
Drop the support of Kubernetes 1.18 and lower version to keep it simple and clean.

