### PR TITLE
feat: adding IPv6 Single Stack support

### DIFF
--- a/charts/apisix/README.md
+++ b/charts/apisix/README.md
@@ -49,6 +49,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | admin.externalIPs | list | `[]` | IPs for which nodes in the cluster will also accept traffic for the servic |
 | admin.ingress | object | `{"annotations":{},"enabled":false,"hosts":[{"host":"apisix-admin.local","paths":["/apisix"]}],"tls":[]}` | Using ingress access Apache APISIX admin service |
 | admin.ingress.annotations | object | `{}` | Ingress annotations |
+| admin.ip | string | `0.0.0.0` | which ip to listen on for Apache APISIX admin API. Set to `"[::]"` when on IPv6 single stack |
 | admin.port | int | `9180` | which port to use for Apache APISIX admin API |
 | admin.servicePort | int | `9180` | Service port to use for Apache APISIX admin API |
 | admin.type | string | `"ClusterIP"` | admin service type |

--- a/charts/apisix/README.md
+++ b/charts/apisix/README.md
@@ -49,7 +49,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | admin.externalIPs | list | `[]` | IPs for which nodes in the cluster will also accept traffic for the servic |
 | admin.ingress | object | `{"annotations":{},"enabled":false,"hosts":[{"host":"apisix-admin.local","paths":["/apisix"]}],"tls":[]}` | Using ingress access Apache APISIX admin service |
 | admin.ingress.annotations | object | `{}` | Ingress annotations |
-| admin.ip | string | `0.0.0.0` | which ip to listen on for Apache APISIX admin API. Set to `"[::]"` when on IPv6 single stack |
+| admin.ip | string | `"0.0.0.0"` | which ip to listen on for Apache APISIX admin API. Set to `"[::]"` when on IPv6 single stack |
 | admin.port | int | `9180` | which port to use for Apache APISIX admin API |
 | admin.servicePort | int | `9180` | Service port to use for Apache APISIX admin API |
 | admin.type | string | `"ClusterIP"` | admin service type |

--- a/charts/apisix/templates/configmap.yaml
+++ b/charts/apisix/templates/configmap.yaml
@@ -287,7 +287,7 @@ data:
         #   - "::/64"
         {{- if .Values.admin.enabled }}
         admin_listen:
-          ip: 0.0.0.0
+          ip: {{ .Values.admin.ip }}
           port: {{ .Values.admin.port }}
         {{- end }}
         # Default token when use API to call for Admin API.

--- a/charts/apisix/values.yaml
+++ b/charts/apisix/values.yaml
@@ -281,7 +281,7 @@ admin:
   #   - "143.231.0.0/16"
   # -- IPs for which nodes in the cluster will also accept traffic for the servic
   externalIPs: []
-  # -- which ip to listen on for Apache APISIX admin API
+  # -- which ip to listen on for Apache APISIX admin API. Set to `"[::]"` when on IPv6 single stack
   ip: 0.0.0.0
   # -- which port to use for Apache APISIX admin API
   port: 9180

--- a/charts/apisix/values.yaml
+++ b/charts/apisix/values.yaml
@@ -281,6 +281,8 @@ admin:
   #   - "143.231.0.0/16"
   # -- IPs for which nodes in the cluster will also accept traffic for the servic
   externalIPs: []
+  # -- which ip to listen on for Apache APISIX admin API
+  ip: 0.0.0.0
   # -- which port to use for Apache APISIX admin API
   port: 9180
   # -- Service port to use for Apache APISIX admin API


### PR DESCRIPTION
Currently the Helm chart doesn't works on IPv6 single stack as the apisix-ingress-controller will wait until apisix-admin is serving. However, currently it is not possible to set the apisix-admin listen address given 0.0.0.0 is hardcoded and in that way it will never work properly on IPv6 single stack deployments. 

This PR adds the possiblity to set the apisix-admin IP listen address to any value. It should be set to `[::]` when on IPv6 single stack deployments.