### PR TITLE
feat: Allow `fullnameOverride`s to work correctly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea/
 .DS_Store
 test_**.yaml
+.history

--- a/charts/apisix-ingress-controller/templates/configmap.yaml
+++ b/charts/apisix-ingress-controller/templates/configmap.yaml
@@ -55,7 +55,11 @@ data:
       apisix_route_version: {{ .Values.config.kubernetes.apisixRouteVersion | quote }}
       enable_gateway_api: {{ .Values.config.kubernetes.enableGatewayAPI }}
     apisix:
+      {{ if .Values.config.apisix.serviceFullname }}
+      default_cluster_base_url: http://{{ .Values.config.apisix.serviceFullname }}:{{ .Values.config.apisix.servicePort }}/apisix/admin
+      {{ else }}
       default_cluster_base_url: http://{{ .Values.config.apisix.serviceName }}.{{ .Values.config.apisix.serviceNamespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.config.apisix.servicePort }}/apisix/admin
+      {{ end}}
       default_cluster_admin_key: {{ .Values.config.apisix.adminKey | quote }}
       default_cluster_name: {{ .Values.config.apisix.clusterName | quote }}
 kind: ConfigMap

--- a/charts/apisix-ingress-controller/templates/deployment.yaml
+++ b/charts/apisix-ingress-controller/templates/deployment.yaml
@@ -55,7 +55,12 @@ spec:
       initContainers:
         - name: wait-apisix-admin
           image: {{ .Values.initContainer.image }}:{{ .Values.initContainer.tag }}
+          {{ if .Values.config.apisix.serviceFullname }}
+          command: ['sh', '-c', "until nc -z {{ .Values.config.apisix.serviceFullname }} {{ .Values.config.apisix.servicePort }} ; do echo waiting for apisix-admin; sleep 2; done;"]
+          {{ else }}
           command: ['sh', '-c', "until nc -z {{ .Values.config.apisix.serviceName }}.{{ .Values.config.apisix.serviceNamespace }}.svc.{{ .Values.clusterDomain }} {{ .Values.config.apisix.servicePort }} ; do echo waiting for apisix-admin; sleep 2; done;"]
+          {{ end}}
+
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
       containers:

--- a/charts/apisix-ingress-controller/values.yaml
+++ b/charts/apisix-ingress-controller/values.yaml
@@ -123,7 +123,7 @@ config:
   # APISIX related configurations.
   apisix:
     # Enabling this value, overrides serviceName and serviceNamespace.
-    # serviceFullname: "apisix-admin"
+    # serviceFullname: "apisix-admin.apisix.svc.local"
     serviceName: apisix-admin
     serviceNamespace: ingress-apisix
     servicePort: 9180

--- a/charts/apisix-ingress-controller/values.yaml
+++ b/charts/apisix-ingress-controller/values.yaml
@@ -122,6 +122,8 @@ config:
     enableGatewayAPI: false
   # APISIX related configurations.
   apisix:
+    # Enabling this value, overrides serviceName and serviceNamespace.
+    # serviceFullname: "apisix-admin"
     serviceName: apisix-admin
     serviceNamespace: ingress-apisix
     servicePort: 9180

--- a/charts/apisix/templates/configmap.yaml
+++ b/charts/apisix/templates/configmap.yaml
@@ -214,7 +214,11 @@ data:
     etcd:
     {{- if .Values.etcd.enabled }}
       host:                                 # it's possible to define multiple etcd hosts addresses of the same etcd cluster.
+        {{- if .Values.etcd.fullnameOverride }}
+        - "http://{{ .Values.etcd.fullnameOverride }}:{{ .Values.etcd.service.port }}"
+        {{- else }}
         - "http://{{ .Release.Name }}-etcd.{{ .Release.Namespace }}.svc.{{ .Values.etcd.clusterDomain }}:{{ .Values.etcd.service.port }}"
