### PR TITLE
chore: use helm docs to generate documentation

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -68,3 +68,20 @@ jobs:
                && helm repo add apisix https://charts.apiseven.com \
                && ct install \
                   --charts charts/apisix'
+
+      - name: Setup Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: '1.19.2'
+
+      - name: Run helm-docs
+        run: |
+          GOBIN=$PWD GO111MODULE=on go install github.com/norwoodj/helm-docs/cmd/helm-docs@v1.11.0
+          ./helm-docs --chart-search-root=${GITHUB_WORKSPACE}/charts
+          DIFF=$(git diff ${GITHUB_WORKSPACE}/charts/**/*md)
+          if [ ! -z "$DIFF" ]; then
+            echo "Please use helm-docs in your clone, of your fork, of the project, and commit a updated README.md for the chart. https://github.com/kubernetes/ingress-nginx/blob/main/RELEASE.md#d-edit-the-valuesyaml-and-run-helm-docs"
+          fi
+          git diff --exit-code
+          rm -f ./helm-docs
+          

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -80,7 +80,7 @@ jobs:
           ./helm-docs --chart-search-root=${GITHUB_WORKSPACE}/charts
           DIFF=$(git diff ${GITHUB_WORKSPACE}/charts/**/*md)
           if [ ! -z "$DIFF" ]; then
-            echo "Please use helm-docs in your clone, of your fork, of the project, and commit a updated README.md for the chart. https://github.com/kubernetes/ingress-nginx/blob/main/RELEASE.md#d-edit-the-valuesyaml-and-run-helm-docs"
+            echo "Please use helm-docs in your clone, of your fork, of the project, and commit a updated README.md for the chart."
           fi
           git diff --exit-code
           rm -f ./helm-docs

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -84,4 +84,3 @@ jobs:
           fi
           git diff --exit-code
           rm -f ./helm-docs
-          

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+.PHONY: helm-docs
+helm-docs:
+ifeq (, $(shell which helm-docs))	
+	$(info "helm-docs not found, installing")
+	$(shell go install github.com/norwoodj/helm-docs/cmd/helm-docs@latest)
+	helm-docs
+else
+	helm-docs
+endif

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,5 @@ helm-docs:
 ifeq (, $(shell which helm-docs))	
 	$(info "helm-docs not found, installing")
 	$(shell go install github.com/norwoodj/helm-docs/cmd/helm-docs@latest)
-	helm-docs
-else
-	helm-docs
 endif
+	helm-docs

--- a/charts/apisix-dashboard/README.md
+++ b/charts/apisix-dashboard/README.md
@@ -49,71 +49,48 @@ _See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command documen
 
 ## Parameters
 
-The following tables lists the configurable parameters of the apisix-dashboard chart and their default values per section/component:
+## Values
 
