### PR TITLE
fix: Move ingressClassName to spec

### DIFF
--- a/charts/apisix-dashboard/templates/ingress.yaml
+++ b/charts/apisix-dashboard/templates/ingress.yaml
@@ -26,9 +26,6 @@ apiVersion: extensions/v1beta1
 {{- end }}
 kind: Ingress
 metadata:
-  {{- if .Values.ingress.className }}
-  ingressClassName: {{ .Values.ingress.className }}
-  {{- end }}
   name: {{ $fullName }}
   namespace: {{ .Release.Namespace }}
   labels:
@@ -38,6 +35,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
   {{- if .Values.ingress.tls }}
   tls:
     {{- range .Values.ingress.tls }}


### PR DESCRIPTION
The property `ingressClassName` should be rendered inside `spec` and not `metadata`
