### PR TITLE
apisix Deployment and DaemonSet securityContext reference error

### DIFF
--- a/charts/apisix/templates/daemonset.yaml
+++ b/charts/apisix/templates/daemonset.yaml
@@ -43,11 +43,11 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       securityContext:
-        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+        {{- toYaml .Values.apisix.podSecurityContext | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
-            {{- toYaml .Values.securityContext | nindent 12 }}
+            {{- toYaml .Values.apisix.securityContext | nindent 12 }}
           image: "{{ .Values.apisix.image.repository }}:{{ .Values.apisix.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.apisix.image.pullPolicy }}
           ports:

--- a/charts/apisix/templates/deployment.yaml
+++ b/charts/apisix/templates/deployment.yaml
@@ -46,11 +46,11 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       securityContext:
-        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+        {{- toYaml .Values.apisix.podSecurityContext | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
-            {{- toYaml .Values.securityContext | nindent 12 }}
+            {{- toYaml .Values.apisix.securityContext | nindent 12 }}
           image: "{{ .Values.apisix.image.repository }}:{{ .Values.apisix.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.apisix.image.pullPolicy }}
           env:


### PR DESCRIPTION
In apisix Deployment and DaemonSet, securityContext refer to .Values.podSecurityContext, But in values.yaml, there is no definition of it, I think this is a input mistake.

In apisix deployment.yaml

```
securityContext:
        {{- toYaml .Values.podSecurityContext | nindent 8 }}
```
should be

```
securityContext:
        {{- toYaml .Values.apisix.podSecurityContext | nindent 8 }}
```

