### PR TITLE
feat: Bump apisix-dashboard helm chart

### DIFF
--- a/charts/apisix-dashboard/Chart.yaml
+++ b/charts/apisix-dashboard/Chart.yaml
@@ -31,7 +31,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.0
+version: 0.7.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to


### PR DESCRIPTION
Hello dear APISIX Helm chart maintainers!

As a apisix user I would like to have the latest changes in the apisix-dashboard helm chart. 
I'm particularly interested in this fix https://github.com/apache/apisix-helm-chart/pull/323 for the ingressClassName field, I took the liberty of just bumping the version of the chart to `0.7.0`

Please let me know if further changes are required to release this chart, I will be happy to contribute!

ps: I believe this project would benefit of having something like helm-docs (https://github.com/norwoodj/helm-docs)