+        {{- end}}
     {{- else }}
       host:                                 # it's possible to define multiple etcd hosts addresses of the same etcd cluster.
         {{- range $value := .Values.etcd.host }}

--- a/charts/apisix/templates/daemonset.yaml
+++ b/charts/apisix/templates/daemonset.yaml
@@ -143,7 +143,11 @@ spec:
       initContainers:
       - name: wait-etcd
         image: {{ .Values.initContainer.image }}:{{ .Values.initContainer.tag }}
+        {{- if .Values.etcd.fullnameOverride }}
+        command: ['sh', '-c', "until nc -z {{ .Values.etcd.fullnameOverride }} {{ .Values.etcd.service.port }}; do echo waiting for etcd `date`; sleep 2; done;"]
+        {{ else }}
         command: ['sh', '-c', "until nc -z {{ .Release.Name }}-etcd.{{ .Release.Namespace }}.svc.{{ .Values.etcd.clusterDomain }} {{ .Values.etcd.service.port }}; do echo waiting for etcd `date`; sleep 2; done;"]
+        {{- end }}
       {{- end }}
       volumes:
         - configMap:

--- a/charts/apisix/templates/deployment.yaml
+++ b/charts/apisix/templates/deployment.yaml
@@ -154,7 +154,11 @@ spec:
       initContainers:
       - name: wait-etcd
         image: {{ .Values.initContainer.image }}:{{ .Values.initContainer.tag }}
+        {{- if .Values.etcd.fullnameOverride }}
+        command: ['sh', '-c', "until nc -z {{ .Values.etcd.fullnameOverride }} {{ .Values.etcd.service.port }}; do echo waiting for etcd `date`; sleep 2; done;"]
+        {{- else }}
         command: ['sh', '-c', "until nc -z {{ .Release.Name }}-etcd.{{ .Release.Namespace }}.svc.{{ .Values.etcd.clusterDomain }} {{ .Values.etcd.service.port }}; do echo waiting for etcd `date`; sleep 2; done;"]
+        {{- end }}
       {{- end }}
       volumes:
         - configMap:

--- a/docs/en/latest/apisix-ingress-controller.md
+++ b/docs/en/latest/apisix-ingress-controller.md
@@ -37,6 +37,8 @@ helm repo update
 helm install apisix-ingress-controller apisix/apisix-ingress-controller --namespace ingress-apisix --create-namespace
 ```
 
+Note: APISIX Ingress Controller will try to establish a connection with APISIX admin in the location specified by `apisix.serviceName` and `apisix.serviceNamespace` values following the naming convention `<serviceName.serviceNamespace.svc.clusterDomain>`. You can override this behavior to specify a fully custom location by setting the `apisix.serviceFullname` value.
+
 ## Uninstall
 
 To uninstall/delete the `apisix-ingress-controller` release:


### PR DESCRIPTION
Purpose: Allow `fullnameOverride`s to work correctly to fully automate Helm deployments.
Note: This is an updated PR, a lot less intrusive than the one suggested in https://github.com/apache/apisix-helm-chart/pull/292 (which I have now closed).

- In APISIX admin:
If the etcd subchart is configured to use a `fullnameOverride`, APISIX admin fails to start. This is due to the fact that etcd `fullnameOverride` is not taken into account in APISIX admin's init container nor configmap. This PR is backwards compatible in the sense that if users do not use a `fullnameOverride` for etcd, the chart behaves identically as before.

- In APISIX Ingress Controller:
`apisix.serviceName` and `apisix.serviceNamespace` must be explicitly set, thus not allowing users to fully automate a Helm install when using a custom `fullnameOverride` for APISIX admin which might have a different logic than the one currently used to construct the APISIX admin URL. This PR introduces a new value `apisix.serviceFullname`. When this value is set, it is overriding the logic of constructing the APISIX admin URL from `apisix.serviceName` and `apisix.serviceNamespace`. This PR is backwards compatible in the sense that if users do not use the newly introduced `apisix.serviceFullname` value, the chart behaves identically as before.