### PR TITLE
Fix: when custom plugin's attr is null

### DIFF
--- a/charts/apisix/templates/configmap.yaml
+++ b/charts/apisix/templates/configmap.yaml
@@ -165,14 +165,16 @@ data:
     nginx_config:                     # config for render the template to genarate nginx.conf
       error_log: "{{ .Values.logs.errorLog }}"
       error_log_level: "{{ .Values.logs.errorLogLevel }}"         # warn,error
-      worker_rlimit_nofile: 20480     # the number of files a worker process can open, should be larger than worker_connections
+      worker_processes: "{{ .Values.nginx.workerProcesses }}"
+      enable_cpu_affinity: {{ default "true" .Values.nginx.enableCPUAffinity }}
+      worker_rlimit_nofile: {{ default 20480 .Values.nginx.workerRlimitNofile }}     # the number of files a worker process can open, should be larger than worker_connections
       event:
-        worker_connections: 10620
+        worker_connections: {{ default 10620 .Values.nginx.workerConnections  }}
       http:
         enable_access_log: {{ .Values.logs.enableAccessLog }}
         {{- if .Values.logs.enableAccessLog }}
         access_log: "{{ .Values.logs.accessLog }}"
-        access_log_format: "{{ .Values.logs.accessLogFormat }}"
+        access_log_format: '{{ .Values.logs.accessLogFormat }}'
         access_log_format_escape: {{ .Values.logs.accessLogFormatEscape }}
         {{- end }}
         keepalive_timeout: 60s         # timeout during which a keep-alive client connection will stay open on the server side.

--- a/charts/apisix/templates/configmap.yaml
+++ b/charts/apisix/templates/configmap.yaml
@@ -167,9 +167,9 @@ data:
       error_log_level: "{{ .Values.logs.errorLogLevel }}"         # warn,error
       worker_processes: "{{ .Values.nginx.workerProcesses }}"
       enable_cpu_affinity: {{ default "true" .Values.nginx.enableCPUAffinity }}
-      worker_rlimit_nofile: {{ default 20480 .Values.nginx.workerRlimitNofile }}     # the number of files a worker process can open, should be larger than worker_connections
+      worker_rlimit_nofile: {{ default "20480" .Values.nginx.workerRlimitNofile }}     # the number of files a worker process can open, should be larger than worker_connections
       event:
-        worker_connections: {{ default 10620 .Values.nginx.workerConnections  }}
+        worker_connections: {{ default "10620" .Values.nginx.workerConnections  }}
       http:
         enable_access_log: {{ .Values.logs.enableAccessLog }}
         {{- if .Values.logs.enableAccessLog }}

--- a/charts/apisix/templates/configmap.yaml
+++ b/charts/apisix/templates/configmap.yaml
@@ -277,7 +277,9 @@ data:
     {{- end }}
     {{- if .Values.customPlugins.enabled }}
     {{- range $plugin := .Values.customPlugins.plugins }}
+      {{- if $plugin.attrs }}
       {{ $plugin.name }}: {{- $plugin.attrs | toYaml | nindent 8 }}
+      {{- end }}
     {{- end }}
     {{- end }}
     {{- if .Values.pluginAttrs }}

--- a/charts/apisix/values.yaml
+++ b/charts/apisix/values.yaml
@@ -17,7 +17,6 @@
 global:
   imagePullSecrets: []
 
-
 apisix:
   # Enable or disable Apache APISIX itself
   # Set it to false and ingress-controller.enabled=true will deploy only ingress-controller
@@ -121,7 +120,6 @@ apisix:
 nameOverride: ""
 fullnameOverride: ""
 
-
 gateway:
   type: NodePort
   # If you want to keep the client source IP, you can set this to Local.
@@ -161,7 +159,6 @@ gateway:
   #    hosts:
   #      - chart-example.local
 
-
 admin:
   # Enable Admin API
   enabled: true
@@ -186,6 +183,11 @@ admin:
     ipList:
       - 127.0.0.1/24
 
+nginx:
+  workerRlimitNofile: "1047552"
+  workerConnections: "16384"
+  workerProcesses: auto
+  enableCPUAffinity: true
 
 # APISIX plugins to be enabled
 plugins:
@@ -399,10 +401,8 @@ etcd:
 
   replicaCount: 3
 
-
 dashboard:
   enabled: false
-
 
 ingress-controller:
   enabled: false

--- a/charts/apisix/values.yaml
+++ b/charts/apisix/values.yaml
@@ -184,8 +184,8 @@ admin:
       - 127.0.0.1/24
 
 nginx:
-  workerRlimitNofile: "1047552"
-  workerConnections: "16384"
+  workerRlimitNofile: "20480"
+  workerConnections: "10620"
   workerProcesses: auto
   enableCPUAffinity: true
 

--- a/charts/apisix/values.yaml
+++ b/charts/apisix/values.yaml
@@ -257,7 +257,7 @@ customPlugins:
       # plugin name.
     - name: ""
       # plugin attrs
-      attrs: 
+      attrs: {}
       # plugin codes can be saved inside configmap object.
       configMap:
         # name of configmap.

--- a/charts/apisix/values.yaml
+++ b/charts/apisix/values.yaml
@@ -255,7 +255,7 @@ customPlugins:
       # plugin name.
     - name: ""
       # plugin attrs
-      attrs: |
+      attrs: 
       # plugin codes can be saved inside configmap object.
       configMap:
         # name of configmap.


### PR DESCRIPTION
- fix when custom plugin's attributes is null, type of attributes is object
- make more nginx's configuration configurable in values.yaml