### PR TITLE
fix: apisix access log is corrupted when accessLogFormatEscape is set to json

### DIFF
--- a/charts/apisix/templates/configmap.yaml
+++ b/charts/apisix/templates/configmap.yaml
@@ -152,7 +152,7 @@ data:
         enable_access_log: {{ .Values.logs.enableAccessLog }}
         {{- if .Values.logs.enableAccessLog }}
         access_log: "{{ .Values.logs.accessLog }}"
-        access_log_format: "{{ .Values.logs.accessLogFormat }}"
+        access_log_format: '{{ .Values.logs.accessLogFormat }}'
         access_log_format_escape: {{ .Values.logs.accessLogFormatEscape }}
         {{- end }}
         keepalive_timeout: 60s         # timeout during which a keep-alive client connection will stay open on the server side.


### PR DESCRIPTION
Fix broken access logs when log format is set to json, as per issue https://github.com/apache/apisix-helm-chart/issues/452