### PR TITLE
fix: apisix-charts's global.imagePullSecrets

### DIFF
--- a/charts/apisix/templates/_pod.tpl
+++ b/charts/apisix/templates/_pod.tpl
@@ -10,7 +10,9 @@ metadata:
 spec:
   {{- with .Values.global.imagePullSecrets }}
   imagePullSecrets:
-    {{- toYaml . | nindent 4 }}
+    {{- range $.Values.global.imagePullSecrets }}
+    - name: {{ . }}
+    {{- end }}
   {{- end }}
   serviceAccountName: {{ include "apisix.serviceAccountName" . }}
   securityContext: {{- toYaml .Values.podSecurityContext | nindent 4 }}

--- a/charts/apisix/values.yaml
+++ b/charts/apisix/values.yaml
@@ -15,6 +15,11 @@
 # limitations under the License.
 
 global:
+  # e.g.
+  # imagePullSecrets:
+  #   - my-registry-secrets
+  #   - other-registry-secrets
+  #
   imagePullSecrets: []
 
 apisix:


### PR DESCRIPTION
Since we use the same parameter name as bitnami/etcd charts, this parameter will affect the final configuration of both charts.

This modification makes their behavior consistent.

Signed-off-by: Jintao Zhang <zhangjintao9020@gmail.com>