### PR TITLE
bugfix: 0.0.0.0/0 is always set for allow_admin

### DIFF
--- a/charts/apisix/templates/configmap.yaml
+++ b/charts/apisix/templates/configmap.yaml
@@ -281,9 +281,6 @@ data:
         {{- else }}
           - 0.0.0.0/0
         {{- end}}
-        {{- if or (index .Values "ingress-controller" "enabled") .Values.dashboard.enabled  }}
-          - 0.0.0.0/0
-        {{- end}}
         #   - "::/64"
         {{- if .Values.admin.enabled }}
         admin_listen:


### PR DESCRIPTION
0.0.0.0/0 is always set for allow_admin. If this is intentional, I suggest this PR is dismissed, but that the documentation is updated registering that fact as it is misleading in its current form