-### Common parameters
-
-| Name               | Description                                                                                       | Value                    |
-| ------------------ | ------------------------------------------------------------------------------------------------- | ------------------------ |
-| `nameOverride`     | String to partially override apisix-dashboard.fullname template (will maintain the release name)  | `nil`                    |
-| `fullnameOverride` | String to fully override apisix-dashboard.fullname template                                       | `nil`                    |
-| `imagePullSecrets` | Docker registry secret names as an array                                                          | `[]`                     |
-| `image.repository` | Apache APISIX Dashboard image repository                                                          | `apache/apisix-dashboard`|
-| `image.tag`        | Apache APISIX Dashboard image tag (immutable tags are recommended)                                | `2.10.1-alpine`          |
-| `image.pullPolicy` | Apache APISIX Dashboard image pull policy                                                         | `IfNotPresent`           |
-
-### Apache APISIX Dashboard configurable parameters
-
-| Name                                 | Description                                                                               | Value           |
-| ------------------------------------ | ----------------------------------------------------------------------------------------- | --------------- |
-| `config.conf.listen.host`                       | The address on which the `Manager API` should listen. The default value is 0.0.0.0, if want to specify, please enable it. This value accepts IPv4, IPv6, and hostname.                                                                   | `0.0.0.0`             |
-| `config.conf.listen.port`                       | The port on which the `Manager API` should listen.                                                                  | `9000`             |
-| `config.authentication.secert`                  | Secret for jwt token generation | `secert` |
-| `config.authentication.expireTime`                  | JWT token expire time, in second | `3600` |
-| `config.authentication.users`                  | Specifies username and password for login `manager api`. | `[{username: admin, password: admin}]` |
-| `config.conf.etcd.endpoints`                       | Supports defining multiple etcd host addresses for an etcd cluster                                                                  | `apisix-etcd:2379`             |
-| `config.conf.etcd.prefix`                       | Apache APISIX config's prefix in etcd, /apisix by default                                                                  | `/apisix`             |
-| `config.conf.etcd.username`                       | Specifies etcd basic auth username if  enable etcd auth                                                                | `~`             |
-| `config.conf.etcd.password`                       | Specifies etcd basic auth password  if  enable etcd auth                                                              | `~`             |
-| `config.conf.log.accessLog.filePath`                  | Access log path | `/dev/stdout` |
-| `config.conf.log.errorLog.filePath`                  | Error log path | `/dev/stderr` |
-| `config.conf.log.errorLog.level`                  | Error log level. Supports levels, lower to higher: debug, info, warn, error, panic, fatal | `warn` |
-
-### Deployment parameters
-
-| Name                                            | Description                                                                               | Value           |
-| ----------------------------------------------- | ----------------------------------------------------------------------------------------- | --------------- |
-| `replicaCount`                                  | Number of Apache APISIX Dashboard nodes                                                   | `1`             |
-| `priorityClassName`                             | Set the [priorityClassName](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#pod-priority) for pods | `""` |
-| `podAnnotations`                                | Apache APISIX Dashboard Pod annotations                                                   | `{}`            |
-| `nodeSelector`                                  | Node labels for pod assignment                                                            | `{}`            |
-| `tolerations`                                   | Tolerations for pod assignment                                                            | `[]`            |
-| `resources.limits`                              | The resources limits for Apache APISIX Dashboard containers                               | `{}`            |
-| `resources.requests`                            | The requested resources for Apache APISIX Dashboardcontainers                             | `{}`            |
-| `podSecurityContext`                            | Set the securityContext for Apache APISIX Dashboard pods                                  | `{}`            |
-| `securityContext`                               | Set the securityContext for Apache APISIX Dashboard container                             | `{}`            |
-| `autoscaling.enabled`                           | Enable autoscaling for Apache APISIX Dashboard deployment                                 | `false`         |
-| `autoscaling.minReplicas`                       | Minimum number of replicas to scale back                                                  | `1`             |
-| `autoscaling.maxReplicas`                       | Maximum number of replicas to scale out                                                   | `100`           |
-| `autoscaling.targetCPUUtilizationPercentage`    | Target CPU utilization percentage                                                         | `80`            |
-| `autoscaling.targetMemoryUtilizationPercentage` | Target Memory utilization percentage                                                      | `nil`           |
-
-### Traffic Exposure parameters
-
-| Name                            | Description                                                                                      | Value       |
-| ------------------------------- |--------------------------------------------------------------------------------------------------|-------------|
-| `service.type`                  | Service type                                                                                     | `ClusterIP` |
-| `service.port`                  | Service HTTP port                                                                                | `80`        |
-| `ingress.enabled`               | Set to true to enable ingress record generation                                                  | `false`     |
-| `ingress.annotations`           | Ingress annotations                                                                              | `{}`        |
-| `ingress.hosts`                 | The list of hostnames to be covered with this ingress record.                                    | `[]`        |
-| `ingress.tls`                   | Create TLS Secret                                                                                | `false`     |
-| `ingress.className`             | `ingressClassName` replace `annotations kubernetes.io/ingress.class`, required kubernetes 1.18>= | `apisix`    |
-
-### RBAC parameters
-
-| Name                         | Description                                                                                                           | Value  |
-| ---------------------------- | --------------------------------------------------------------------------------------------------------------------- | ------ |
-| `serviceAccount.create`      | Specifies whether a ServiceAccount should be created                                                                  | `true` |
-| `serviceAccount.name`        | The name of the ServiceAccount to use. If not set and create is true, a name is generated using the fullname template | `nil`  |
-| `serviceAccount.annotations` | Annotations to add to the ServiceAccount Metadata                                                                     | `{}`   |
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` |  |
+| autoscaling.enabled | bool | `false` | Enable autoscaling for Apache APISIX Dashboard deployment |
+| autoscaling.maxReplicas | int | `100` | Maximum number of replicas to scale out |
+| autoscaling.minReplicas | int | `1` | Minimum number of replicas to scale back |
+| autoscaling.targetCPUUtilizationPercentage | int | `80` | Target CPU utilization percentage |
+| config.authentication.expireTime | int | `3600` | JWT token expire time, in second |
+| config.authentication.secret | string | `"secret"` | Secret for jwt token generation |
+| config.authentication.users | list | `[{"password":"admin","username":"admin"}]` | Specifies username and password for login manager api. |
+| config.conf.etcd.endpoints | list | `["apisix-etcd:2379"]` | Supports defining multiple etcd host addresses for an etcd cluster |
+| config.conf.etcd.password | string | `nil` | Specifies etcd basic auth password if enable etcd auth |
+| config.conf.etcd.prefix | string | `"/apisix"` | apisix configurations prefix |
+| config.conf.etcd.username | string | `nil` | Specifies etcd basic auth username if enable etcd auth |
+| config.conf.listen.host | string | `"0.0.0.0"` | The address on which the Manager API should listen. The default value is 0.0.0.0, if want to specify, please enable it. This value accepts IPv4, IPv6, and hostname. |
+| config.conf.listen.port | int | `9000` | The port on which the Manager API should listen. |
+| config.conf.log.accessLog.filePath | string | `"/dev/stdout"` | Error log path |
+| config.conf.log.errorLog | object | `{"filePath":"/dev/stderr","level":"warn"}` | Error log level. Supports levels, lower to higher: debug, info, warn, error, panic, fatal |
+| config.conf.log.errorLog.filePath | string | `"/dev/stderr"` | Access log path |
+| fullnameOverride | string | `""` | String to fully override apisix-dashboard.fullname template |
+| image.pullPolicy | string | `"IfNotPresent"` | Apache APISIX Dashboard image pull policy |
+| image.repository | string | `"apache/apisix-dashboard"` | Apache APISIX Dashboard image repository |
+| image.tag | string | `"2.13-alpine"` | Overrides the image tag whose default is the chart appVersion. Apache APISIX Dashboard image tag (immutable tags are recommended) |
+| imagePullSecrets | list | `[]` | Docker registry secret names as an array |
+| ingress.annotations | object | `{}` | Ingress annotations |
+| ingress.className | string | `""` | Kubernetes 1.18+ support ingressClassName attribute |
+| ingress.enabled | bool | `false` | Set to true to enable ingress record generation |
+| ingress.hosts | list | `[{"host":"apisix-dashboard.local","paths":[]}]` | The list of hostnams to be covered with this ingress record |
+| ingress.tls | list | `[]` | Create TLS Secret |
+| nameOverride | string | `""` | String to partially override apisix-dashboard.fullname template (will maintain the release name) |
+| nodeSelector | object | `{}` | Node labels for pod assignment |
+| podAnnotations | object | `{}` | Apache APISIX Dashboard Pod annotations |
+| podSecurityContext | object | `{}` | Set the securityContext for Apache APISIX Dashboard pods |
+| priorityClassName | string | `""` | Set the [priorityClassName](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#pod-priority) for pods |
+| replicaCount | int | `1` | Number of Apache APISIX Dashboard nodes |
+| resources | object | `{}` |  |
+| securityContext | object | `{}` | Set the securityContext for Apache APISIX Dashboard container |
+| service.port | int | `80` | Service HTTP port |
+| service.type | string | `"ClusterIP"` | Service type |
+| serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
+| serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
+| serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |
+| tolerations | list | `[]` | Tolerations for pod assignment |

--- a/charts/apisix-dashboard/README.md.gotmpl
+++ b/charts/apisix-dashboard/README.md.gotmpl
@@ -1,0 +1,52 @@
+# Apache APISIX Dashboard
+
+[APISIX Dashboard](https://github.com/apache/apisix-dashboard/) is designed to make it as easy as possible for users to operate Apache APISIX through a frontend interface.
+
+This chart bootstraps an apisix-dashboard deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+
+## Prerequisites
+
+APISIX Dashboard requires Kubernetes version 1.14+.
+
+## Get Repo Info
+
+```console
+helm repo add apisix https://charts.apiseven.com
+helm repo update
+```
+
+## Install Chart
+
+**Important:** only helm3 is supported
+
+```console
+helm install [RELEASE_NAME] apisix/apisix-dashboard --namespace ingress-apisix --create-namespace
+```
+
+The command deploys apisix-dashboard on the Kubernetes cluster in the default configuration.
+
+_See [configuration](#configuration) below._
+
+_See [helm install](https://helm.sh/docs/helm/helm_install/) for command documentation._
+
+## Uninstall Chart
+
+```console
+helm uninstall [RELEASE_NAME] --namespace ingress-apisix
+```
+
+This removes all the Kubernetes components associated with the chart and deletes the release.
+
+_See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall/) for command documentation._
+
+## Upgrading Chart
+
+```console
+helm upgrade [RELEASE_NAME] [CHART] --install
+```
+
+_See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command documentation._
+
+## Parameters
+
+{{ template "chart.valuesSection" . }}

--- a/charts/apisix-dashboard/values.yaml
+++ b/charts/apisix-dashboard/values.yaml
@@ -18,34 +18,45 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+# -- Number of Apache APISIX Dashboard nodes
 replicaCount: 1
 
 image:
+  # -- Apache APISIX Dashboard image repository
   repository: apache/apisix-dashboard
+  # -- Apache APISIX Dashboard image pull policy
   pullPolicy: IfNotPresent
-  # Overrides the image tag whose default is the chart appVersion.
+  # -- Overrides the image tag whose default is the chart appVersion.
+  # Apache APISIX Dashboard image tag (immutable tags are recommended)
   tag: 2.13-alpine
 
+# -- Docker registry secret names as an array
 imagePullSecrets: []
+# -- String to partially override apisix-dashboard.fullname template (will maintain the release name)
 nameOverride: ""
+# -- String to fully override apisix-dashboard.fullname template
 fullnameOverride: ""
 
 serviceAccount:
-  # Specifies whether a service account should be created
+  # -- Specifies whether a service account should be created
   create: true
-  # Annotations to add to the service account
+  # -- Annotations to add to the service account
   annotations: {}
-  # The name of the service account to use.
+  # -- The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
+# -- Apache APISIX Dashboard Pod annotations
 podAnnotations: {}
 
+# -- Set the [priorityClassName](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#pod-priority) for pods
 priorityClassName: ""
 
+# -- Set the securityContext for Apache APISIX Dashboard pods
 podSecurityContext: {}
   # fsGroup: 2000
 
+# -- Set the securityContext for Apache APISIX Dashboard container
 securityContext: {}
   # capabilities:
   #   drop:
@@ -57,39 +68,55 @@ securityContext: {}
 config:
   conf:
     listen:
+      # -- The address on which the Manager API should listen.
+      # The default value is 0.0.0.0, if want to specify, please enable it.
+      # This value accepts IPv4, IPv6, and hostname.
       host: 0.0.0.0
+      # -- The port on which the Manager API should listen.
       port: 9000
     etcd:
-      # Supports defining multiple etcd host addresses for an etcd cluster
+      # -- Supports defining multiple etcd host addresses for an etcd cluster
       endpoints:
         - apisix-etcd:2379
-      # apisix configurations prefix
+      # -- apisix configurations prefix
       prefix: "/apisix"
-      # Etcd basic auth info
+      # -- Specifies etcd basic auth username if enable etcd auth
       username: ~
+      # -- Specifies etcd basic auth password if enable etcd auth
       password: ~
     log:
+      # -- Error log level.
+      # Supports levels, lower to higher: debug, info, warn, error, panic, fatal
       errorLog:
         level: warn
+        # -- Access log path
         filePath: /dev/stderr
       accessLog:
+        # -- Error log path
         filePath: /dev/stdout
 
   authentication:
+    # -- Secret for jwt token generation
     secret: secret
+    # -- JWT token expire time, in second
     expireTime: 3600
+    # -- Specifies username and password for login manager api.
     users:
       - username: admin
         password: admin
 
 service:
+  # -- Service type
   type: ClusterIP
+  # -- Service HTTP port
   port: 80
 
 ingress:
+  # -- Set to true to enable ingress record generation
   enabled: false
-  # Kubernetes 1.18+ support ingressClassName attribute
+  # -- Kubernetes 1.18+ support ingressClassName attribute
   className: ""
+  # -- Ingress annotations
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
@@ -98,16 +125,18 @@ ingress:
   # - host: apisix-dashboard.local
   #    paths:
   #     - /*
+  # -- The list of hostnams to be covered with this ingress record
   hosts:
     - host: apisix-dashboard.local
       paths: []
+  # -- Create TLS Secret
   tls: []
   #  - secretName: chart-example-tls
   #    hosts:
   #      - chart-example.local
 
 resources: {}
-  # We usually recommend not to specify default resources and to leave this as a conscious
+  # -- We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
   # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
@@ -119,14 +148,20 @@ resources: {}
   #   memory: 128Mi
 
 autoscaling:
+  # -- Enable autoscaling for Apache APISIX Dashboard deployment
   enabled: false
+  # -- Minimum number of replicas to scale back
   minReplicas: 1
+  # -- Maximum number of replicas to scale out
   maxReplicas: 100
+  # -- Target CPU utilization percentage
   targetCPUUtilizationPercentage: 80
   # targetMemoryUtilizationPercentage: 80
 
+# -- Node labels for pod assignment
 nodeSelector: {}
 
+# -- Tolerations for pod assignment
 tolerations: []
 
 affinity: {}

--- a/charts/apisix-ingress-controller/README.md
+++ b/charts/apisix-ingress-controller/README.md
@@ -100,3 +100,60 @@ The same for container level, you need to set:
     --set SecurityContext.runAsGroup=«VALUE»
     ...
 ```
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| autoscaling.enabled | bool | `false` |  |
+| autoscaling.maxReplicas | int | `100` |  |
+| autoscaling.minReplicas | int | `1` |  |
+| autoscaling.targetCPUUtilizationPercentage | int | `80` |  |
+| clusterDomain | string | `"cluster.local"` |  |
+| config.apisix | object | `{"adminKey":"edd1c9f034335f136f87ad84b625c8f1","clusterName":"default","serviceName":"apisix-admin","serviceNamespace":"ingress-apisix","servicePort":9180}` | APISIX related configurations. |
+| config.apisix.serviceName | string | `"apisix-admin"` | Enabling this value, overrides serviceName and serviceNamespace. serviceFullname: "apisix-admin.apisix.svc.local" |
+| config.apisixResourceSyncInterval | string | `"300s"` | Default interval for synchronizing Kubernetes resources to APISIX |
+| config.certFile | string | `"/etc/webhook/certs/cert.pem"` | the TLS certificate file path. |
+| config.enableProfiling | bool | `true` | enable profiling via web interfaces host:port/debug/pprof, default is true. |
+| config.httpListen | string | `":8080"` | the HTTP Server listen address, default is ":8080" |
+| config.httpsListen | string | `":8443"` | the HTTPS Server listen address, default is ":8443" |
+| config.ingressPublishService | string | `""` | the controller will use the Endpoint of this Service to update the status information of the Ingress resource. The format is "namespace/svc-name" to solve the situation that the data plane and the controller are not deployed in the same namespace. |
+| config.ingressStatusAddress | list | `[]` |  |
+| config.keyFile | string | `"/etc/webhook/certs/key.pem"` | the TLS key file path. |
+| config.kubernetes | object | `{"apisixRouteVersion":"apisix.apache.org/v2","appNamespaces":["*"],"electionId":"ingress-apisix-leader","enableGatewayAPI":false,"ingressClass":"apisix","ingressVersion":"networking/v1","kubeconfig":"","namespaceSelector":[""],"resyncInterval":"6h","watchEndpointSlices":false}` | Kubernetes related configurations. |
+| config.kubernetes.apisixRouteVersion | string | `"apisix.apache.org/v2"` | the supported apisixroute api group version, can be "apisix.apache.org/v2" "apisix.apache.org/v2beta3" or "apisix.apache.org/v2beta2" |
+| config.kubernetes.appNamespaces | list | `["*"]` | namespace list that controller will watch for resources, by default all namespaces (represented by "*") are watched. |
+| config.kubernetes.electionId | string | `"ingress-apisix-leader"` | the election id for the controller leader campaign, only the leader will watch and delivery resource changes, other instances (as candidates) stand by. |
+| config.kubernetes.enableGatewayAPI | bool | `false` | whether to enable support for Gateway API. Note: This feature is currently under development and may not work as expected. It is not recommended to use it in a production environment. Before we announce support for it to reach Beta level or GA. |
+| config.kubernetes.ingressClass | string | `"apisix"` | The class of an Ingress object is set using the field IngressClassName in Kubernetes clusters version v1.18.0 or higher or the annotation "kubernetes.io/ingress.class" (deprecated). |
+| config.kubernetes.ingressVersion | string | `"networking/v1"` | the supported ingress api group version, can be "networking/v1beta1", "networking/v1" (for Kubernetes version v1.19.0 or higher), and "extensions/v1beta1", default is "networking/v1". |
+| config.kubernetes.kubeconfig | string | `""` | the Kubernetes configuration file path, default is "", so the in-cluster configuration will be used. |
+| config.kubernetes.namespaceSelector | list | `[""]` | namespace_selector represent basis for selecting managed namespaces. the field is support since version 1.4.0 For example, "apisix.ingress=watching", so ingress will watching the namespaces which labels "apisix.ingress=watching" |
+| config.kubernetes.resyncInterval | string | `"6h"` | how long should apisix-ingress-controller re-synchronizes with Kubernetes, default is 6h, |
+| config.kubernetes.watchEndpointSlices | bool | `false` | whether to watch EndpointSlices rather than Endpoints. |
+| config.logLevel | string | `"info"` | the error log level, default is info, optional values are: debug, info, warn, error, panic, fatal |
+| config.logOutput | string | `"stderr"` | the output file path of error log, default is stderr, when the file path is "stderr" or "stdout", logs are marshalled plainly, which is more readable for human; otherwise logs are marshalled in JSON format, which can be parsed by programs easily. |
+| fullnameOverride | string | `""` |  |
+| image.pullPolicy | string | `"IfNotPresent"` |  |
+| image.repository | string | `"apache/apisix-ingress-controller"` |  |
+| image.tag | string | `"1.5.1"` |  |
+| imagePullSecrets | list | `[]` |  |
+| initContainer.image | string | `"busybox"` |  |
+| initContainer.tag | float | `1.28` |  |
+| nameOverride | string | `""` | Default values for apisix-ingress-controller. This is a YAML-formatted file. Declare variables to be passed into your templates.  |
+| nodeSelector | object | `{}` |  |
+| podAnnotations | object | `{}` |  |
+| podSecurityContext | object | `{}` |  |
+| priorityClassName | string | `""` |  |
+| rbac.create | bool | `true` | Specifies whether RBAC resources should be created |
+| replicaCount | int | `1` |  |
+| resources | object | `{}` |  |
+| securityContext | object | `{}` |  |
+| service.port | int | `80` |  |
+| serviceAccount.automountServiceAccountToken | bool | `true` | Whether automounting API credentials for a service account |
+| serviceAccount.create | bool | `true` | Specifies whether a ServiceAccount should be created |
+| serviceAccount.name | string | `""` | The name of the ServiceAccount to use. If not set and create is true, a name is generated using the fullname template |
+| serviceMonitor | object | `{"annotations":{},"enabled":false,"interval":"15s","labels":{},"namespace":"monitoring"}` | namespace: "ingress-apisix" |
+| serviceMonitor.annotations | object | `{}` | @param serviceMonitor.annotations ServiceMonitor annotations |
+| serviceMonitor.labels | object | `{}` | @param serviceMonitor.labels ServiceMonitor extra labels |
+| tolerations | list | `[]` |  |

--- a/charts/apisix-ingress-controller/README.md.gotmpl
+++ b/charts/apisix-ingress-controller/README.md.gotmpl
@@ -1,0 +1,104 @@
+# Apache APISIX ingress controller
+
+[APISIX Ingress controller](https://github.com/apache/apisix-ingress-controller/) for Kubernetes using Apache APISIX as a high performance reverse proxy and load balancer.
+
+If you have installed multiple ingress controller, add the `kubernetes.io/ingress.class: apisix` annotation to your Ingress resources.
+
+This chart bootstraps an apisix-ingress-controller deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+
+## Prerequisites
+
+Apisix ingress controller requires Kubernetes version 1.16+.
+
+## Get Repo Info
+
+```console
+helm repo add apisix https://charts.apiseven.com
+helm repo update
+```
+
+## Install Chart
+
+**Important:** only helm3 is supported
+
+```console
+helm install [RELEASE_NAME] apisix/apisix-ingress-controller --namespace ingress-apisix --create-namespace
+```
+
+The command deploys apisix-ingress-controller on the Kubernetes cluster in the default configuration.
+
+_See [configuration](#configuration) below._
+
+_See [helm install](https://helm.sh/docs/helm/helm_install/) for command documentation._
+
+## Uninstall Chart
+
+```console
+helm uninstall [RELEASE_NAME] --namespace ingress-apisix
+```
+
+This removes all the Kubernetes components associated with the chart and deletes the release.
+
+_See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall/) for command documentation._
+
+## Upgrading Chart
+
+```console
+helm upgrade [RELEASE_NAME] [CHART] --install
+```
+
+_See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command documentation._
+
+## Configuration
+
+See [Customizing the Chart Before Installing](https://helm.sh/docs/intro/using_helm/#customizing-the-chart-before-installing). To see all configurable options with detailed comments, visit the chart's [values.yaml](./values.yaml), or run these configuration commands:
+
+```console
+helm show values apisix/apisix-ingress-controller
+```
+
+### Pod priority
+
+`priorityClassName` field referenced a name of a created `PriorityClass` object. Check [here](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption) for more details.
+
+### Security context
+
+A security context provides us with a way to define privilege and access control for a Pod or even at the container level.
+
+Check [here](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#securitycontext-v1-core) to see the SecurityContext resource with more detail.
+
+Check also [here](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) to see a full explanation and some examples to configure the security context.
+
+Right below you have an example of the security context configuration. In this case, we define that all the processes in the container will run with user ID 1000.
+
+```yaml
+...
+
+spec:
+  securityContext:
+    runAsUser: 1000
+    runAsGroup: 3000
+...
+```
+
+The same for the group definition, where we define the primary group of 3000 for all processes.
+
+**It's quite important to know, if the `runAsGroup` is omited, the primary group will be root(0)**, which in some cases goes against some security policies.
+
+To define this configuration at the **pod level**, you need to set:
+
+```yaml
+    --set podSecurityContext.runAsUser=«VALUE»
+    --set podSecurityContext.runAsGroup=«VALUE»
+    ...
+```
+
+The same for container level, you need to set:
+
+```yaml
+    --set securityContext.runAsUser=«VALUE»
+    --set SecurityContext.runAsGroup=«VALUE»
+    ...
+```
+
+{{ template "chart.valuesSection" . }}

--- a/charts/apisix-ingress-controller/values.yaml
+++ b/charts/apisix-ingress-controller/values.yaml
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-# Default values for apisix-ingress-controller.
+# -- Default values for apisix-ingress-controller.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 #
@@ -24,16 +24,16 @@ nameOverride: ""
 fullnameOverride: ""
 
 rbac:
-  # Specifies whether RBAC resources should be created
+  # -- Specifies whether RBAC resources should be created
   create: true
 
 serviceAccount:
-  # Specifies whether a ServiceAccount should be created
+  # -- Specifies whether a ServiceAccount should be created
   create: true
-  # The name of the ServiceAccount to use.
+  # -- The name of the ServiceAccount to use.
   # If not set and create is true, a name is generated using the fullname template
   name: ""
-  # Whether automounting API credentials for a service account
+  # -- Whether automounting API credentials for a service account
   automountServiceAccountToken: true
 
 
@@ -55,78 +55,72 @@ service:
   port: 80
 
 config:
-  # the error log level, default is info, optional values are:
-  # debug
-  # info
-  # warn
-  # error
-  # panic
-  # fatal
+  # -- the error log level, default is info, optional values are: debug, info, warn, error, panic, fatal
   logLevel: "info"
-  # the output file path of error log, default is stderr, when
+  # -- the output file path of error log, default is stderr, when
   # the file path is "stderr" or "stdout", logs are marshalled
   # plainly, which is more readable for human; otherwise logs
   # are marshalled in JSON format, which can be parsed by
   # programs easily.
   logOutput: "stderr"
-  # the TLS certificate file path.
+  # -- the TLS certificate file path.
   certFile: "/etc/webhook/certs/cert.pem"
-  # the TLS key file path.
+  # -- the TLS key file path.
   keyFile: "/etc/webhook/certs/key.pem"
-  # the HTTP Server listen address, default is ":8080"
+  # -- the HTTP Server listen address, default is ":8080"
   httpListen: ":8080"
-  # the HTTPS Server listen address, default is ":8443"
+  # -- the HTTPS Server listen address, default is ":8443"
   httpsListen: ":8443"
-  # the controller will use the Endpoint of this Service to
+  # -- the controller will use the Endpoint of this Service to
   # update the status information of the Ingress resource.
   # The format is "namespace/svc-name" to solve the situation that
   # the data plane and the controller are not deployed in the same namespace.
   ingressPublishService: ""
   ingressStatusAddress: []
-  # enable profiling via web interfaces host:port/debug/pprof, default is true.
+  # -- enable profiling via web interfaces host:port/debug/pprof, default is true.
   enableProfiling: true
-  # Default interval for synchronizing Kubernetes resources to APISIX
+  # -- Default interval for synchronizing Kubernetes resources to APISIX
   apisixResourceSyncInterval: "300s"
-  # Kubernetes related configurations.
+  # -- Kubernetes related configurations.
   kubernetes:
-    # the Kubernetes configuration file path, default is "", so the in-cluster
+    # -- the Kubernetes configuration file path, default is "", so the in-cluster
     # configuration will be used.
     kubeconfig: ""
-    # how long should apisix-ingress-controller re-synchronizes with Kubernetes,
+    # -- how long should apisix-ingress-controller re-synchronizes with Kubernetes,
     # default is 6h,
     resyncInterval: "6h"
-    # namespace list that controller will watch for resources,
+    # -- namespace list that controller will watch for resources,
     # by default all namespaces (represented by "*") are watched.
     appNamespaces: ["*"]
-    # namespace_selector represent basis for selecting managed namespaces.
+    # -- namespace_selector represent basis for selecting managed namespaces.
     # the field is support since version 1.4.0
     # For example, "apisix.ingress=watching", so ingress will watching the namespaces which labels "apisix.ingress=watching"
     namespaceSelector: [""]
-    # the election id for the controller leader campaign,
+    # -- the election id for the controller leader campaign,
     # only the leader will watch and delivery resource changes,
     # other instances (as candidates) stand by.
     electionId: "ingress-apisix-leader"
-    # The class of an Ingress object is set using the field IngressClassName in
+    # -- The class of an Ingress object is set using the field IngressClassName in
     # Kubernetes clusters version v1.18.0 or higher or the annotation
     # "kubernetes.io/ingress.class" (deprecated).
     ingressClass: "apisix"
-    # the supported ingress api group version, can be "networking/v1beta1",
+    # -- the supported ingress api group version, can be "networking/v1beta1",
     # "networking/v1" (for Kubernetes version v1.19.0 or higher), and
     # "extensions/v1beta1", default is "networking/v1".
     ingressVersion: "networking/v1"
-    # whether to watch EndpointSlices rather than Endpoints.
+    # -- whether to watch EndpointSlices rather than Endpoints.
     watchEndpointSlices: false
-    # the supported apisixroute api group version, can be "apisix.apache.org/v2"
+    # -- the supported apisixroute api group version, can be "apisix.apache.org/v2"
     # "apisix.apache.org/v2beta3" or "apisix.apache.org/v2beta2"
     apisixRouteVersion: "apisix.apache.org/v2"
-    # whether to enable support for Gateway API.
+    # -- whether to enable support for Gateway API.
     # Note: This feature is currently under development and may not work as expected.
     # It is not recommended to use it in a production environment.
     # Before we announce support for it to reach Beta level or GA.
     enableGatewayAPI: false
-  # APISIX related configurations.
+  # -- APISIX related configurations.
   apisix:
-    # Enabling this value, overrides serviceName and serviceNamespace.
+    # -- Enabling this value, overrides serviceName and serviceNamespace.
     # serviceFullname: "apisix-admin.apisix.svc.local"
     serviceName: apisix-admin
     serviceNamespace: ingress-apisix
@@ -150,15 +144,15 @@ autoscaling:
 nodeSelector: {}
 tolerations: []
 
-# namespace: "ingress-apisix"
+# -- namespace: "ingress-apisix"
 
 serviceMonitor:
   enabled: false
   namespace: "monitoring"
   interval: 15s
-  # @param serviceMonitor.labels ServiceMonitor extra labels
+  # -- @param serviceMonitor.labels ServiceMonitor extra labels
   labels: {}
-  # @param serviceMonitor.annotations ServiceMonitor annotations
+  # -- @param serviceMonitor.annotations ServiceMonitor annotations
   annotations: {}
 
 

--- a/charts/apisix/README.md
+++ b/charts/apisix/README.md
@@ -36,254 +36,152 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ## Parameters
 
-The following tables lists the configurable parameters of the apisix chart and their default values per section/component:
+## Values
 
-### Global parameters
-
-| Parameter                 | Description                                     | Default                                                 |
-|---------------------------|-------------------------------------------------|---------------------------------------------------------|
-| `global.imagePullSecrets` | Global Docker registry secret names as an array | `[]` (does not add image pull secrets to deployed pods) |
-
-### apisix parameters
-
-| Parameter                                         | Description                                                                                                                                                                                                                                                                                                                  | Default                                                |
-|---------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------|
-| `apisix.enabled`                                  | Enable or disable Apache APISIX itself                                                                                                                                                                                                                                                                                       | `true`                                                 |
-| `apisix.enableIPv6`                               | Enable nginx IPv6 resolver                                                                                                                                                                                                                                                                                                   | `true`                                                 |
-| `apisix.hostNetwork`                              | Use the host's network namespace                                                                                                                                                                                                                                                                                             | `false`                                                |
-| `apisix.enableCustomizedConfig`                   | Enable full customized `config.yaml`                                                                                                                                                                                                                                                                                         | `false`                                                |
-| `apisix.customizedConfig`                         | If `apisix.enableCustomizedConfig` is true, full customized `config.yaml`. Please note that other settings about APISIX config will be ignored                                                                                                                                                                               | `{}`                                                   |
-| `apisix.image.repository`                         | Apache APISIX image repository                                                                                                                                                                                                                                                                                               | `apache/apisix`                                        |
-| `apisix.image.tag`                                | Apache APISIX image tag                                                                                                                                                                                                                                                                                                      | `{TAG_NAME}` (the latest Apache APISIX image tag)      |
-| `apisix.image.pullPolicy`                         | Apache APISIX image pull policy                                                                                                                                                                                                                                                                                              | `IfNotPresent`                                         |
-| `apisix.kind`                                     | Apache APISIX kind use a `DaemonSet` or `Deployment`                                                                                                                                                                                                                                                                         | `Deployment`                                           |
-| `apisix.replicaCount`                             | Apache APISIX deploy replica count,kind is DaemonSet,replicaCount not become effective                                                                                                                                                                                                                                       | `1`                                                    |
-| `apisix.podAnnotations`                           | Annotations to add to each pod                                                                                                                                                                                                                                                                                               | `{}`                                                   |
-| `apisix.priorityClassName`                        | Set [priorityClassName](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#pod-priority) for Apache APISIX pods                                                                                                                                                                               | `""`                                                   |
-| `apisix.podSecurityContext`                       | Set the securityContext for Apache APISIX pods                                                                                                                                                                                                                                                                               | `{}`                                                   |
-| `apisix.securityContext`                          | Set the securityContext for Apache APISIX container                                                                                                                                                                                                                                                                          | `{}`                                                   |
-| `apisix.podDisruptionBudget.enabled`              | Enable or disable podDisruptionBudget                                                                                                                                                                                                                                                                                        | `false`                                                |
-| `apisix.podDisruptionBudget.minAvailable`         | Set the `minAvailable` of podDisruptionBudget. You can specify only one of `maxUnavailable` and `minAvailable` in a single PodDisruptionBudget. See [Specifying a Disruption Budget for your Application](https://kubernetes.io/docs/tasks/run-application/configure-pdb/#specifying-a-poddisruptionbudget) for more details | `Not set` |
-| `apisix.podDisruptionBudget.maxUnavailable`       | Set the maxUnavailable of podDisruptionBudget                                                                                                                                                                                                                                                                                | `1`                                                    |
-| `apisix.resources`                                | Set pod resource requests & limits                                                                                                                                                                                                                                                                                           | `{}`                                                   |
-| `apisix.nodeSelector`                             | Node labels for Apache APISIX pod assignment                                                                                                                                                                                                                                                                                 | `{}`                                                   |
-| `apisix.tolerations`                              | List of node taints to tolerate                                                                                                                                                                                                                                                                                              | `{}`                                                   |
-| `apisix.affinity`                                 | Set affinity for Apache APISIX deploy                                                                                                                                                                                                                                                                                        | `{}`                                                   |
-| `apisix.setIDFromPodUID`                          | Whether to use the Pod UID as the APISIX instance id, see [apache/apisix#5417](https://github.com/apache/apisix/issues/5417) to decide whether you should enable this setting)                                                                                                                                               | `false` |
-| `apisix.enableServerTokens`                       | Set the `enable_server_tokens` (Whether the APISIX version number should be shown in Server header)                                                                                                                                                                                                                          | `Not Set`                                              |
-| `apisix.customLuaSharedDicts`                     | Add custom [lua_shared_dict](https://github.com/openresty/lua-nginx-module#toc88) settings, click [here](https://github.com/apache/apisix-helm-chart/blob/master/charts/apisix/values.yaml#L27-L30) to learn the format of a shared dict                                                                                     | `[]` |
-| `apisix.pluginAttrs`                              | Set APISIX plugin attributes, see [config-default.yaml](https://github.com/apache/apisix/blob/master/conf/config-default.yaml#L376) for more details                                                                                                                                                                         | `{}` |
-| `apisix.luaModuleHook.enabled`                    | Whether to add a custom lua module                                                                                                                                                                                                                                                                                           | `false` |
-| `apisix.luaModuleHook.luaPath`                    | Configure `LUA_PATH` so that your own lua module codes can be located                                                                                                                                                                                                                                                        | `""` |
-| `apisix.luaModuleHook.hookPoint`                  | The entrypoint of your lua module, use Lua require syntax, like `"module.say_hello"`                                                                                                                                                                                                                                         | `""` |
-| `apisix.luaModuleHook.configMapRef.name`          | Name of the ConfigMap where the lua module codes store                                                                                                                                                                                                                                                                       | "" |
-| `apisix.luaModuleHook.configMapRef.mounts[].key`  | Name of the ConfigMap key, for setting the mapping relationship between ConfigMap key and the lua module code path.                                                                                                                                                                                                          | `""` |
-| `apisix.luaModuleHook.configMapRef.mounts[].path` | Filepath of the plugin code, for setting the mapping relationship between ConfigMap key and the lua module code path.                                                                                                                                                                                                        | `""` |
-| `apisix.httpRouter`                               | HTTP routing strategy. See [APISIX Router](https://apisix.apache.org/docs/apisix/terminology/router/) for the detail.                                                                                                                                                                                                    | `[]` |
-| `extraVolumes`                                    | Additional `volume`, See [Kubernetes Volumes](https://kubernetes.io/docs/concepts/storage/volumes/) for the detail.                                                                                                                                                                                                          | `[]` |
-| `extraVolumeMounts`                               | Additional `volumeMounts`, See [Kubernetes Volumes](https://kubernetes.io/docs/concepts/storage/volumes/) for the detail.                                                                                                                                                                                                    | `[]` |
-| `extraInitContainers`                             | Additional `initContainers`, See [Kubernetes initContainers](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/) for the detail.                                                                                                                                                                                                    | `[]` |
-
-### gateway parameters
-
-Apache APISIX service parameters, this determines how users can access itself.
-
-| Parameter                       | Description                                                                                                                                                                         | Default    |
-|---------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------|
-| `gateway.type`                  | Apache APISIX service type for user access itself                                                                                                                                   | `NodePort` |
-| `gateway.externalTrafficPolicy` | Setting how the Service route external traffic                                                                                                                                      | `Cluster`  |
-| `gateway.http`                  | Apache APISIX service settings for http                                                                                                                                             |            |
-| `gateway.tls`                   | Apache APISIX service settings for tls                                                                                                                                              |            |
-| `gateway.tls.existingCASecret`  | Specifies the name of Secret contains trusted CA certificates in the PEM format used to verify the certificate when APISIX needs to do SSL/TLS handshaking with external services (e.g. etcd) | `""`       |
-| `gateway.tls.certCAFilename`    | Filename be used in the `gateway.tls.existingCASecret`                                                                                                                                          | `""`       |
-| `gateway.tls.sslProtocols`    |   TLS protocols allowed to use.  | `"TLSv1.2 TLSv1.3"`       |
-| `gateway.stream`                | Apache APISIX service settings for stream                                                                                                                                           |            |
-| `gateway.ingress`               | Using ingress access Apache APISIX service                                                                                                                                          |            |
-| `gateway.ingress.annotations`   | Ingress annotations                                                                                                                                                                 | `[]`       |
-| `gateway.ingress.className`     | `ingressClassName` replaces `annotations kubernetes.io/ingress.class`, required Kubernetes `>=1.18`                                                                                   |            |
-
-### admin parameters
-
-| Parameter                  | Description                                                                      | Default                                                 |
-|----------------------------|----------------------------------------------------------------------------------|---------------------------------------------------------|
-| `admin.enabled`            | Enable or disable Apache APISIX admin API                                        | `true`                                                  |
-| `admin.port`               | which port to use for Apache APISIX admin API                                    | `9180`                                                  |
-| `admin.servicePort`        | Service port to use for Apache APISIX admin API                                  | `9180`                                                  |
-| `admin.type`               | Apache APISIX admin API service type                                             | `ClusterIP`                                             |
-| `admin.externalIPs`        | IPs for which nodes in the cluster will also accept traffic for the servic       | `[]`                                                    |
-| `admin.cors`               | Apache APISIX admin API support CORS response headers                            | `true`                                                  |
-| `admin.credentials.admin`  | Apache APISIX admin API admin role credentials                                   | `edd1c9f034335f136f87ad84b625c8f1`                      |
-| `admin.credentials.viewer` | Apache APISIX admin API viewer role credentials                                  | `4054f7cf07e344346cd3f287985e76a2`                      |
-| `admin.allow.ipList`       | The client IP CIDR allowed to access Apache APISIX Admin API service             | `["127.0.0.1/24"]`                                      |
-
-### custom configuration snippet parameters
-
-| Parameter                        | Description                                                                                        | Default |
-|----------------------------------|----------------------------------------------------------------------------------------------------|---------|
-| `configurationSnippet.main`      | Add custom Nginx configuration (main block) to nginx.conf                                          | `{}`    |
-| `configurationSnippet.httpStart` | Add custom Nginx configuration (http block) to nginx.conf                                          | `{}`    |
-| `configurationSnippet.httpEnd`   | Add custom Nginx configuration (http block) to nginx.conf, will be put at the bottom of http block | `{}`    |
-| `configurationSnippet.httpSrv`   | Add custom Nginx configuration (server block) to nginx.conf                                        | `{}`    |
-| `configurationSnippet.httpAdmin` | Add custom Nginx configuration (Admin API server block) to nginx.conf                              | `{}`    |
-| `configurationSnippet.stream`    | Add custom Nginx configuration (stream block) to nginx.conf                                        | `{}`    |
-
-### etcd parameters
-
-| Parameter                       | Description                                                                                                                                                      | Default                     |
-|---------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------|
-| `etcd.enabled`                  | use built-in etcd                                                                                                                                                | `true`                      |
-| `etcd.host`                     | if `etcd.enabled` is false, use external etcd, support multiple address, if your etcd cluster enables TLS, please use https scheme, e.g. https://127.0.0.1:2379. | `["http://etcd.host:2379"]` |
-| `etcd.prefix`                   | apisix configurations prefix                                                                                                                                     | `/apisix`                   |
-| `etcd.timeout`                  | Set the timeout value in seconds for subsequent socket operations from apisix to etcd cluster                                                                    | `30`                        |
-| `etcd.auth.rbac.create`        | Switch to enable RBAC authentication                                                                                                                                             | `false`                     |
-| `etcd.auth.rbac.user`           | root username for etcd                                                                                                                                           | `""`                        |
-| `etcd.auth.rbac.password`       | root password for etcd                                                                                                                                           | `""`                        |
-| `etcd.auth.tls.enabled`         | enable etcd client certificate                                                                                                                                   | `false`                     |
-| `etcd.auth.tls.existingSecret`  | name of the secret contains etcd client cert                                                                                                                     | `""`                        |
-| `etcd.auth.tls.certFilename`    | etcd client cert filename using in `etcd.auth.tls.existingSecret`                                                                                                | `""`                        |
-| `etcd.auth.tls.certKeyFilename` | etcd client cert key filename using in `etcd.auth.tls.existingSecret`                                                                                            | `""`                        |
-| `etcd.auth.tls.verify`          | whether to verify the etcd endpoint certificate when setup a TLS connection to etcd                                                                              | `true`                      |
-| `etcd.auth.tls.sni`            | specify the TLS [Server Name Indication](https://en.wikipedia.org/wiki/Server_Name_Indication) extension,  the ETCD endpoint hostname will be used when this setting is unset. | `""` |
-
-If etcd.enabled is true, set more values of bitnami/etcd helm chart use etcd as prefix.
-
-### plugins and stream_plugins parameters
-
-Default enabled plugins. See [configmap template](https://github.com/apache/apisix-helm-chart/blob/master/charts/apisix/templates/configmap.yaml) for details.
-
-
-### external plugin parameters
-
-| Parameter                       | Description                                                                                                                                                      | Default                     |
-|---------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------|
-| `extPlugin.enabled` | Enable External Plugins. See [external plugin](https://apisix.apache.org/docs/apisix/next/external-plugin/) | `false` |
-| `extPlugin.cmd` | the command and its arguements to run as a subprocess | `{}` |
-
-### wasm plugin parameters
-
-| Parameter                       | Description                                                                                                                                                      | Default                     |
-|---------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------|
-| `wasmPlugins.enabled` | Enable Wasm Plugins. See [wasm plugin](https://apisix.apache.org/docs/apisix/next/wasm/) | `false` |
-| `wasmPlugins.plugins[].name` | Set wasm plugin name | `""` |
-| `wasmPlugins.plugins[].priority` | Set wasm plugin priority | `7999` |
-| `wasmPlugins.plugins[].file` | Set path to wasm plugin | `""` |
-| `wasmPlugins.plugins[].http_request_phase` | Set which http request phase for the plugin to run in | `access` |
-
-Note:
-  - the easiest way to include your wasm custom plugin is to rebuild the apisix image with those custom plugins included within the directory you define and later on gets referenced to `wasmPlugins.plugins[].file`
-  - otherwise you could use `extraVolumes` and `extraVolumeMounts` option to include your plugin by creating your plugin via `ConfigMap` and mount it to apisix pod like example below
-    ```
-    #... more options omitted ...
-    ingress-controller:
-      enabled: true
-
-    dashboard:
-      enabled: true
-
-    # assuming you install apisix in `apisix` namespace,
-    # create the plugin by this command and had the wasm plugin
-    # kubectl create configmap --namespace apisix --from-file=./wasm_plugin_x.wasm wasm-plugin-x
-    # Note: there are also size limitation on `ConfigMap`
-
-    # these options are kubernetes
-    # Volume and VolumeMount api objects
-    extraVolumes:
-    - name: wasm-plugin-x
-      configMap:
-        name: wasm-plugin-x
-        items:
-        - key: wasm_plugin_x.wasm
-          path: wasm_plugin_x.wasm
-    extraVolumeMounts:
-    - name: wasm-plugin-x
-      mountPath: /var/local/wasm-plugins/ # later on reference to `wasmPlugins.plugins[].file` as its value
-      readOnly: true
-    #... more options omitted ...
-    ```
-
-### custom plugin parameters
-
-| Parameter                       | Description                                                                                                                                                      | Default                     |
-|---------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------|
-| `apisix.customPlugins.enabled` | Whether to configure some custom plugins | `false` |
-| `apisix.customPlugins.luaPath` | Configure `LUA_PATH` so that custom plugin codes can be located | `""` |
-| `apisix.customPlugins.plugins[].name` | Custom plugin name | `""` |
-| `apisix.customPlugins.plugins[].attrs` | Custom plugin attributes | `{}` |
-| `apisix.customPlugins.plugins[].configMap.name` | Name of the ConfigMap where the plugin codes store | `""` |
-| `apisix.customPlugins.plugins[].configMap.mounts[].key` | Name of the ConfigMap key, for setting the mapping relationship between ConfigMap key and the plugin code path. | `""` |
-| `apisix.customPlugins.plugins[].configMap.mounts[].path` | Filepath of the plugin code, for setting the mapping relationship between ConfigMap key and the plugin code path. | `""` |
-
-### discovery parameters
-
-| Parameter                       | Description                                                                                                                                                                         | Default    |
-|---------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------|
-| `discovery.enabled`                  | Enable or disable Apache APISIX integration service discovery | `false` |
-| `discovery.registry`                  | Registry is the same to the one in APISIX [config-default.yaml](https://github.com/apache/apisix/blob/master/conf/config-default.yaml#L281), and refer to such file for more setting details. also refer to [this documentation for integration service discovery](https://apisix.apache.org/docs/apisix/discovery) | nil |
-
-If you have enabled this feature,  here is an example:
-
-```yaml
-discovery:
-  enabled: true
-  registry:
-    eureka:
-      host:
-        - "http://${username}:${password}@${eureka_host1}:${eureka_port1}"
-        - "http://${username}:${password}@${eureka_host2}:${eureka_port2}"
-      prefix: "/eureka/"
-      fetch_interval: 30
-      weight: 100
-      timeout:
-        connect: 2000
-        send: 2000
-        read: 5000
-```
-
-### logs parameters
-
-| Parameter                       | Description                                                                                                                                                                         | Default    |
-|---------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------|
-| `logs.enableAccessLog`                  | Enable access log or not, default true | `true` |
-| `logs.accessLog`                  | Access log path | `/dev/stdout` |
-| `logs.accessLogFormat`                  | Access log format | `$remote_addr - $remote_user [$time_local] $http_host \"$request\" $status $body_bytes_sent $request_time \"$http_referer\" \"$http_user_agent\" $upstream_addr $upstream_status $upstream_response_time \"$upstream_scheme://$upstream_host$upstream_uri\"` |
-| `logs.accessLogFormatEscape`                  | Allows setting json or default characters escaping in variables | `default` |
-| `logs.errorLog`                  | Error log path | `/dev/stderr` |
-| `logs.errorLogLevel`                  | Error log level | `warn` |
-
-### dashboard parameters
-
-Configurations for apisix-dashboard sub chart.
-
-### ingress-controller parameters
-
-Configurations for Apache APISIX ingress-controller sub chart.
-
-### serviceMonitor parameters
-
-| Parameter                      | Description                                                  | Default                      |
-| ------------------------------ | ------------------------------------------------------------ | ---------------------------- |
-| `serviceMonitor.enabled`       | Enable or disable Apache APISIX serviceMonitor               | `false`                      |
-| `serviceMonitor.namespace`     | Namespace where the serviceMonitor is deployed               | `""`                         |
-| `serviceMonitor.interval`      | Interval at which metrics should be scraped                  | `15s`                        |
-| `serviceMonitor.path`          | Path of the Prometheus metrics endpoint                      | `/apisix/prometheus/metrics` |
-| `serviceMonitor.containerPort` | Container port which Prometheus metrics are exposed          | `9091`                       |
-| `serviceMonitor.labels`        | ServiceMonitor extra labels                                  | `{}`                         |
-| `serviceMonitor.annotations`   | ServiceMonitor annotations                                   | `{}`                         |
-
-### initContainers parameters
-
-| Parameter                      | Description          | Default   |
-|--------------------------------|----------------------|-----------|
-| `initContainer.image`          | Init container image | `busybox` |
-| `initContainer.tag`            | Init container tag   | `1.28`    |
-
-### vault integration parameters
-
-| Parameter                  | Description                                                                                      | Default                                                 |
-|----------------------------|--------------------------------------------------------------------------------------------------|---------------------------------------------------------|
-| `vault.enabled`            | Enable or disable the vault integration                                                          | `false`                                                 |
-| `vault.host`               | The host address where the vault server is running.                                              |                                                         |
-| `vault.timeout`            | HTTP timeout for each request.                                                                   |                                                         |
-| `vault.token`              | The generated token from vault instance that can grant access to read data from the vault.       |                                                         |
-| `vault.prefix`             | Prefix allows you to better enforcement of policies.                                             |                                                         |
-
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| admin.allow.ipList | list | `["127.0.0.1/24"]` | The client IP CIDR allowed to access Apache APISIX Admin API service. |
+| admin.cors | bool | `true` | Admin API support CORS response headers |
+| admin.credentials | object | `{"admin":"edd1c9f034335f136f87ad84b625c8f1","viewer":"4054f7cf07e344346cd3f287985e76a2"}` | Admin API credentials |
+| admin.credentials.admin | string | `"edd1c9f034335f136f87ad84b625c8f1"` | Apache APISIX admin API admin role credentials |
+| admin.credentials.viewer | string | `"4054f7cf07e344346cd3f287985e76a2"` | Apache APISIX admin API viewer role credentials |
+| admin.enabled | bool | `true` | Enable Admin API |
+| admin.externalIPs | list | `[]` | IPs for which nodes in the cluster will also accept traffic for the servic |
+| admin.port | int | `9180` | which port to use for Apache APISIX admin API |
+| admin.servicePort | int | `9180` | Service port to use for Apache APISIX admin API |
+| admin.type | string | `"ClusterIP"` | admin service type |
+| apisix.affinity | object | `{}` | Set affinity for Apache APISIX deploy |
+| apisix.customLuaSharedDicts | list | `[]` | Add custom [lua_shared_dict](https://github.com/openresty/lua-nginx-module#toc88) settings, click [here](https://github.com/apache/apisix-helm-chart/blob/master/charts/apisix/values.yaml#L27-L30) to learn the format of a shared dict |
+| apisix.customizedConfig | object | `{}` | If apisix.enableCustomizedConfig is true, full customized config.yaml. Please note that other settings about APISIX config will be ignored |
+| apisix.enableCustomizedConfig | bool | `false` | Enable full customized config.yaml |
+| apisix.enableIPv6 | bool | `true` | Enable nginx IPv6 resolver |
+| apisix.enableServerTokens | bool | `true` | Whether the APISIX version number should be shown in Server header |
+| apisix.enabled | bool | `true` | Enable or disable Apache APISIX itself Set it to false and ingress-controller.enabled=true will deploy only ingress-controller |
+| apisix.extraEnvVars | list | `[]` | extraEnvVars An array to add extra env vars e.g: extraEnvVars:   - name: FOO     value: "bar"   - name: FOO2     valueFrom:       secretKeyRef:         name: SECRET_NAME         key: KEY |
+| apisix.hostNetwork | bool | `false` |  |
+| apisix.httpRouter | string | `"radixtree_uri"` | Defines how apisix handles routing: - radixtree_uri: match route by uri(base on radixtree) - radixtree_host_uri: match route by host + uri(base on radixtree) - radixtree_uri_with_parameter: match route by uri with parameters |
+| apisix.image.pullPolicy | string | `"IfNotPresent"` | Apache APISIX image pull policy |
+| apisix.image.repository | string | `"apache/apisix"` | Apache APISIX image repository |
+| apisix.image.tag | string | `"2.15.1-debian"` | Apache APISIX image tag Overrides the image tag whose default is the chart appVersion. |
+| apisix.kind | string | `"Deployment"` | Use a `DaemonSet` or `Deployment` |
+| apisix.luaModuleHook | object | `{"configMapRef":{"mounts":[{"key":"","path":""}],"name":""},"enabled":false,"hookPoint":"","luaPath":""}` | Whether to add a custom lua module |
+| apisix.luaModuleHook.configMapRef | object | `{"mounts":[{"key":"","path":""}],"name":""}` | configmap that stores the codes |
+| apisix.luaModuleHook.configMapRef.mounts[0] | object | `{"key":"","path":""}` | Name of the ConfigMap key, for setting the mapping relationship between ConfigMap key and the lua module code path. |
+| apisix.luaModuleHook.configMapRef.mounts[0].path | string | `""` | Filepath of the plugin code, for setting the mapping relationship between ConfigMap key and the lua module code path. |
+| apisix.luaModuleHook.configMapRef.name | string | `""` | Name of the ConfigMap where the lua module codes store |
+| apisix.luaModuleHook.hookPoint | string | `""` | the hook module which will be used to inject third party code into APISIX use the lua require style like: "module.say_hello" |
+| apisix.luaModuleHook.luaPath | string | `""` | extend lua_package_path to load third party code |
+| apisix.nodeSelector | object | `{}` | Node labels for Apache APISIX pod assignment |
+| apisix.podAnnotations | object | `{}` | Annotations to add to each pod |
+| apisix.podDisruptionBudget | object | `{"enabled":false,"maxUnavailable":1,"minAvailable":"90%"}` | See https://kubernetes.io/docs/tasks/run-application/configure-pdb/ for more details |
+| apisix.podDisruptionBudget.enabled | bool | `false` | Enable or disable podDisruptionBudget |
+| apisix.podDisruptionBudget.maxUnavailable | int | `1` | Set the maxUnavailable of podDisruptionBudget |
+| apisix.podDisruptionBudget.minAvailable | string | `"90%"` | Set the `minAvailable` of podDisruptionBudget. You can specify only one of `maxUnavailable` and `minAvailable` in a single PodDisruptionBudget. See [Specifying a Disruption Budget for your Application](https://kubernetes.io/docs/tasks/run-application/configure-pdb/#specifying-a-poddisruptionbudget) for more details |
+| apisix.podSecurityContext | object | `{}` | Set the securityContext for Apache APISIX pods |
+| apisix.priorityClassName | string | `""` | Set [priorityClassName](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#pod-priority) for Apache APISIX pods |
+| apisix.replicaCount | int | `1` | kind is DaemonSet, replicaCount not become effective |
+| apisix.resources | object | `{}` | Set pod resource requests & limits |
+| apisix.securityContext | object | `{}` | Set the securityContext for Apache APISIX container |
+| apisix.setIDFromPodUID | bool | `false` | Use Pod metadata.uid as the APISIX id. |
+| apisix.timezone | string | `""` | timezone is the timezone where apisix uses. For example: "UTC" or "Asia/Shanghai" This value will be set on apisix container's environment variable TZ. You may need to set the timezone to be consistent with your local time zone, otherwise the apisix's logs may used to retrieve event maybe in wrong timezone. |
+| apisix.tolerations | list | `[]` | List of node taints to tolerate |
+| autoscaling.enabled | bool | `false` |  |
+| autoscaling.maxReplicas | int | `100` |  |
+| autoscaling.minReplicas | int | `1` |  |
+| autoscaling.targetCPUUtilizationPercentage | int | `80` |  |
+| autoscaling.targetMemoryUtilizationPercentage | int | `80` |  |
+| configurationSnippet | object | `{"httpAdmin":"","httpEnd":"","httpSrv":"","httpStart":"","main":"","stream":""}` | Custom configuration snippet. |
+| customPlugins | object | `{"enabled":false,"luaPath":"/opts/custom_plugins/?.lua","plugins":[{"attrs":{},"configMap":{"mounts":[{"key":"","path":""},{"key":"","path":""}],"name":""},"name":""}]}` | customPlugins allows you to mount your own HTTP plugins. |
+| customPlugins.enabled | bool | `false` | Whether to configure some custom plugins |
+| customPlugins.luaPath | string | `"/opts/custom_plugins/?.lua"` | the lua_path that tells APISIX where it can find plugins, note the last ';' is required. |
+| customPlugins.plugins[0] | object | `{"attrs":{},"configMap":{"mounts":[{"key":"","path":""},{"key":"","path":""}],"name":""},"name":""}` | plugin name. |
+| customPlugins.plugins[0].attrs | object | `{}` | plugin attrs |
+| customPlugins.plugins[0].configMap | object | `{"mounts":[{"key":"","path":""},{"key":"","path":""}],"name":""}` | plugin codes can be saved inside configmap object. |
+| customPlugins.plugins[0].configMap.mounts | list | `[{"key":"","path":""},{"key":"","path":""}]` | since keys in configmap is flat, mountPath allows to define the mount path, so that plugin codes can be mounted hierarchically. |
+| customPlugins.plugins[0].configMap.name | string | `""` | name of configmap. |
+| dashboard.enabled | bool | `false` |  |
+| discovery.enabled | bool | `false` | Enable or disable Apache APISIX integration service discovery |
+| discovery.registry | object | `{}` | Registry is the same to the one in APISIX [config-default.yaml](https://github.com/apache/apisix/blob/master/conf/config-default.yaml#L281), and refer to such file for more setting details. also refer to [this documentation for integration service discovery](https://apisix.apache.org/docs/apisix/discovery) |
+| dns.resolvers[0] | string | `"127.0.0.1"` |  |
+| dns.resolvers[1] | string | `"172.20.0.10"` |  |
+| dns.resolvers[2] | string | `"114.114.114.114"` |  |
+| dns.resolvers[3] | string | `"223.5.5.5"` |  |
+| dns.resolvers[4] | string | `"1.1.1.1"` |  |
+| dns.resolvers[5] | string | `"8.8.8.8"` |  |
+| dns.timeout | int | `5` |  |
+| dns.validity | int | `30` |  |
+| etcd | object | `{"auth":{"rbac":{"create":false,"password":"","user":""},"tls":{"certFilename":"","certKeyFilename":"","enabled":false,"existingSecret":"","sni":"","verify":true}},"enabled":true,"host":["http://etcd.host:2379"],"prefix":"/apisix","replicaCount":3,"service":{"port":2379},"timeout":30}` | etcd configuration use the FQDN address or the IP of the etcd |
+| etcd.auth | object | `{"rbac":{"create":false,"password":"","user":""},"tls":{"certFilename":"","certKeyFilename":"","enabled":false,"existingSecret":"","sni":"","verify":true}}` | if etcd.enabled is true, set more values of bitnami/etcd helm chart |
+| etcd.auth.rbac.create | bool | `false` | No authentication by default. Switch to enable RBAC authentication |
+| etcd.auth.rbac.password | string | `""` | root password for etcd |
+| etcd.auth.rbac.user | string | `""` | root username for etcd |
+| etcd.auth.tls.certFilename | string | `""` | etcd client cert filename using in etcd.auth.tls.existingSecret |
+| etcd.auth.tls.certKeyFilename | string | `""` | etcd client cert key filename using in etcd.auth.tls.existingSecret |
+| etcd.auth.tls.enabled | bool | `false` | enable etcd client certificate |
+| etcd.auth.tls.existingSecret | string | `""` | name of the secret contains etcd client cert |
+| etcd.auth.tls.sni | string | `""` | specify the TLS Server Name Indication extension, the ETCD endpoint hostname will be used when this setting is unset. |
+| etcd.auth.tls.verify | bool | `true` | whether to verify the etcd endpoint certificate when setup a TLS connection to etcd |
+| etcd.enabled | bool | `true` | install etcd(v3) by default, set false if do not want to install etcd(v3) together |
+| etcd.host | list | `["http://etcd.host:2379"]` | if etcd.enabled is false, use external etcd, support multiple address, if your etcd cluster enables TLS, please use https scheme, e.g. https://127.0.0.1:2379. |
+| etcd.prefix | string | `"/apisix"` | apisix configurations prefix |
+| etcd.timeout | int | `30` | Set the timeout value in seconds for subsequent socket operations from apisix to etcd cluster |
+| extPlugin.cmd | list | `["/path/to/apisix-plugin-runner/runner","run"]` | the command and its arguements to run as a subprocess |
+| extPlugin.enabled | bool | `false` | Enable External Plugins. See [external plugin](https://apisix.apache.org/docs/apisix/next/external-plugin/) |
+| extraInitContainers | list | `[]` | Additional `initContainers`, See [Kubernetes initContainers](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/) for the detail. |
+| extraVolumeMounts | list | `[]` | Additional `volume`, See [Kubernetes Volumes](https://kubernetes.io/docs/concepts/storage/volumes/) for the detail. |
+| extraVolumes | list | `[]` | Additional `volume`, See [Kubernetes Volumes](https://kubernetes.io/docs/concepts/storage/volumes/) for the detail. |
+| fullnameOverride | string | `""` |  |
+| gateway.externalIPs | list | `[]` |  |
+| gateway.externalTrafficPolicy | string | `"Cluster"` |  |
+| gateway.http | object | `{"containerPort":9080,"enabled":true,"servicePort":80}` | Apache APISIX service settings for http |
+| gateway.ingress | object | `{"annotations":{},"enabled":false,"hosts":[{"host":"apisix.local","paths":[]}],"tls":[]}` | Using ingress access Apache APISIX service |
+| gateway.ingress.annotations | object | `{}` | Ingress annotations |
+| gateway.stream | object | `{"enabled":false,"only":false,"tcp":[],"udp":[]}` | Apache APISIX service settings for stream. L4 proxy (TCP/UDP) |
+| gateway.tls | object | `{"certCAFilename":"","containerPort":9443,"enabled":false,"existingCASecret":"","http2":{"enabled":true},"servicePort":443,"sslProtocols":"TLSv1.2 TLSv1.3"}` | Apache APISIX service settings for tls |
+| gateway.tls.certCAFilename | string | `""` | Filename be used in the gateway.tls.existingCASecret |
+| gateway.tls.existingCASecret | string | `""` | Specifies the name of Secret contains trusted CA certificates in the PEM format used to verify the certificate when APISIX needs to do SSL/TLS handshaking with external services (e.g. etcd) |
+| gateway.tls.sslProtocols | string | `"TLSv1.2 TLSv1.3"` | TLS protocols allowed to use. |
+| gateway.type | string | `"NodePort"` | Apache APISIX service type for user access itself |
+| global.imagePullSecrets | list | `[]` | Global Docker registry secret names as an array |
+| ingress-controller.enabled | bool | `false` |  |
+| initContainer.image | string | `"busybox"` | Init container image |
+| initContainer.tag | float | `1.28` | Init container tag |
+| logs.accessLog | string | `"/dev/stdout"` | Access log path |
+| logs.accessLogFormat | string | `"$remote_addr - $remote_user [$time_local] $http_host \\\"$request\\\" $status $body_bytes_sent $request_time \\\"$http_referer\\\" \\\"$http_user_agent\\\" $upstream_addr $upstream_status $upstream_response_time \\\"$upstream_scheme://$upstream_host$upstream_uri\\\""` | Access log format |
+| logs.accessLogFormatEscape | string | `"default"` | Allows setting json or default characters escaping in variables |
+| logs.enableAccessLog | bool | `true` | Enable access log or not, default true |
+| logs.errorLog | string | `"/dev/stderr"` | Error log path |
+| logs.errorLogLevel | string | `"warn"` | Error log level |
+| nameOverride | string | `""` |  |
+| nginx.enableCPUAffinity | bool | `true` |  |
+| nginx.envs | list | `[]` |  |
+| nginx.workerConnections | string | `"10620"` |  |
+| nginx.workerProcesses | string | `"auto"` |  |
+| nginx.workerRlimitNofile | string | `"20480"` |  |
+| pluginAttrs | object | `{}` | Set APISIX plugin attributes, see [config-default.yaml](https://github.com/apache/apisix/blob/master/conf/config-default.yaml#L376) for more details |
+| plugins | list | `["api-breaker","authz-keycloak","basic-auth","batch-requests","consumer-restriction","cors","echo","fault-injection","file-logger","grpc-transcode","hmac-auth","http-logger","ip-restriction","ua-restriction","jwt-auth","kafka-logger","key-auth","limit-conn","limit-count","limit-req","node-status","openid-connect","authz-casbin","prometheus","proxy-cache","proxy-mirror","proxy-rewrite","redirect","referer-restriction","request-id","request-validation","response-rewrite","serverless-post-function","serverless-pre-function","sls-logger","syslog","tcp-logger","udp-logger","uri-blocker","wolf-rbac","zipkin","traffic-split","gzip","real-ip","ext-plugin-pre-req","ext-plugin-post-req"]` | APISIX plugins to be enabled |
+| rbac.create | bool | `false` |  |
+| serviceAccount.annotations | object | `{}` |  |
+| serviceAccount.create | bool | `false` |  |
+| serviceAccount.name | string | `""` |  |
+| serviceMonitor | object | `{"annotations":{},"containerPort":9091,"enabled":false,"interval":"15s","labels":{},"metricPrefix":"apisix_","name":"","namespace":"","path":"/apisix/prometheus/metrics"}` | Observability configuration. ref: https://apisix.apache.org/docs/apisix/plugins/prometheus/ |
+| serviceMonitor.annotations | object | `{}` | @param serviceMonitor.annotations ServiceMonitor annotations |
+| serviceMonitor.containerPort | int | `9091` | container port where the metrics are exposed |
+| serviceMonitor.enabled | bool | `false` | Enable or disable Apache APISIX serviceMonitor |
+| serviceMonitor.interval | string | `"15s"` | interval at which metrics should be scraped |
+| serviceMonitor.labels | object | `{}` | @param serviceMonitor.labels ServiceMonitor extra labels |
+| serviceMonitor.metricPrefix | string | `"apisix_"` | prefix of the metrics |
+| serviceMonitor.name | string | `""` | name of the serviceMonitor, by default, it is the same as the apisix fullname |
+| serviceMonitor.namespace | string | `""` | namespace where the serviceMonitor is deployed, by default, it is the same as the namespace of the apisix |
+| serviceMonitor.path | string | `"/apisix/prometheus/metrics"` | path of the metrics endpoint |
+| stream_plugins[0] | string | `"mqtt-proxy"` |  |
+| stream_plugins[1] | string | `"ip-restriction"` |  |
+| stream_plugins[2] | string | `"limit-conn"` |  |
+| updateStrategy | object | `{}` |  |
+| vault.enabled | bool | `false` | Enable or disable the vault integration |
+| vault.host | string | `""` | The host address where the vault server is running. |
+| vault.prefix | string | `""` | Prefix allows you to better enforcement of policies. |
+| vault.timeout | int | `10` | HTTP timeout for each request. |
+| vault.token | string | `""` | The generated token from vault instance that can grant access to read data from the vault. |
+| wasmPlugins.enabled | bool | `false` | Enable Wasm Plugins. See [wasm plugin](https://apisix.apache.org/docs/apisix/next/wasm/) |
+| wasmPlugins.plugins | list | `[]` |  |

--- a/charts/apisix/README.md.gotmpl
+++ b/charts/apisix/README.md.gotmpl
@@ -1,0 +1,39 @@
+## Apache APISIX for Kubernetes
+
+Apache APISIX is a dynamic, real-time, high-performance API gateway.
+
+APISIX provides rich traffic management features such as load balancing, dynamic upstream, canary release, circuit breaking, authentication, observability, and more.
+
+You can use Apache APISIX to handle traditional north-south traffic, as well as east-west traffic between services. It can also be used as a [k8s ingress controller](https://github.com/apache/apisix-ingress-controller/).
+
+This chart bootstraps all the components needed to run Apache APISIX on a Kubernetes Cluster using [Helm](https://helm.sh).
+
+## Prerequisites
+
+* Kubernetes v1.14+
+* Helm v3+
+
+## Install
+
+To install the chart with the release name `my-apisix`:
+
+```sh
+helm repo add apisix https://charts.apiseven.com
+helm repo update
+
+helm install [RELEASE_NAME] apisix/apisix --namespace ingress-apisix --create-namespace
+```
+
+## Uninstall
+
+ To uninstall/delete a Helm release `my-apisix`:
+
+ ```sh
+helm delete [RELEASE_NAME] --namespace ingress-apisix
+ ```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Parameters
+
+{{ template "chart.valuesSection" . }}

--- a/charts/apisix/values.yaml
+++ b/charts/apisix/values.yaml
@@ -19,67 +19,83 @@ global:
   # imagePullSecrets:
   #   - my-registry-secrets
   #   - other-registry-secrets
-  #
+  # -- Global Docker registry secret names as an array
   imagePullSecrets: []
 
 apisix:
-  # Enable or disable Apache APISIX itself
+  # -- Enable or disable Apache APISIX itself
   # Set it to false and ingress-controller.enabled=true will deploy only ingress-controller
   enabled: true
 
-  # Enable nginx IPv6 resolver
+  # -- Enable nginx IPv6 resolver
   enableIPv6: true
 
-  # Whether the APISIX version number should be shown in Server header
+  # -- Whether the APISIX version number should be shown in Server header
   enableServerTokens: true
 
-  # Use Pod metadata.uid as the APISIX id.
+  # -- Use Pod metadata.uid as the APISIX id.
   setIDFromPodUID: false
 
+  # -- Add custom [lua_shared_dict](https://github.com/openresty/lua-nginx-module#toc88) settings,
+  # click [here](https://github.com/apache/apisix-helm-chart/blob/master/charts/apisix/values.yaml#L27-L30) to learn the format of a shared dict
   customLuaSharedDicts: []
     # - name: foo
     #   size: 10k
     # - name: bar
     #   size: 1m
+  # -- Whether to add a custom lua module
   luaModuleHook:
     enabled: false
-    # extend lua_package_path to load third party code
+    # -- extend lua_package_path to load third party code
     luaPath: ""
-    # the hook module which will be used to inject third party code into APISIX
+    # -- the hook module which will be used to inject third party code into APISIX
     # use the lua require style like: "module.say_hello"
     hookPoint: ""
-    # configmap that stores the codes
+    # -- configmap that stores the codes
     configMapRef:
+      # -- Name of the ConfigMap where the lua module codes store
       name: ""
       # mounts decides how to mount the codes to the container.
       mounts:
+        # -- Name of the ConfigMap key, for setting the mapping relationship between ConfigMap key and the lua module code path.
         - key: ""
+        # -- Filepath of the plugin code, for setting the mapping relationship between ConfigMap key and the lua module code path.
           path: ""
 
-  # Defines how apisix handles routing:
+  # -- Defines how apisix handles routing:
   # - radixtree_uri: match route by uri(base on radixtree)
   # - radixtree_host_uri: match route by host + uri(base on radixtree)
   # - radixtree_uri_with_parameter: match route by uri with parameters
   httpRouter: radixtree_uri
 
+  # -- Enable full customized config.yaml
   enableCustomizedConfig: false
+  # -- If apisix.enableCustomizedConfig is true, full customized config.yaml.
+  # Please note that other settings about APISIX config will be ignored
   customizedConfig: {}
 
   image:
+    # -- Apache APISIX image repository
     repository: apache/apisix
+    # -- Apache APISIX image pull policy
     pullPolicy: IfNotPresent
+    # -- Apache APISIX image tag
     # Overrides the image tag whose default is the chart appVersion.
     tag: 2.15.1-debian
 
-  # Use a `DaemonSet` or `Deployment`
+  # -- Use a `DaemonSet` or `Deployment`
   kind: Deployment
-  # kind is DaemonSet, replicaCount not become effective
+  # -- kind is DaemonSet, replicaCount not become effective
   replicaCount: 1
 
+  # -- Set [priorityClassName](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#pod-priority) for Apache APISIX pods
   priorityClassName: ""
+  # -- Annotations to add to each pod
   podAnnotations: {}
+  # -- Set the securityContext for Apache APISIX pods
   podSecurityContext: {}
     # fsGroup: 2000
+  # -- Set the securityContext for Apache APISIX container
   securityContext: {}
     # capabilities:
     #   drop:
@@ -88,13 +104,21 @@ apisix:
     # runAsNonRoot: true
     # runAsUser: 1000
 
-  # See https://kubernetes.io/docs/tasks/run-application/configure-pdb/ for more details
+  # -- See https://kubernetes.io/docs/tasks/run-application/configure-pdb/ for more details
   podDisruptionBudget:
+    # -- Enable or disable podDisruptionBudget
     enabled: false
+    # -- Set the `minAvailable` of podDisruptionBudget. You can specify only one of `maxUnavailable` and `minAvailable` in a single PodDisruptionBudget. 
+    # See [Specifying a Disruption Budget for your Application](https://kubernetes.io/docs/tasks/run-application/configure-pdb/#specifying-a-poddisruptionbudget) 
+    # for more details
     minAvailable: 90%
+    # -- Set the maxUnavailable of podDisruptionBudget
     maxUnavailable: 1
 
+  # -- Set pod resource requests & limits
   resources: {}
+    # -- Use the host's network namespace
+
     # We usually recommend not to specify default resources and to leave this as a conscious
     # choice for the user. This also increases chances charts run on environments with little
     # resources, such as Minikube. If you do want to specify resources, uncomment the following
@@ -107,18 +131,21 @@ apisix:
     #   memory: 128Mi
   hostNetwork: false
 
+  # -- Node labels for Apache APISIX pod assignment
   nodeSelector: {}
+  # -- List of node taints to tolerate
   tolerations: []
+  # -- Set affinity for Apache APISIX deploy
   affinity: {}
 
-  # timezone is the timezone where apisix uses.
+  # -- timezone is the timezone where apisix uses.
   # For example: "UTC" or "Asia/Shanghai"
   # This value will be set on apisix container's environment variable TZ.
   # You may need to set the timezone to be consistent with your local time zone,
   # otherwise the apisix's logs may used to retrieve event maybe in wrong timezone.
   timezone: ""
 
-  # extraEnvVars An array to add extra env vars
+  # -- extraEnvVars An array to add extra env vars
   # e.g:
   # extraEnvVars:
   #   - name: FOO
@@ -142,35 +169,45 @@ rbac:
   create: false
 
 gateway:
+  # -- Apache APISIX service type for user access itself
   type: NodePort
+  # -- Setting how the Service route external traffic
   # If you want to keep the client source IP, you can set this to Local.
+
   # ref: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
   externalTrafficPolicy: Cluster
   # type: LoadBalancer
   # annotations:
   #   service.beta.kubernetes.io/aws-load-balancer-type: nlb
   externalIPs: []
+  # -- Apache APISIX service settings for http
   http:
     enabled: true
     servicePort: 80
     containerPort: 9080
+  # -- Apache APISIX service settings for tls
   tls:
     enabled: false
     servicePort: 443
     containerPort: 9443
+    # -- Specifies the name of Secret contains trusted CA certificates in the PEM format used to verify the certificate when APISIX needs to do SSL/TLS handshaking with external services (e.g. etcd)
     existingCASecret: ""
+    # -- Filename be used in the gateway.tls.existingCASecret
     certCAFilename: ""
     http2:
       enabled: true
+    # -- TLS protocols allowed to use.
     sslProtocols: "TLSv1.2 TLSv1.3"
-  # L4 proxy (TCP/UDP)
+  # -- Apache APISIX service settings for stream. L4 proxy (TCP/UDP)
   stream:
     enabled: false
     only: false
     tcp: []
     udp: []
+  # -- Using ingress access Apache APISIX service
   ingress:
     enabled: false
+    # -- Ingress annotations
     annotations: {}
       # kubernetes.io/ingress.class: nginx
       # kubernetes.io/tls-acme: "true"
@@ -183,26 +220,30 @@ gateway:
   #      - chart-example.local
 
 admin:
-  # Enable Admin API
+  # -- Enable Admin API
   enabled: true
-  # admin service type
+  # -- admin service type
   type: ClusterIP
   # loadBalancerIP: a.b.c.d
   # loadBalancerSourceRanges:
   #   - "143.231.0.0/16"
+  # -- IPs for which nodes in the cluster will also accept traffic for the servic
   externalIPs: []
-  #
+  # -- which port to use for Apache APISIX admin API
   port: 9180
+  # -- Service port to use for Apache APISIX admin API
   servicePort: 9180
-  # Admin API support CORS response headers
+  # -- Admin API support CORS response headers
   cors: true
-  # Admin API credentials
+  # -- Admin API credentials
   credentials:
+    # -- Apache APISIX admin API admin role credentials
     admin: edd1c9f034335f136f87ad84b625c8f1
+    # -- Apache APISIX admin API viewer role credentials
     viewer: 4054f7cf07e344346cd3f287985e76a2
 
   allow:
-    # The client IP CIDR allowed to access Apache APISIX Admin API service.
+    # -- The client IP CIDR allowed to access Apache APISIX Admin API service.
     ipList:
       - 127.0.0.1/24
 
@@ -213,7 +254,7 @@ nginx:
   enableCPUAffinity: true
   envs: []
 
-# APISIX plugins to be enabled
+# -- APISIX plugins to be enabled
 plugins:
   - api-breaker
   - authz-keycloak
@@ -266,32 +307,37 @@ stream_plugins:
   - ip-restriction
   - limit-conn
 
+# -- Set APISIX plugin attributes, see [config-default.yaml](https://github.com/apache/apisix/blob/master/conf/config-default.yaml#L376) for more details
 pluginAttrs: {}
 
 extPlugin:
+  # -- Enable External Plugins. See [external plugin](https://apisix.apache.org/docs/apisix/next/external-plugin/)
   enabled: false
+  # -- the command and its arguements to run as a subprocess
   cmd: ["/path/to/apisix-plugin-runner/runner", "run"]
 
 wasmPlugins:
+  # -- Enable Wasm Plugins. See [wasm plugin](https://apisix.apache.org/docs/apisix/next/wasm/)
   enabled: false
   plugins: []
 
-# customPlugins allows you to mount your own HTTP plugins.
+# -- customPlugins allows you to mount your own HTTP plugins.
 customPlugins:
+  # -- Whether to configure some custom plugins
   enabled: false
-  # the lua_path that tells APISIX where it can find plugins,
+  # -- the lua_path that tells APISIX where it can find plugins,
   # note the last ';' is required.
   luaPath: "/opts/custom_plugins/?.lua"
   plugins:
-    # plugin name.
+    # -- plugin name.
     - name: ""
-      # plugin attrs
+      # -- plugin attrs
       attrs: {}
-      # plugin codes can be saved inside configmap object.
+      # -- plugin codes can be saved inside configmap object.
       configMap:
-        # name of configmap.
+        # -- name of configmap.
         name: ""
-        # since keys in configmap is flat, mountPath allows to define the mount
+        # -- since keys in configmap is flat, mountPath allows to define the mount
         # path, so that plugin codes can be mounted hierarchically.
         mounts:
           - key: ""
@@ -302,22 +348,28 @@ customPlugins:
 updateStrategy: {}
   # type: RollingUpdate
 
+# -- Additional `volume`, See [Kubernetes Volumes](https://kubernetes.io/docs/concepts/storage/volumes/) for the detail.
 extraVolumes: []
 # - name: extras
 #   emptyDir: {}
 
+# -- Additional `volume`, See [Kubernetes Volumes](https://kubernetes.io/docs/concepts/storage/volumes/) for the detail.
 extraVolumeMounts: []
 # - name: extras
 #   mountPath: /usr/share/extras
 #   readOnly: true
 
+# -- Additional `initContainers`, See [Kubernetes initContainers](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/) for the detail.
 extraInitContainers: []
 # - name: init-myservice
 #   image: busybox:1.28
 #   command: ['sh', '-c', "until nslookup myservice.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for myservice; sleep 2; done"]
 
 discovery:
+  # -- Enable or disable Apache APISIX integration service discovery
   enabled: false
+  # -- Registry is the same to the one in APISIX [config-default.yaml](https://github.com/apache/apisix/blob/master/conf/config-default.yaml#L281),
+  # and refer to such file for more setting details. also refer to [this documentation for integration service discovery](https://apisix.apache.org/docs/apisix/discovery)
   registry: {}
     # Integration service discovery registry. E.g eureka\dns\nacos\consul_kv
     # reference:
@@ -360,11 +412,17 @@ discovery:
 
 # access log and error log configuration
 logs:
+  # -- Enable access log or not, default true
   enableAccessLog: true
+  # -- Access log path
   accessLog: "/dev/stdout"
+  # -- Access log format
   accessLogFormat: '$remote_addr - $remote_user [$time_local] $http_host \"$request\" $status $body_bytes_sent $request_time \"$http_referer\" \"$http_user_agent\" $upstream_addr $upstream_status $upstream_response_time \"$upstream_scheme://$upstream_host$upstream_uri\"'
+  # -- Allows setting json or default characters escaping in variables
   accessLogFormatEscape: default
+  # -- Error log path
   errorLog: "/dev/stderr"
+  # -- Error log level
   errorLogLevel: "warn"
 
 dns:
@@ -379,7 +437,9 @@ dns:
   timeout: 5
 
 initContainer:
+  # -- Init container image
   image: busybox
+  # -- Init container tag
   tag: 1.28
 
 autoscaling:
@@ -389,7 +449,7 @@ autoscaling:
   targetCPUUtilizationPercentage: 80
   targetMemoryUtilizationPercentage: 80
 
-# Custom configuration snippet.
+# -- Custom configuration snippet.
 configurationSnippet:
   main: |
 
@@ -403,51 +463,63 @@ configurationSnippet:
 
   stream: |
 
-# Observability configuration.
+# -- Observability configuration.
 # ref: https://apisix.apache.org/docs/apisix/plugins/prometheus/
 serviceMonitor:
+  # -- Enable or disable Apache APISIX serviceMonitor
   enabled: false
-  # namespace where the serviceMonitor is deployed, by default, it is the same as the namespace of the apisix
+  # -- namespace where the serviceMonitor is deployed, by default, it is the same as the namespace of the apisix
   namespace: ""
-  # name of the serviceMonitor, by default, it is the same as the apisix fullname
+  # -- name of the serviceMonitor, by default, it is the same as the apisix fullname
   name: ""
-  # interval at which metrics should be scraped
+  # -- interval at which metrics should be scraped
   interval: 15s
-  # path of the metrics endpoint
+  # -- path of the metrics endpoint
   path: /apisix/prometheus/metrics
-  # prefix of the metrics
+  # -- prefix of the metrics
   metricPrefix: apisix_
-  # container port where the metrics are exposed
+  # -- container port where the metrics are exposed
   containerPort: 9091
-  # @param serviceMonitor.labels ServiceMonitor extra labels
+  # -- @param serviceMonitor.labels ServiceMonitor extra labels
   labels: {}
-  # @param serviceMonitor.annotations ServiceMonitor annotations
+  # -- @param serviceMonitor.annotations ServiceMonitor annotations
   annotations: {}
 
-# etcd configuration
+# -- etcd configuration
 # use the FQDN address or the IP of the etcd
 etcd:
-  # install etcd(v3) by default, set false if do not want to install etcd(v3) together
+  # -- install etcd(v3) by default, set false if do not want to install etcd(v3) together
   enabled: true
+  # -- if etcd.enabled is false, use external etcd, support multiple address, if your etcd cluster enables TLS, please use https scheme, e.g. https://127.0.0.1:2379.
   host:
     # host or ip e.g. http://172.20.128.89:2379
     - http://etcd.host:2379
+  # -- apisix configurations prefix
   prefix: "/apisix"
+  # -- Set the timeout value in seconds for subsequent socket operations from apisix to etcd cluster
   timeout: 30
 
-  # if etcd.enabled is true, set more values of bitnami/etcd helm chart
+  # -- if etcd.enabled is true, set more values of bitnami/etcd helm chart
   auth:
     rbac:
-      # No authentication by default
+      # -- No authentication by default. Switch to enable RBAC authentication
       create: false
+      # -- root username for etcd
       user: ""
+      # -- root password for etcd
       password: ""
     tls:
+      # -- enable etcd client certificate
       enabled: false
+      # -- name of the secret contains etcd client cert
       existingSecret: ""
+      # -- etcd client cert filename using in etcd.auth.tls.existingSecret
       certFilename: ""
+      # -- etcd client cert key filename using in etcd.auth.tls.existingSecret
       certKeyFilename: ""
+      # -- whether to verify the etcd endpoint certificate when setup a TLS connection to etcd
       verify: true
+      # -- specify the TLS Server Name Indication extension, the ETCD endpoint hostname will be used when this setting is unset.
       sni: ""
 
   service:
@@ -462,8 +534,13 @@ ingress-controller:
   enabled: false
 
 vault:
+  # -- Enable or disable the vault integration
   enabled: false
+  # -- The host address where the vault server is running.
   host: ""
+  # -- HTTP timeout for each request.
   timeout: 10
+  # -- The generated token from vault instance that can grant access to read data from the vault.
   token: ""
+  # -- Prefix allows you to better enforcement of policies.
   prefix: ""


### PR DESCRIPTION
Here's a brief description of what I did:

- prefixed the comments in the `values.yaml` file with `--` so that it could be used by the `helm-docs` tool for the description of fields to generate `README.md`.
- added some more comments as description to some yaml fields.
- added `.md.gotmpl` files which will be used to generate the `README.md` files.
- added github action step for checking if helm-docs was run by the user after making changes to the helm chart. This is to ensure that the README.md files are up to date.
- finally, I used the helm-docs tool to regenerate the README.md file.

Closes #334 