### PR TITLE
Customizable ingressClassName for gateway

### DIFF
--- a/charts/apisix/README.md
+++ b/charts/apisix/README.md
@@ -96,7 +96,7 @@ Apache APISIX service parameters, this determines how users can access itself.
 | `gateway.stream`                | Apache APISIX service settings for stream                                                                                                                                           |            |
 | `gateway.ingress`               | Using ingress access Apache APISIX service                                                                                                                                          |            |
 | `gateway.ingress.annotations`   | Ingress annotations                                                                                                                                                                 | `[]`       |
-| `gateway.ingress.className`     | `ingressClassName` replaces `annotations kubernetes.io/ingress.class`, required kubernetes 1.18>=                                                                                   |            |
+| `gateway.ingress.className`     | `ingressClassName` replaces `annotations kubernetes.io/ingress.class`, required Kubernetes `1.18>=`                                                                                   |            |
 
 ### admin parameters
 

--- a/charts/apisix/README.md
+++ b/charts/apisix/README.md
@@ -95,6 +95,8 @@ Apache APISIX service parameters, this determines how users can access itself.
 | `gateway.tls.sslProtocols`    |   TLS protocols allowed to use.  | `"TLSv1.2 TLSv1.3"`       |
 | `gateway.stream`                | Apache APISIX service settings for stream                                                                                                                                           |            |
 | `gateway.ingress`               | Using ingress access Apache APISIX service                                                                                                                                          |            |
+| `gateway.ingress.annotations`   | Ingress annotations                                                                                                                                                                 | `[]`       |
+| `gateway.ingress.className`     | `ingressClassName` replaces `annotations kubernetes.io/ingress.class`, required kubernetes 1.18>=                                                                                   |            |
 
 ### admin parameters
 

--- a/charts/apisix/README.md
+++ b/charts/apisix/README.md
@@ -96,7 +96,7 @@ Apache APISIX service parameters, this determines how users can access itself.
 | `gateway.stream`                | Apache APISIX service settings for stream                                                                                                                                           |            |
 | `gateway.ingress`               | Using ingress access Apache APISIX service                                                                                                                                          |            |
 | `gateway.ingress.annotations`   | Ingress annotations                                                                                                                                                                 | `[]`       |
-| `gateway.ingress.className`     | `ingressClassName` replaces `annotations kubernetes.io/ingress.class`, required Kubernetes `1.18>=`                                                                                   |            |
+| `gateway.ingress.className`     | `ingressClassName` replaces `annotations kubernetes.io/ingress.class`, required Kubernetes `>=1.18`                                                                                   |            |
 
 ### admin parameters
 

--- a/charts/apisix/templates/ingress.yaml
+++ b/charts/apisix/templates/ingress.yaml
@@ -34,6 +34,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  {{- if .Values.gateway.ingress.className }}
+  ingressClassName: {{ .Values.gateway.ingress.className }}
+  {{- end }}
   {{- if .Values.gateway.ingress.tls }}
   tls:
     {{- range .Values.gateway.ingress.tls }}

--- a/charts/apisix/templates/ingress.yaml
+++ b/charts/apisix/templates/ingress.yaml
@@ -17,6 +17,11 @@
 {{- if (and .Values.apisix.enabled .Values.gateway.ingress.enabled) -}}
 {{- $fullName := include "apisix.fullname" . -}}
 {{- $svcPort := .Values.gateway.http.servicePort -}}
+{{- if and .Values.gateway.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.gateway.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.gateway.ingress.annotations "kubernetes.io/ingress.class" .Values.gateway.ingress.className}}
+  {{- end }}
+{{- end }}
 {{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.Version }}
 apiVersion: networking.k8s.io/v1
 {{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.Version }}

--- a/charts/apisix/templates/ingress.yaml
+++ b/charts/apisix/templates/ingress.yaml
@@ -34,7 +34,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  {{- if .Values.gateway.ingress.className }}
+  {{- if and .Values.gateway.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
   ingressClassName: {{ .Values.gateway.ingress.className }}
   {{- end }}
   {{- if .Values.gateway.ingress.tls }}


### PR DESCRIPTION
The helm chart supports exposing Apisix Gateway Service through an Ingress.

Unfortunately it does not support choosing `ingressClassName`, so it would work only if there's a default available.

This PR allows setting up a custom Ingress `className` within `values.yaml`, as for example:
```
gateway:
  ingress:
    enabled: true
    className: alb-private
    hosts:
      - host: api.dev.project.int.corp
        paths:
          - /
```

Variable name was choosen to be consisting with className used in apisix-dashboard. The change was tested and is backwards compatible.