### PR TITLE
feat: Node Port Configuration for Stream Proxy Gateway Service

### DIFF
--- a/charts/apisix/templates/service-gateway.yaml
+++ b/charts/apisix/templates/service-gateway.yaml
@@ -69,18 +69,24 @@ spec:
   {{- if and .Values.gateway.stream.enabled (or (gt (len .Values.gateway.stream.tcp) 0) (gt (len .Values.gateway.stream.udp) 0)) }}
   {{- with .Values.gateway.stream }}
   {{- if (gt (len .tcp) 0) }}
-  {{- range $index, $port := .tcp }}
+  {{- range $index, $elem := .tcp }}
   - name: proxy-tcp-{{ $index | toString }}
-    port: {{ $port }}
-    targetPort: {{ $port }}
+    port: {{ $elem.port }}
+    targetPort: {{ $elem.port }}
+    {{- if not (empty $elem.port) }}
+    nodePort: {{ $elem.nodePort }}
+    {{- end}}
     protocol: TCP
   {{- end }}
   {{- end }}
   {{- if (gt (len .udp) 0) }}
-  {{- range $index, $port := .udp }}
+  {{- range $index, $elem := .udp }}
   - name: proxy-udp-{{ $index | toString }}
-    port: {{ $port }}
-    targetPort: {{ $port }}
+    port: {{ $elem.port }}
+    targetPort: {{ $elem.port }}
+    {{- if not (empty $elem.port) }}
+    nodePort: {{ $elem.nodePort }}
+    {{- end}}
     protocol: UDP
   {{- end }}
   {{- end }}

--- a/charts/apisix/values.yaml
+++ b/charts/apisix/values.yaml
@@ -167,6 +167,12 @@ gateway:
   stream:
     enabled: false
     only: false
+    # tcp:
+    #   - port: 9101
+    #     nodePort: 30091
+    # udp:
+    #   - port: 9102
+    #     nodePort: 30092
     tcp: []
     udp: []
   ingress:


### PR DESCRIPTION
This PR adds the ability to specify a NodePort for every tcp or udp Stream Proxy Service that is created.