### PR TITLE
fix: etcd sni

### DIFF
--- a/charts/apisix/templates/configmap.yaml
+++ b/charts/apisix/templates/configmap.yaml
@@ -251,7 +251,9 @@ data:
         cert: "/etcd-ssl/{{ .Values.etcd.auth.tls.certFilename }}"
         key: "/etcd-ssl/{{ .Values.etcd.auth.tls.certKeyFilename }}"
         verify: {{ .Values.etcd.auth.tls.verify }}
+        {{- if .Values.etcd.auth.tls.sni }}
         sni: "{{ .Values.etcd.auth.tls.sni }}"
+        {{- end }}
       {{- end }}
     {{- end }}
 


### PR DESCRIPTION
Currently, the default value of `etcd.auth.tls.sni` field is `""`, and it'll be set unconditionally to APISIX config.yaml if `etcd.auth.tls.enabled` is `true`, in such a case, an empty SNI will be set when APISIX is trying to access ETCD (in a TLS handshake).

Signed-off-by: Chao Zhang <tokers@apache.org>