### PR TITLE
add wasmPlugins options and set wasm plugins to apisix config to apisix chart

### DIFF
--- a/charts/apisix/README.md
+++ b/charts/apisix/README.md
@@ -154,6 +154,48 @@ Default enabled plugins. See [configmap template](https://github.com/apache/apis
 | `extPlugin.enabled` | Enable External Plugins. See [external plugin](https://apisix.apache.org/docs/apisix/next/external-plugin/) | `false` |
 | `extPlugin.cmd` | the command and its arguements to run as a subprocess | `{}` |
 
+### wasm plugin parameters
+
+| Parameter                       | Description                                                                                                                                                      | Default                     |
+|---------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------|
+| `wasmPlugins.enabled` | Enable Wasm Plugins. See [wasm plugin](https://apisix.apache.org/docs/apisix/next/wasm/) | `false` |
+| `wasmPlugins.plugins[].name` | Set wasm plugin name | `""` |
+| `wasmPlugins.plugins[].priority` | Set wasm plugin priority | `7999` |
+| `wasmPlugins.plugins[].file` | Set path to wasm plugin | `""` |
+| `wasmPlugins.plugins[].http_request_phase` | Set which http request phase for the plugin to run in | `access` |
+
+Note:
+  - the easiest way to to include your wasm custom plugin is to rebuild apisix image with those custom plugin included within directory you define and later on gets referenced to `wasmPlugins.plugins[].file`
+  - otherwise you could use `extraVolumes` and `extraVolumeMounts` option to include your plugin by creating your plugin via `ConfigMap` and mount it to apisix pod like example below
+    ```
+    #... more options omitted ...
+    ingress-controller:
+      enabled: true
+
+    dashboard:
+      enabled: true
+
+    # assuming you install apisix in `apisix` namespace,
+    # create the plugin by this command and had the wasm plugin
+    # kubectl create configmap --namespace apisix --from-file=./wasm_plugin_x.wasm wasm-plugin-x
+    # Note: there are also size limitation on `ConfigMap`
+
+    # these options are kubernetes
+    # Volume and VolumeMount api objects
+    extraVolumes:
+    - name: wasm-plugin-x
+      configMap:
+        name: wasm-plugin-x
+        items:
+        - key: wasm_plugin_x.wasm
+          path: wasm_plugin_x.wasm
+    extraVolumeMounts:
+    - name: wasm-plugin-x
+      mountPath: /var/local/wasm-plugins/ # later on reference to `wasmPlugins.plugins[].file` as its value
+      readOnly: true
+    #... more options omitted ...
+    ```
+
 ### custom plugin parameters
 
 | Parameter                       | Description                                                                                                                                                      | Default                     |

--- a/charts/apisix/README.md
+++ b/charts/apisix/README.md
@@ -165,7 +165,7 @@ Default enabled plugins. See [configmap template](https://github.com/apache/apis
 | `wasmPlugins.plugins[].http_request_phase` | Set which http request phase for the plugin to run in | `access` |
 
 Note:
-  - the easiest way to to include your wasm custom plugin is to rebuild apisix image with those custom plugin included within directory you define and later on gets referenced to `wasmPlugins.plugins[].file`
+  - the easiest way to include your wasm custom plugin is to rebuild the apisix image with those custom plugins included within the directory you define and later on gets referenced to `wasmPlugins.plugins[].file`
   - otherwise you could use `extraVolumes` and `extraVolumeMounts` option to include your plugin by creating your plugin via `ConfigMap` and mount it to apisix pod like example below
     ```
     #... more options omitted ...

--- a/charts/apisix/templates/configmap.yaml
+++ b/charts/apisix/templates/configmap.yaml
@@ -292,5 +292,11 @@ data:
     plugin_attr: {{- $pluginAttrs | nindent 6 }}
     {{- end }}
     {{- end }}
+
+    {{- if .Values.wasmPlugins.enabled }}
+    wasm:
+      plugins:
+        {{- toYaml .Values.wasmPlugins.plugins | nindent 8 }}
+    {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/apisix/values.yaml
+++ b/charts/apisix/values.yaml
@@ -268,6 +268,13 @@ extPlugin:
   enabled: false
   cmd: ["/path/to/apisix-plugin-runner/runner", "run"]
 
+wasmPlugins:
+  enabled: false
+  plugins:
+    - name: custom-plugin
+      file: /var/local/wasm-filters/custom_plugin.wasm
+      http_request_phase: access
+
 # customPlugins allows you to mount your own HTTP plugins.
 customPlugins:
   enabled: false

--- a/charts/apisix/values.yaml
+++ b/charts/apisix/values.yaml
@@ -270,10 +270,7 @@ extPlugin:
 
 wasmPlugins:
   enabled: false
-  plugins:
-    - name: custom-plugin
-      file: /var/local/wasm-filters/custom_plugin.wasm
-      http_request_phase: access
+  plugins: []
 
 # customPlugins allows you to mount your own HTTP plugins.
 customPlugins:


### PR DESCRIPTION
this pr contains

- [x] adding `wasmPlugins` options that able to enable/disable and configure wasm plugins that matches [wasm plugins `How to use`](https://apisix.apache.org/docs/apisix/2.15/wasm) section
- [x] adding `wasmPlugins.plugins` to apisix `config.yaml` if `wasmPlugins.enabled` is set to `true`
- [x] adding wasm plugin parameters into readme

notes:
  - if `wasmPlugins.enabled` is set to `true` and `wasmPlugins.plugins` is empty, `wasm.plugins` will have empty list `[]` as value
  - if `wasmPlugins.enabled` is set to `true` and `wasmPlugins.plugins` key is not presented in `values.yaml`, `wasm.plugins` will have `null` as value
  - but in production or real world who would enable wasm plugin and not providing any plugin anyway

finally, I welcome all feedbacks and suggestions