### PR TITLE
fix: use https scheme when etcd.auth.tls.enabled

### DIFF
--- a/charts/apisix/templates/_helpers.tpl
+++ b/charts/apisix/templates/_helpers.tpl
@@ -96,3 +96,14 @@ prometheus:
 {{- define "apisix.pluginAttrs" -}}
 {{- merge .Values.pluginAttrs (include "apisix.basePluginAttrs" . | fromYaml) | toYaml -}}
 {{- end -}}
+
+{{/*
+Scheme to use while connecting etcd
+*/}}
+{{- define "apisix.etcd.auth.scheme" -}}
+{{- if .Values.etcd.auth.tls.enabled }}
+{{- "https" }}
+{{- else }}
+{{- "http" }}
+{{- end }}
+{{- end }}

--- a/charts/apisix/templates/configmap.yaml
+++ b/charts/apisix/templates/configmap.yaml
@@ -286,9 +286,9 @@ data:
           {{- else }}
           host:                                 # it's possible to define multiple etcd hosts addresses of the same etcd cluster.
             {{- if .Values.etcd.fullnameOverride }}
-            - "http://{{ .Values.etcd.fullnameOverride }}:{{ .Values.etcd.service.port }}"
+            - "{{ include "apisix.etcd.auth.scheme" . }}://{{ .Values.etcd.fullnameOverride }}:{{ .Values.etcd.service.port }}"
             {{- else }}
-            - "http://{{ .Release.Name }}-etcd.{{ .Release.Namespace }}.svc.{{ .Values.etcd.clusterDomain }}:{{ .Values.etcd.service.port }}"
+            - "{{ include "apisix.etcd.auth.scheme" . }}://{{ .Release.Name }}-etcd.{{ .Release.Namespace }}.svc.{{ .Values.etcd.clusterDomain }}:{{ .Values.etcd.service.port }}"
             {{- end}}
           {{- end }}
         {{- else }}
@@ -516,9 +516,9 @@ data:
         {{- else }}
         host:                                 # it's possible to define multiple etcd hosts addresses of the same etcd cluster.
           {{- if .Values.etcd.fullnameOverride }}
-          - "http://{{ .Values.etcd.fullnameOverride }}:{{ .Values.etcd.service.port }}"
+          - "{{ include "apisix.etcd.auth.scheme" . }}://{{ .Values.etcd.fullnameOverride }}:{{ .Values.etcd.service.port }}"
           {{- else }}
-          - "http://{{ .Release.Name }}-etcd.{{ .Release.Namespace }}.svc.{{ .Values.etcd.clusterDomain }}:{{ .Values.etcd.service.port }}"
+          - "{{ include "apisix.etcd.auth.scheme" . }}://{{ .Release.Name }}-etcd.{{ .Release.Namespace }}.svc.{{ .Values.etcd.clusterDomain }}:{{ .Values.etcd.service.port }}"
           {{- end}}
         {{- end}}
       {{- else }}

--- a/charts/apisix/templates/configmap.yaml
+++ b/charts/apisix/templates/configmap.yaml
@@ -276,21 +276,12 @@ data:
               role: viewer
         etcd:
         {{- if .Values.etcd.enabled }}
-          {{- if .Values.etcd.auth.tls.enabled }}
-          host:                                 # it's possible to define multiple etcd hosts addresses of the same etcd cluster.
-            {{- if .Values.etcd.fullnameOverride }}
-            - "https://{{ .Values.etcd.fullnameOverride }}:{{ .Values.etcd.service.port }}"
-            {{- else }}
-            - "https://{{ .Release.Name }}-etcd.{{ .Release.Namespace }}.svc.{{ .Values.etcd.clusterDomain }}:{{ .Values.etcd.service.port }}"
-            {{- end}}
-          {{- else }}
           host:                                 # it's possible to define multiple etcd hosts addresses of the same etcd cluster.
             {{- if .Values.etcd.fullnameOverride }}
             - "{{ include "apisix.etcd.auth.scheme" . }}://{{ .Values.etcd.fullnameOverride }}:{{ .Values.etcd.service.port }}"
             {{- else }}
             - "{{ include "apisix.etcd.auth.scheme" . }}://{{ .Release.Name }}-etcd.{{ .Release.Namespace }}.svc.{{ .Values.etcd.clusterDomain }}:{{ .Values.etcd.service.port }}"
             {{- end}}
-          {{- end }}
         {{- else }}
           host:                                 # it's possible to define multiple etcd hosts addresses of the same etcd cluster.
             {{- range $value := .Values.etcd.host }}
