### PR TITLE
Trust & safety : change helm repository from apiseven to apache.github.io

### DIFF
--- a/charts/apisix-dashboard/README.md
+++ b/charts/apisix-dashboard/README.md
@@ -11,7 +11,7 @@ APISIX Dashboard requires Kubernetes version 1.14+.
 ## Get Repo Info
 
 ```console
-helm repo add apisix https://charts.apiseven.com
+helm repo add apisix https://apache.github.io/apisix-helm-chart
 helm repo update
 ```
 

--- a/charts/apisix-dashboard/README.md.gotmpl
+++ b/charts/apisix-dashboard/README.md.gotmpl
@@ -11,7 +11,7 @@ APISIX Dashboard requires Kubernetes version 1.14+.
 ## Get Repo Info
 
 ```console
-helm repo add apisix https://charts.apiseven.com
+helm repo add apisix https://apache.github.io/apisix-helm-chart
 helm repo update
 ```
 

--- a/charts/apisix-ingress-controller/README.md
+++ b/charts/apisix-ingress-controller/README.md
@@ -13,7 +13,7 @@ Apisix ingress controller requires Kubernetes version 1.16+.
 ## Get Repo Info
 
 ```console
-helm repo add apisix https://charts.apiseven.com
+helm repo add apisix https://apache.github.io/apisix-helm-chart
 helm repo update
 ```
 

--- a/charts/apisix-ingress-controller/README.md.gotmpl
+++ b/charts/apisix-ingress-controller/README.md.gotmpl
@@ -13,7 +13,7 @@ Apisix ingress controller requires Kubernetes version 1.16+.
 ## Get Repo Info
 
 ```console
-helm repo add apisix https://charts.apiseven.com
+helm repo add apisix https://apache.github.io/apisix-helm-chart
 helm repo update
 ```
 

--- a/charts/apisix/Chart.lock
+++ b/charts/apisix/Chart.lock
@@ -3,10 +3,10 @@ dependencies:
   repository: https://charts.bitnami.com/bitnami
   version: 8.3.4
 - name: apisix-dashboard
-  repository: https://charts.apiseven.com
+  repository: https://apache.github.io/apisix-helm-chart
   version: 0.6.1
 - name: apisix-ingress-controller
-  repository: https://charts.apiseven.com
+  repository: https://apache.github.io/apisix-helm-chart
   version: 0.10.2
 digest: sha256:9cc89957cb8d6f69c53f084cfc1051bfa19e03271ba59afbffe46ed18def2af0
 generated: "2022-12-10T12:48:34.418741+08:00"

--- a/charts/apisix/Chart.yaml
+++ b/charts/apisix/Chart.yaml
@@ -47,12 +47,12 @@ dependencies:
     condition: etcd.enabled
   - name: apisix-dashboard
     version: 0.6.1
-    repository: https://charts.apiseven.com
+    repository: https://apache.github.io/apisix-helm-chart
     condition: dashboard.enabled
     alias: dashboard
   - name: apisix-ingress-controller
     version: 0.10.2
-    repository: https://charts.apiseven.com
+    repository: https://apache.github.io/apisix-helm-chart
     condition: ingress-controller.enabled
     alias: ingress-controller
 

--- a/charts/apisix/README.md
+++ b/charts/apisix/README.md
@@ -18,7 +18,7 @@ This chart bootstraps all the components needed to run Apache APISIX on a Kubern
 To install the chart with the release name `my-apisix`:
 
 ```sh
-helm repo add apisix https://charts.apiseven.com
+helm repo add apisix https://apache.github.io/apisix-helm-chart
 helm repo update
 
 helm install [RELEASE_NAME] apisix/apisix --namespace ingress-apisix --create-namespace

--- a/charts/apisix/README.md.gotmpl
+++ b/charts/apisix/README.md.gotmpl
@@ -18,7 +18,7 @@ This chart bootstraps all the components needed to run Apache APISIX on a Kubern
 To install the chart with the release name `my-apisix`:
 
 ```sh
-helm repo add apisix https://charts.apiseven.com
+helm repo add apisix https://apache.github.io/apisix-helm-chart
 helm repo update
 
 helm install [RELEASE_NAME] apisix/apisix --namespace ingress-apisix --create-namespace


### PR DESCRIPTION
charts.apiseven.com is redirecting to apache.github.io. To limit supply chain attack risk, I think it's better to avoid this unnecessary redirection.