### PR TITLE
Fix `secret` keyword typo

### DIFF
--- a/charts/apisix-dashboard/templates/configmap.yaml
+++ b/charts/apisix-dashboard/templates/configmap.yaml
@@ -53,7 +53,7 @@ data:
     {{- end }}
     {{- with .Values.config.authentication }}
     authentication:
-      secert: {{ .secert }}
+      secret: {{ .secret }}
       expire_time: {{ .expireTime }}
       users:
         {{- range .users }}

--- a/charts/apisix-dashboard/values.yaml
+++ b/charts/apisix-dashboard/values.yaml
@@ -74,7 +74,7 @@ config:
         filePath: /dev/stdout
 
   authentication:
-    secert: secert
+    secret: secret
     expireTime: 3600
     users:
       - username: admin


### PR DESCRIPTION
There is a wrong spelling in helm chart and yaml config file, where **secret** is misspelled as **secert**. 

This PR fix the misspelling. 