### PR TITLE
feat: enable MTLS between dashboard and etcd 

### DIFF
--- a/charts/apisix-dashboard/README.md
+++ b/charts/apisix-dashboard/README.md
@@ -64,6 +64,11 @@ _See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command documen
 | config.conf.etcd.endpoints | list | `["apisix-etcd:2379"]` | Supports defining multiple etcd host addresses for an etcd cluster |
 | config.conf.etcd.password | string | `nil` | Specifies etcd basic auth password if enable etcd auth |
 | config.conf.etcd.prefix | string | `"/apisix"` | apisix configurations prefix |
+| config.conf.etcd.tls.caFile | string | `"ca.crt"` | Name of CA file in secret |
+| config.conf.etcd.tls.certFile | string | `"tls.crt"` | Name of cert file in secret |
+| config.conf.etcd.tls.enabled | bool | `false` | Enable tls when connecting to an etce cluster with TLS enabled |
+| config.conf.etcd.tls.existingSecret | string | `""` | Name of existing Secret object that contains certs fot TLS authentication |
+| config.conf.etcd.tls.keyFile | string | `"tls.key"` | Name of key file in secret |
 | config.conf.etcd.username | string | `nil` | Specifies etcd basic auth username if enable etcd auth |
 | config.conf.listen.host | string | `"0.0.0.0"` | The address on which the Manager API should listen. The default value is 0.0.0.0, if want to specify, please enable it. This value accepts IPv4, IPv6, and hostname. |
 | config.conf.listen.port | int | `9000` | The port on which the Manager API should listen. |

--- a/charts/apisix-dashboard/templates/configmap.yaml
+++ b/charts/apisix-dashboard/templates/configmap.yaml
@@ -41,6 +41,12 @@ data:
         {{- if .password }}
         password: {{ .password }}
         {{- end }}
+        {{- if .tls.enabled }}
+        mtls:
+          ca_file: {{ printf "/etcd-certs/%s" .tls.caFile }}
+          cert_file: {{ printf "/etcd-certs/%s" .tls.certFile }}
+          key_file: {{ printf "/etcd-certs/%s" .tls.keyFile }}
+        {{- end }}
       {{- end }}
       {{- with .log }}
       log:

--- a/charts/apisix-dashboard/templates/deployment.yaml
+++ b/charts/apisix-dashboard/templates/deployment.yaml
@@ -74,10 +74,19 @@ spec:
             - mountPath: /usr/local/apisix-dashboard/conf/conf.yaml
               name: apisix-dashboard-config
               subPath: conf.yaml
+          {{- if .Values.config.conf.etcd.tls.enabled }}
+            - mountPath: /etcd-certs
+              name: etcd-certs
+          {{- end }}
       volumes:
         - configMap:
             name: {{ include "apisix-dashboard.fullname" . }}
           name: apisix-dashboard-config
+      {{- if .Values.config.conf.etcd.tls.enabled }}
+        - secret:
+            secretName: {{ .Values.config.conf.etcd.tls.existingSecret | quote }}
+          name: etcd-certs
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/apisix-dashboard/values.yaml
+++ b/charts/apisix-dashboard/values.yaml
@@ -84,6 +84,17 @@ config:
       username: ~
       # -- Specifies etcd basic auth password if enable etcd auth
       password: ~
+      tls:
+        # -- Enable tls when connecting to an etce cluster with TLS enabled
+        enabled: false
+        # -- Name of existing Secret object that contains certs fot TLS authentication
+        existingSecret: ""
+        # -- Name of CA file in secret
+        caFile: "ca.crt"
+        # -- Name of cert file in secret
+        certFile: "tls.crt"
+        # -- Name of key file in secret
+        keyFile: "tls.key"
     log:
       # -- Error log level.
       # Supports levels, lower to higher: debug, info, warn, error, panic, fatal


### PR DESCRIPTION
When we deploy apisix with dashboard enabled into a low-load cluster, we prefer to reuse the existing etcd cluster, such as the one that used by `kube-apiserver`, which has MTLS enabled by default. We need to make the dashboard chart support this configurations.