### PR TITLE
chore: set `apisix-resourcce-sync-interval` defaults to 1h

### DIFF
--- a/charts/apisix-ingress-controller/README.md
+++ b/charts/apisix-ingress-controller/README.md
@@ -113,7 +113,7 @@ The same for container level, you need to set:
 | config.apisix | object | `{"adminAPIVersion":"v2","adminKey":"edd1c9f034335f136f87ad84b625c8f1","clusterName":"default","serviceName":"apisix-admin","serviceNamespace":"ingress-apisix","servicePort":9180}` | APISIX related configurations. |
 | config.apisix.adminAPIVersion | string | `"v2"` | the APISIX admin API version. can be "v2" or "v3", default is "v2". |
 | config.apisix.serviceName | string | `"apisix-admin"` | Enabling this value, overrides serviceName and serviceNamespace. serviceFullname: "apisix-admin.apisix.svc.local" |
-| config.apisixResourceSyncInterval | string | `"300s"` | Default interval for synchronizing Kubernetes resources to APISIX |
+| config.apisixResourceSyncInterval | string | `"1h"` | Default interval for synchronizing Kubernetes resources to APISIX |
 | config.certFile | string | `"/etc/webhook/certs/cert.pem"` | the TLS certificate file path. |
 | config.enableProfiling | bool | `true` | enable profiling via web interfaces host:port/debug/pprof, default is true. |
 | config.httpListen | string | `":8080"` | the HTTP Server listen address, default is ":8080" |

--- a/charts/apisix-ingress-controller/values.yaml
+++ b/charts/apisix-ingress-controller/values.yaml
@@ -86,7 +86,7 @@ config:
   # -- enable profiling via web interfaces host:port/debug/pprof, default is true.
   enableProfiling: true
   # -- Default interval for synchronizing Kubernetes resources to APISIX
-  apisixResourceSyncInterval: "300s"
+  apisixResourceSyncInterval: "1h"
   # -- Kubernetes related configurations.
   kubernetes:
     # -- the Kubernetes configuration file path, default is "", so the in-cluster


### PR DESCRIPTION
Related to apache/apisix-ingress-controller#1646 and apache/apisix-ingress-controller/pull/1685