### PR TITLE
change: sync config of APISIX V3 version

### DIFF
--- a/charts/apisix/templates/configmap.yaml
+++ b/charts/apisix/templates/configmap.yaml
@@ -62,12 +62,10 @@ data:
       enable_dev_mode: false                       # Sets nginx worker_processes to 1 if set to true
       enable_reuseport: true                       # Enable nginx SO_REUSEPORT switch if set to true.
       enable_ipv6: {{ .Values.apisix.enableIPv6 }} # Enable nginx IPv6 resolver
-      config_center: etcd                          # etcd: use etcd to store the config value
-                                                   # yaml: fetch the config value from local yaml file `/your_path/conf/apisix.yaml`
 
       #proxy_protocol:                 # Proxy Protocol configuration
-      #  listen_http_port: 9181        # The port with proxy protocol for http, it differs from node_listen and port_admin.
-                                      # This port can only receive http request with proxy protocol, but node_listen & port_admin
+      #  listen_http_port: 9181        # The port with proxy protocol for http, it differs from node_listen and admin_listen.
+                                      # This port can only receive http request with proxy protocol, but node_listen & admin_listen
                                       # can only receive http request. If you enable proxy protocol, you must use this port to
                                       # receive http request with proxy protocol
       #  listen_https_port: 9182       # The port with proxy protocol for https
@@ -89,35 +87,6 @@ data:
       #    disk_path: "/tmp/disk_cache_two"
       #    cache_levels: "1:2"
 
-      allow_admin:                  # http://nginx.org/en/docs/http/ngx_http_access_module.html#allow
-      {{- if .Values.admin.allow.ipList }}
-      {{- range $ips := .Values.admin.allow.ipList }}
-        - {{ $ips }}
-      {{- end }}
-      {{- else }}
-        - 0.0.0.0/0
-      {{- end}}
-      {{- if or (index .Values "ingress-controller" "enabled") .Values.dashboard.enabled  }}
-        - 0.0.0.0/0
-      {{- end}}
-      #   - "::/64"
-      {{- if .Values.admin.enabled }}
-      port_admin: {{ .Values.admin.port }}
-      {{- end }}
-
-      # Default token when use API to call for Admin API.
-      # *NOTE*: Highly recommended to modify this value to protect APISIX's Admin API.
-      # Disabling this configuration item means that the Admin API does not
-      # require any authentication.
-      admin_key:
-        # admin: can everything for configuration data
-        - name: "admin"
-          key: {{ .Values.admin.credentials.admin }}
-          role: admin
-        # viewer: only can view configuration data
-        - name: "viewer"
-          key: {{ .Values.admin.credentials.viewer }}
-          role: viewer
       router:
         http: 'radixtree_uri'         # radixtree_uri: match route by uri(base on radixtree)
                                       # radixtree_host_uri: match route by host + uri(base on radixtree)
@@ -154,8 +123,9 @@ data:
       resolver_timeout: {{.Values.dns.timeout}}
       ssl:
         enable: {{ .Values.gateway.tls.enabled }}
-        enable_http2: {{ .Values.gateway.tls.http2.enabled }}
-        listen_port: {{ .Values.gateway.tls.containerPort }}
+        listen:
+          - port: {{ .Values.gateway.tls.containerPort }}
+            enable_http2: {{ .Values.gateway.tls.http2.enabled }}
         ssl_protocols: {{ .Values.gateway.tls.sslProtocols | quote }}
         ssl_ciphers: "ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES256-SHA256:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:DES-CBC3-SHA"
         {{- if and .Values.gateway.tls.enabled .Values.gateway.tls.existingCASecret }}
@@ -217,34 +187,6 @@ data:
       stream_configuration_snippet: {{- toYaml .Values.configurationSnippet.stream | indent 6 }}
       {{- end }}
 
