### PR TITLE
fix: render the ingressClassName field normally in apisix-dashboard

### DIFF
--- a/charts/apisix-dashboard/templates/ingress.yaml
+++ b/charts/apisix-dashboard/templates/ingress.yaml
@@ -27,7 +27,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   {{- if .Values.ingress.className }}
-  ingressClassName: {{- .Values.ingress.className -}}
+  ingressClassName: {{ .Values.ingress.className }}
   {{- end }}
   name: {{ $fullName }}
   namespace: {{ .Release.Namespace }}


### PR DESCRIPTION
Signed-off-by: Chao Zhang <tokers@apache.org>