@@ -506,21 +497,12 @@ data:
 
       etcd:
       {{- if .Values.etcd.enabled }}
-        {{- if .Values.etcd.auth.tls.enabled }}
-        host:                                 # it's possible to define multiple etcd hosts addresses of the same etcd cluster.
-          {{- if .Values.etcd.fullnameOverride }}
-          - "https://{{ .Values.etcd.fullnameOverride }}:{{ .Values.etcd.service.port }}"
-          {{- else }}
-          - "https://{{ .Release.Name }}-etcd.{{ .Release.Namespace }}.svc.{{ .Values.etcd.clusterDomain }}:{{ .Values.etcd.service.port }}"
-          {{- end}}
-        {{- else }}
         host:                                 # it's possible to define multiple etcd hosts addresses of the same etcd cluster.
           {{- if .Values.etcd.fullnameOverride }}
           - "{{ include "apisix.etcd.auth.scheme" . }}://{{ .Values.etcd.fullnameOverride }}:{{ .Values.etcd.service.port }}"
           {{- else }}
           - "{{ include "apisix.etcd.auth.scheme" . }}://{{ .Release.Name }}-etcd.{{ .Release.Namespace }}.svc.{{ .Values.etcd.clusterDomain }}:{{ .Values.etcd.service.port }}"
           {{- end}}
-        {{- end}}
       {{- else }}
         host:                                 # it's possible to define multiple etcd hosts addresses of the same etcd cluster.
           {{- range $value := .Values.etcd.host }}

--- a/charts/apisix/templates/configmap.yaml
+++ b/charts/apisix/templates/configmap.yaml
@@ -276,12 +276,21 @@ data:
               role: viewer
         etcd:
         {{- if .Values.etcd.enabled }}
+          {{- if .Values.etcd.auth.tls.enabled }}
+          host:                                 # it's possible to define multiple etcd hosts addresses of the same etcd cluster.
+            {{- if .Values.etcd.fullnameOverride }}
+            - "https://{{ .Values.etcd.fullnameOverride }}:{{ .Values.etcd.service.port }}"
+            {{- else }}
+            - "https://{{ .Release.Name }}-etcd.{{ .Release.Namespace }}.svc.{{ .Values.etcd.clusterDomain }}:{{ .Values.etcd.service.port }}"
+            {{- end}}
+          {{- else }}
           host:                                 # it's possible to define multiple etcd hosts addresses of the same etcd cluster.
             {{- if .Values.etcd.fullnameOverride }}
             - "http://{{ .Values.etcd.fullnameOverride }}:{{ .Values.etcd.service.port }}"
             {{- else }}
             - "http://{{ .Release.Name }}-etcd.{{ .Release.Namespace }}.svc.{{ .Values.etcd.clusterDomain }}:{{ .Values.etcd.service.port }}"
             {{- end}}
+          {{- end }}
         {{- else }}
           host:                                 # it's possible to define multiple etcd hosts addresses of the same etcd cluster.
             {{- range $value := .Values.etcd.host }}
@@ -497,12 +506,21 @@ data:
 
       etcd:
       {{- if .Values.etcd.enabled }}
+        {{- if .Values.etcd.auth.tls.enabled }}
+        host:                                 # it's possible to define multiple etcd hosts addresses of the same etcd cluster.
+          {{- if .Values.etcd.fullnameOverride }}
+          - "https://{{ .Values.etcd.fullnameOverride }}:{{ .Values.etcd.service.port }}"
+          {{- else }}
+          - "https://{{ .Release.Name }}-etcd.{{ .Release.Namespace }}.svc.{{ .Values.etcd.clusterDomain }}:{{ .Values.etcd.service.port }}"
+          {{- end}}
+        {{- else }}
         host:                                 # it's possible to define multiple etcd hosts addresses of the same etcd cluster.
           {{- if .Values.etcd.fullnameOverride }}
           - "http://{{ .Values.etcd.fullnameOverride }}:{{ .Values.etcd.service.port }}"
           {{- else }}
           - "http://{{ .Release.Name }}-etcd.{{ .Release.Namespace }}.svc.{{ .Values.etcd.clusterDomain }}:{{ .Values.etcd.service.port }}"
           {{- end}}
+        {{- end}}
       {{- else }}
         host:                                 # it's possible to define multiple etcd hosts addresses of the same etcd cluster.
           {{- range $value := .Values.etcd.host }}


### PR DESCRIPTION
Eventhough the `etcd.auth.tls.enabled`, `apisix` tries to connect with `http`.

This PR will solve it.