### PR TITLE
Add Support to Enable Proxy Protocol

### DIFF
--- a/charts/apisix/templates/configmap.yaml
+++ b/charts/apisix/templates/configmap.yaml
@@ -65,15 +65,16 @@ data:
       enable_server_tokens: {{ .Values.apisix.enableServerTokens }} # Whether the APISIX version number should be shown in Server header
       config_center: etcd                          # etcd: use etcd to store the config value
                                                    # yaml: fetch the config value from local yaml file `/your_path/conf/apisix.yaml`
-
-      #proxy_protocol:                 # Proxy Protocol configuration
-      #  listen_http_port: 9181        # The port with proxy protocol for http, it differs from node_listen and port_admin.
+      {{- if .Values.apisix.proxyProtocol.enabled }}
+      proxy_protocol:                 # Proxy Protocol configuration
+        listen_http_port: {{ .Values.apisix.proxyProtocol.listenHttpPort }}        # The port with proxy protocol for http, it differs from node_listen and port_admin.
                                       # This port can only receive http request with proxy protocol, but node_listen & port_admin
                                       # can only receive http request. If you enable proxy protocol, you must use this port to
                                       # receive http request with proxy protocol
-      #  listen_https_port: 9182       # The port with proxy protocol for https
-      #  enable_tcp_pp: true           # Enable the proxy protocol for tcp proxy, it works for stream_proxy.tcp option
+        listen_https_port: {{ .Values.apisix.proxyProtocol.listenHttpsPort }}       # The port with proxy protocol for https
+        enable_tcp_pp: {{ .Values.apisix.proxyProtocol.enabled }}           # Enable the proxy protocol for tcp proxy, it works for stream_proxy.tcp option
       #  enable_tcp_pp_to_upstream: true # Enables the proxy protocol to the upstream server
+      {{- end }}
 
       proxy_cache:                     # Proxy Caching configuration
         cache_ttl: 10s                 # The default caching time if the upstream does not specify the cache time
@@ -260,7 +261,7 @@ data:
       timeout: {{ .Values.vault.timeout }}
       token: {{ .Values.vault.token }}
       prefix: {{ .Values.vault.prefix }}
-    {{- end }}    
+    {{- end }}
 
     {{- if .Values.plugins }}
     plugins:                          # plugin list

--- a/charts/apisix/templates/service-gateway.yaml
+++ b/charts/apisix/templates/service-gateway.yaml
@@ -66,6 +66,24 @@ spec:
   {{- end }}
     protocol: TCP
   {{- end }}
+  {{- if or .Values.gateway.proxyProtocol.http.enabled }}
+  - name: apisix-gateway-pp-http
+    port: {{ .Values.gateway.proxyProtocol.http.servicePort }}
+    targetPort: {{ .Values.gateway.proxyProtocol.http.containerPort }}
+  {{- if (and (eq .Values.gateway.type "NodePort") (not (empty .Values.gateway.proxyProtocol.http.nodePort))) }}
+    nodePort: {{ .Values.proxyProtocol.http.nodePort }}
+  {{- end }}
+    protocol: TCP
+  {{- end }}
+  {{- if or .Values.gateway.proxyProtocol.https.enabled }}
+  - name: apisix-gateway-pp-https
+    port: {{ .Values.gateway.proxyProtocol.https.servicePort }}
+    targetPort: {{ .Values.gateway.proxyProtocol.https.containerPort }}
+  {{- if (and (eq .Values.gateway.type "NodePort") (not (empty .Values.gateway.proxyProtocol.https.nodePort))) }}
+    nodePort: {{ .Values.proxyProtocol.https.nodePort }}
+  {{- end }}
+    protocol: TCP
+  {{- end }}
   {{- if and .Values.gateway.stream.enabled (or (gt (len .Values.gateway.stream.tcp) 0) (gt (len .Values.gateway.stream.udp) 0)) }}
   {{- with .Values.gateway.stream }}
   {{- if (gt (len .tcp) 0) }}

--- a/charts/apisix/values.yaml
+++ b/charts/apisix/values.yaml
@@ -51,6 +51,11 @@ apisix:
         - key: ""
           path: ""
 
+  proxyProtocol:
+    enabled: true
+    listenHttpPort: 9181
+    listenHttpsPort: 9182
+
   enableCustomizedConfig: false
   customizedConfig: {}
 
@@ -154,12 +159,22 @@ gateway:
     http2:
       enabled: true
     sslProtocols: "TLSv1.2 TLSv1.3"
+  proxyProtocol:
+    http:
+      enabled: false
+      servicePort: 9181
+      containerPort: 9181
+    https:
+      enabled: false
+      servicePort: 9182
+      containerPort: 9182
   # L4 proxy (TCP/UDP)
   stream:
     enabled: false
     only: false
     tcp: []
     udp: []
+
   ingress:
     enabled: false
     annotations: {}


### PR DESCRIPTION
Hello Dear APISIX Helm Chart maintainers!

This PR adds the option to enable Proxy Protocol (pp) in the APISIX configuration file and allows to add the proxy protocol listeners to the gateway Kubernetes service.

Made all ports configurable in a fashion similar to `apisix-gateway` and `apisix-gateway-tls`

I left `enable_tcp_pp_to_upstream` out because at this moment I have no way to test it. I can add the toggle if needed to merge this PR.

I tested these changes with the following configuration in one of my EKS Clusters. 
I'm using the [aws-load-balancer-controller](https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.4/) to provision a NBL with SSL/TLS Offloading and Proxy Protocol enabled (see loadbalancer annotations below)

This allows me to send HTTP(80) -> ProxyProtocol HTTP(9181) and HTTPS 443 -> ProxyProtocol HTTP (9181)

values.yaml
```
gateway:
  type: LoadBalancer
  externalTrafficPolicy: Cluster
  annotations:
    service.beta.kubernetes.io/aws-load-balancer-additional-resource-tags: service_name=ingress-apisix
    service.beta.kubernetes.io/aws-load-balancer-backend-protocol: "http"
    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: 3600
    service.beta.kubernetes.io/aws-load-balancer-healthcheck-interval: 10
    service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: "ip"
    service.beta.kubernetes.io/aws-load-balancer-scheme: "internet-facing"
    service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "443"
    service.beta.kubernetes.io/aws-load-balancer-target-group-attributes: proxy_protocol_v2.enabled=true
    # https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.4/guide/service/nlb/#configuration
    # The AWS in-tree controller ignores those services resources that have the service.beta.kubernetes.io/aws-load-balancer-type annotation as external
    service.beta.kubernetes.io/aws-load-balancer-type: "external"
    #Env Specific Annotations
    service.beta.kubernetes.io/aws-load-balancer-name: "my-ingress-apisix"
    service.beta.kubernetes.io/aws-load-balancer-ssl-cert: arn:aws:acm:xx-xxxx-x:xxxxxxxxxxxxxx:certificate/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx

  http:
    enabled: true
    servicePort: 9080
    containerPort: 9080
  tls:
    enabled: true
    servicePort: 9443
    containerPort: 9443
    existingCASecret: ""
    certCAFilename: ""
    http2:
      enabled: true
    sslProtocols: "TLSv1.2 TLSv1.3"
  proxyProtocol:
    http:
      enabled: true
      servicePort: 80
      containerPort: 9181
    https:
      enabled: true
      servicePort: 443
      containerPort: 9181
```

I've also tested sending HTTPs traffic to the HTTPs Proxy Protocol port with a regular non SSL/TLS offloading NLB and seemed to work fine.

Solves: https://github.com/apache/apisix-helm-chart/issues/325