### PR TITLE
could not install apisix-ingress if ingress-controller.enabled changed to true when helm install apisix charts

### DIFF
--- a/charts/apisix-ingress-controller/templates/configmap.yaml
+++ b/charts/apisix-ingress-controller/templates/configmap.yaml
@@ -55,7 +55,7 @@ data:
       apisix_route_version: {{ .Values.config.kubernetes.apisixRouteVersion | quote }}
       enable_gateway_api: {{ .Values.config.kubernetes.enableGatewayAPI }}
     apisix:
-      default_cluster_base_url: http://{{ .Values.config.apisix.serviceName }}.{{ .Values.config.apisix.serviceNamespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.config.apisix.servicePort }}/apisix/admin
+      default_cluster_base_url: http://{{ .Values.config.apisix.serviceName }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.config.apisix.servicePort }}/apisix/admin
       default_cluster_admin_key: {{ .Values.config.apisix.adminKey | quote }}
       default_cluster_name: {{ .Values.config.apisix.clusterName | quote }}
 kind: ConfigMap

--- a/charts/apisix-ingress-controller/templates/deployment.yaml
+++ b/charts/apisix-ingress-controller/templates/deployment.yaml
@@ -55,7 +55,7 @@ spec:
       initContainers:
         - name: wait-apisix-admin
           image: {{ .Values.initContainer.image }}:{{ .Values.initContainer.tag }}
-          command: ['sh', '-c', "until nc -z {{ .Values.config.apisix.serviceName }}.{{ .Values.config.apisix.serviceNamespace }}.svc.{{ .Values.clusterDomain }} {{ .Values.config.apisix.servicePort }} ; do echo waiting for apisix-admin; sleep 2; done;"]
+          command: ['sh', '-c', "until nc -z {{ .Values.config.apisix.serviceName }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }} {{ .Values.config.apisix.servicePort }} ; do echo waiting for apisix-admin; sleep 2; done;"]
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
       containers:

--- a/charts/apisix-ingress-controller/values.yaml
+++ b/charts/apisix-ingress-controller/values.yaml
@@ -123,7 +123,7 @@ config:
   # APISIX related configurations.
   apisix:
     serviceName: apisix-admin
-    serviceNamespace: ingress-apisix
+    #serviceNamespace: ingress-apisix
     servicePort: 9180
     adminKey: "edd1c9f034335f136f87ad84b625c8f1"
     clusterName: "default"

--- a/charts/apisix/templates/daemonset.yaml
+++ b/charts/apisix/templates/daemonset.yaml
@@ -43,7 +43,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       securityContext:
-        {{- toYaml .Values.apisix.podSecurityContext | nindent 8 }}
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:

--- a/charts/apisix/templates/daemonset.yaml
+++ b/charts/apisix/templates/daemonset.yaml
@@ -43,11 +43,11 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       securityContext:
-        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+        {{- toYaml .Values.apisix.podSecurityContext | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
-            {{- toYaml .Values.securityContext | nindent 12 }}
+            {{- toYaml .Values.apisix.securityContext | nindent 12 }}
           image: "{{ .Values.apisix.image.repository }}:{{ .Values.apisix.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.apisix.image.pullPolicy }}
           ports:

--- a/charts/apisix/templates/deployment.yaml
+++ b/charts/apisix/templates/deployment.yaml
@@ -46,11 +46,11 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       securityContext:
-        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+        {{- toYaml .Values.apisix.podSecurityContext | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
-            {{- toYaml .Values.securityContext | nindent 12 }}
+            {{- toYaml .Values.apisix.securityContext | nindent 12 }}
           image: "{{ .Values.apisix.image.repository }}:{{ .Values.apisix.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.apisix.image.pullPolicy }}
           env:

--- a/charts/apisix/templates/deployment.yaml
+++ b/charts/apisix/templates/deployment.yaml
@@ -46,7 +46,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       securityContext:
-        {{- toYaml .Values.apisix.podSecurityContext | nindent 8 }}
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:


### PR DESCRIPTION
apisix chart and apisix-dashboard chart use {{ .Release.Namespace }}, when we change the config `ingress-controller.enabled` default behaviour, we could not install the apisix-ingress chart.

In apisix charts values.yaml
```
ingress-controller:
  enabled: false
```
changed to 
```
ingress-controller:
  enabled: true
```
I want to install apisix and apisix-ingress at the same time. but apisix-ingress could not install successfully. In apisix chart, we do not specify the namesapce, we use {{ .Release.Namespace }}, but in apisix-ingress charts, we use the configured namespace in values.yaml 

```
  apisix:
    serviceName: apisix-admin
    #serviceNamespace: ingress-apisix
```

the code in apisix-ingress-controller charts deployment.yaml, we use a different namespace configured in values.yaml, 

```
command: ['sh', '-c', "until nc -z {{ .Values.config.apisix.serviceName }}.{{ Values.config.apisix.serviceNamespace }}.svc.{{ .Values.clusterDomain }} {{ .Values.config.apisix.servicePort }} ;
```

the init container could not success, so the apisix ingress controller could not startup

<img width="938" alt="image" src="https://user-images.githubusercontent.com/23027077/168234140-e66ed99d-55cd-4af9-a490-f8b9a85fa44c.png">

we should use `.Release.Namespace` consistent with others charts, apisix charts and apisix-dashboard.