-    etcd:
-    {{- if .Values.etcd.enabled }}
-      host:                                 # it's possible to define multiple etcd hosts addresses of the same etcd cluster.
-        {{- if .Values.etcd.fullnameOverride }}
-        - "http://{{ .Values.etcd.fullnameOverride }}:{{ .Values.etcd.service.port }}"
-        {{- else }}
-        - "http://{{ .Release.Name }}-etcd.{{ .Release.Namespace }}.svc.{{ .Values.etcd.clusterDomain }}:{{ .Values.etcd.service.port }}"
-        {{- end}}
-    {{- else }}
-      host:                                 # it's possible to define multiple etcd hosts addresses of the same etcd cluster.
-        {{- range $value := .Values.etcd.host }}
-        - "{{ $value }}"             # multiple etcd address
-        {{- end}}
-    {{- end }}
-      prefix: {{ .Values.etcd.prefix | quote }}     # apisix configurations prefix
-      timeout: {{ .Values.etcd.timeout }}   # 30 seconds
-      {{- if .Values.etcd.auth.rbac.create }}
-      user: {{ .Values.etcd.auth.rbac.user | quote }}
-      password: {{ .Values.etcd.auth.rbac.password | quote }}
-      {{- end }}
-      {{- if .Values.etcd.auth.tls.enabled }}
-      tls:
-        cert: "/etcd-ssl/{{ .Values.etcd.auth.tls.certFilename }}"
-        key: "/etcd-ssl/{{ .Values.etcd.auth.tls.certKeyFilename }}"
-        verify: {{ .Values.etcd.auth.tls.verify }}
-        sni: "{{ .Values.etcd.auth.tls.sni }}"
-      {{- end }}
-
     {{- if .Values.discovery.enabled }}
     discovery:
       {{- range $key, $value := .Values.discovery.registry }}
@@ -283,5 +225,69 @@ data:
     plugin_attr: {{- $pluginAttrs | nindent 6 }}
     {{- end }}
     {{- end }}
+
+    deployment:
+      role: traditional
+      role_traditional:
+        config_provider: etcd
+      admin:
+        allow_admin:                  # http://nginx.org/en/docs/http/ngx_http_access_module.html#allow
+        {{- if .Values.admin.allow.ipList }}
+        {{- range $ips := .Values.admin.allow.ipList }}
+          - {{ $ips }}
+        {{- end }}
+        {{- else }}
+          - 0.0.0.0/0
+        {{- end}}
+        {{- if or (index .Values "ingress-controller" "enabled") .Values.dashboard.enabled  }}
+          - 0.0.0.0/0
+        {{- end}}
+        #   - "::/64"
+        {{- if .Values.admin.enabled }}
+        admin_listen:
+          ip: 0.0.0.0
+          port: {{ .Values.admin.port }}
+        {{- end }}
+
+        # Default token when use API to call for Admin API.
+        # *NOTE*: Highly recommended to modify this value to protect APISIX's Admin API.
+        # Disabling this configuration item means that the Admin API does not
+        # require any authentication.
+        admin_key:
+          # admin: can everything for configuration data
+          - name: "admin"
+            key: {{ .Values.admin.credentials.admin }}
+            role: admin
+          # viewer: only can view configuration data
+          - name: "viewer"
+            key: {{ .Values.admin.credentials.viewer }}
+            role: viewer
+      etcd:
+      {{- if .Values.etcd.enabled }}
+        host:                                 # it's possible to define multiple etcd hosts addresses of the same etcd cluster.
+          {{- if .Values.etcd.fullnameOverride }}
+          - "http://{{ .Values.etcd.fullnameOverride }}:{{ .Values.etcd.service.port }}"
+          {{- else }}
+          - "http://{{ .Release.Name }}-etcd.{{ .Release.Namespace }}.svc.{{ .Values.etcd.clusterDomain }}:{{ .Values.etcd.service.port }}"
+          {{- end}}
+      {{- else }}
+        host:                                 # it's possible to define multiple etcd hosts addresses of the same etcd cluster.
+          {{- range $value := .Values.etcd.host }}
+          - "{{ $value }}"             # multiple etcd address
+          {{- end}}
+      {{- end }}
+        prefix: {{ .Values.etcd.prefix | quote }}     # configuration prefix in etcd
+        timeout: {{ .Values.etcd.timeout }}   # 30 seconds
+        {{- if .Values.etcd.auth.rbac.create }}
+        user: {{ .Values.etcd.auth.rbac.user | quote }}
+        password: {{ .Values.etcd.auth.rbac.password | quote }}
+        {{- end }}
+        {{- if .Values.etcd.auth.tls.enabled }}
+        tls:
+          cert: "/etcd-ssl/{{ .Values.etcd.auth.tls.certFilename }}"
+          key: "/etcd-ssl/{{ .Values.etcd.auth.tls.certKeyFilename }}"
+          verify: {{ .Values.etcd.auth.tls.verify }}
+          sni: "{{ .Values.etcd.auth.tls.sni }}"
+        {{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
In APISIX V3 version, there are some breaking changes in `config-default.yaml`, and this PR is changed synchronously to this repo.

The following are the PRs I have filtered in relation to breaking changes: 
https://github.com/apache/apisix/pull/7716
https://github.com/apache/apisix/pull/7717
https://github.com/apache/apisix/pull/7806
https://github.com/apache/apisix/pull/7860
https://github.com/apache/apisix/pull/7823
https://github.com/apache/apisix/pull/7901 (in review)

I am not familiar with the helm chart, please let me know if there is anything else that needs to be changed.