### PR TITLE
fix(apisix-ingress-controller): get apisix-admin service namespace error

### DIFF
--- a/charts/apisix-ingress-controller/templates/_helpers.tpl
+++ b/charts/apisix-ingress-controller/templates/_helpers.tpl
@@ -82,3 +82,26 @@ Create the name of the service account to use
 {{- define "apisix-ingress-controller.namespace" -}}
 {{- default .Release.Namespace .Values.namespace -}}
 {{- end -}}
+
+
+{{/*
+Apisix Admin Service Address
+*/}}
+{{- define "apisix-ingress-controller.serviceAddress" -}}
+{{- if .Values.config.apisix.serviceFullname -}}
+{{ .Values.config.apisix.serviceName }}
+{{- else }}
+{{- $serviceNamespace := .Release.Namespace -}}
+{{- if .Values.config.apisix.serviceNamespace -}}
+{{- $serviceNamespace = .Values.config.apisix.serviceNamespace -}}
+{{- end -}}
+{{ .Values.config.apisix.serviceName }}.{{ $serviceNamespace }}.svc.{{ .Values.clusterDomain }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Apisix Admin Service Url
+*/}}
+{{- define "apisix-admin.serviceUrl" -}}
+{{ include "apisix-ingress-controller.serviceAddress" . }}:{{ .Values.config.apisix.servicePort }}
+{{- end -}}

--- a/charts/apisix-ingress-controller/templates/configmap.yaml
+++ b/charts/apisix-ingress-controller/templates/configmap.yaml
@@ -56,11 +56,7 @@ data:
       apisix_route_version: {{ .Values.config.kubernetes.apisixRouteVersion | quote }}
       enable_gateway_api: {{ .Values.config.kubernetes.enableGatewayAPI }}
     apisix:
-      {{ if .Values.config.apisix.serviceFullname }}
-      default_cluster_base_url: http://{{ .Values.config.apisix.serviceFullname }}:{{ .Values.config.apisix.servicePort }}/apisix/admin
-      {{ else }}
-      default_cluster_base_url: http://{{ .Values.config.apisix.serviceName }}.{{ .Values.config.apisix.serviceNamespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.config.apisix.servicePort }}/apisix/admin
-      {{ end}}
+      default_cluster_base_url: http://{{ include "apisix-admin.serviceUrl" . }}/apisix/admin
       default_cluster_admin_key: {{ .Values.config.apisix.adminKey | quote }}
       default_cluster_name: {{ .Values.config.apisix.clusterName | quote }}
 kind: ConfigMap

--- a/charts/apisix-ingress-controller/templates/deployment.yaml
+++ b/charts/apisix-ingress-controller/templates/deployment.yaml
@@ -60,11 +60,7 @@ spec:
       initContainers:
         - name: wait-apisix-admin
           image: {{ .Values.initContainer.image }}:{{ .Values.initContainer.tag }}
-          {{ if .Values.config.apisix.serviceFullname }}
-          command: ['sh', '-c', "until nc -z {{ .Values.config.apisix.serviceFullname }} {{ .Values.config.apisix.servicePort }} ; do echo waiting for apisix-admin; sleep 2; done;"]
-          {{ else }}
-          command: ['sh', '-c', "until nc -z {{ .Values.config.apisix.serviceName }}.{{ .Values.config.apisix.serviceNamespace }}.svc.{{ .Values.clusterDomain }} {{ .Values.config.apisix.servicePort }} ; do echo waiting for apisix-admin; sleep 2; done;"]
-          {{ end}}
+          command: ['sh', '-c', "until nc -z {{ include "apisix-ingress-controller.serviceAddress" . }} {{ .Values.config.apisix.servicePort }} ; do echo waiting for apisix-admin; sleep 2; done;"]
 
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}

--- a/charts/apisix-ingress-controller/values.yaml
+++ b/charts/apisix-ingress-controller/values.yaml
@@ -129,7 +129,7 @@ config:
     # Enabling this value, overrides serviceName and serviceNamespace.
     # serviceFullname: "apisix-admin.apisix.svc.local"
     serviceName: apisix-admin
-    serviceNamespace: ingress-apisix
+    # serviceNamespace: ingress-apisix
     servicePort: 9180
     adminKey: "edd1c9f034335f136f87ad84b625c8f1"
     clusterName: "default"


### PR DESCRIPTION
## What does this pr do ?
Fix namespace error which had been mentioned in Issue #263 

## How do I fix it ?
I noticed that Service `apisix-admin` always use `.Value.config.apisix.serviceNamespace` as target url namespace.
Well, it might not cause problem by deploy helm chart to namespace ingress-apisix as same as docs do.
Therefore, when I deploy to another namespace, it failed.

As usuall, all apisix resource should be deployed into same namespace. SO I use `.Release.Namespace` by default instead  of `ingress-apisix`. And it could also change namespace by set `.Value.config.apisix.serviceNamespace` to the real apisix service namespace.
