### PR TITLE
fix: fix format of configmap for apisix-ingress-controller

### DIFF
--- a/charts/apisix-ingress-controller/templates/configmap.yaml
+++ b/charts/apisix-ingress-controller/templates/configmap.yaml
@@ -16,7 +16,7 @@
 #
 apiVersion: v1
 data:
-  config.yaml: |
+  config.yaml: |-
     # log options
     log_level: {{ .Values.config.logLevel | quote }}
     log_output: {{ .Values.config.logOutput | quote }}
@@ -24,7 +24,7 @@ data:
     key_file: {{ .Values.config.keyFile | quote }}
     http_listen: {{ .Values.config.httpListen | quote }}
     https_listen: {{ .Values.config.httpsListen | quote }}
-    ingress_publish_service: {{ .Values.config.ingressPublishService }}
+    ingress_publish_service: {{ .Values.config.ingressPublishService | quote }}
     {{- if gt (len .Values.config.ingressStatusAddress) 0 }}
     ingress_status_address:
     {{- range .Values.config.ingressStatusAddress }}
@@ -53,11 +53,11 @@ data:
       plugin_metadata_cm: {{ .Values.config.kubernetes.pluginMetadataCM | quote }}
     apisix:
       admin_api_version: {{ .Values.config.apisix.adminAPIVersion | quote }}
-      {{ if .Values.config.apisix.serviceFullname }}
+      {{- if .Values.config.apisix.serviceFullname }}
       default_cluster_base_url: http://{{ .Values.config.apisix.serviceFullname }}:{{ .Values.config.apisix.servicePort }}/apisix/admin
       {{ else }}
       default_cluster_base_url: http://{{ .Values.config.apisix.serviceName }}.{{ .Values.config.apisix.serviceNamespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.config.apisix.servicePort }}/apisix/admin
-      {{ end}}
+      {{- end}}
       default_cluster_admin_key: {{ .Values.config.apisix.adminKey | quote }}
       default_cluster_name: {{ .Values.config.apisix.clusterName | quote }}
 kind: ConfigMap


### PR DESCRIPTION
 fix format of configmap for apisix-ingress-controller: https://github.com/apache/apisix-helm-chart/issues/428


before fixed:

```
apiVersion: v1
data:
  config.yaml: "# log options\nlog_level: \"info\"\nlog_output: \"stderr\"\ncert_file:
    \"/etc/webhook/certs/cert.pem\"\nkey_file: \"/etc/webhook/certs/key.pem\"\nhttp_listen:
    \":8080\"\nhttps_listen: \":8443\"\ningress_publish_service: \nenable_profiling:
    true\napisix-resource-sync-interval: 300s\nkubernetes:\n  kubeconfig: \"\"\n  resync_interval:
    \"6h\"\n  namespace_selector:\n  - \"\"\n  election_id: \"ingress-apisix-leader\"\n
    \ ingress_class: \"apisix\"\n  ingress_version: \"networking/v1\"\n  watch_endpointslices:
    false\n  apisix_route_version: \"apisix.apache.org/v2\"\n  enable_gateway_api:
    false\n  apisix_version: \"apisix.apache.org/v2\"\n  plugin_metadata_cm: \"\"\napisix:\n
    \ admin_api_version: \"v2\"\n  \n  default_cluster_base_url: http://apisix-admin.ingress-apisix.svc.cluster.local:9180/apisix/admin\n
    \ \n  default_cluster_admin_key: \"edd1c9f034335f136f87ad84b625c8f1\"\n  default_cluster_name:
    \"default\"\n"
kind: ConfigMap
metadata:
```

after fixed :

```
apiVersion: v1
data:
  config.yaml: |-
    # log options
    log_level: "info"
    log_output: "stderr"
    cert_file: "/etc/webhook/certs/cert.pem"
    key_file: "/etc/webhook/certs/key.pem"
    http_listen: ":8080"
    https_listen: ":8443"
    ingress_publish_service: ""
    enable_profiling: true
    apisix-resource-sync-interval: 300s
```