### PR TITLE
feat(dashboard): Allow dashboards to use external etcd with mtls

### DIFF
--- a/charts/apisix-dashboard/README.md
+++ b/charts/apisix-dashboard/README.md
@@ -63,8 +63,8 @@ _See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command documen
 | config.authentication.secret | string | `"secret"` | Secret for jwt token generation |
 | config.authentication.users | list | `[{"password":"admin","username":"admin"}]` | Specifies username and password for login manager api. |
 | config.conf.etcd.endpoints | list | `["apisix-etcd:2379"]` | Supports defining multiple etcd host addresses for an etcd cluster |
-| config.conf.etcd.existingSecret | string | `""` | Specifies a secret to be mounted on /etc/etcd for mtls usage |
 | config.conf.etcd.mtls | object | `{}` |  |
+| config.conf.etcd.mtlsExistingSecret | string | `""` | Specifies a secret to be mounted on /etc/etcd for mtls usage |
 | config.conf.etcd.password | string | `nil` | Specifies etcd basic auth password if enable etcd auth |
 | config.conf.etcd.prefix | string | `"/apisix"` | apisix configurations prefix |
 | config.conf.etcd.username | string | `nil` | Specifies etcd basic auth username if enable etcd auth |

--- a/charts/apisix-dashboard/README.md
+++ b/charts/apisix-dashboard/README.md
@@ -63,6 +63,8 @@ _See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command documen
 | config.authentication.secret | string | `"secret"` | Secret for jwt token generation |
 | config.authentication.users | list | `[{"password":"admin","username":"admin"}]` | Specifies username and password for login manager api. |
 | config.conf.etcd.endpoints | list | `["apisix-etcd:2379"]` | Supports defining multiple etcd host addresses for an etcd cluster |
+| config.conf.etcd.existingSecret | string | `""` | Specifies a secret to be mounted on /etc/etcd for mtls usage |
+| config.conf.etcd.mtls | object | `{}` |  |
 | config.conf.etcd.password | string | `nil` | Specifies etcd basic auth password if enable etcd auth |
 | config.conf.etcd.prefix | string | `"/apisix"` | apisix configurations prefix |
 | config.conf.etcd.username | string | `nil` | Specifies etcd basic auth username if enable etcd auth |
@@ -71,8 +73,6 @@ _See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command documen
 | config.conf.log.accessLog.filePath | string | `"/dev/stdout"` | Error log path |
 | config.conf.log.errorLog | object | `{"filePath":"/dev/stderr","level":"warn"}` | Error log level. Supports levels, lower to higher: debug, info, warn, error, panic, fatal |
 | config.conf.log.errorLog.filePath | string | `"/dev/stderr"` | Access log path |
-| config.conf.etcd.mtls | object | `{"key_file": "/etc/etcd/server-client.key", "cert_file": "/etc/etcd/server-client.crt", "ca_file": "/etc/etcd/server-ca.crt"}` | Pass a mtls config directly to the dashboard. |
-| config.conf.etcd.existingSecret | string | `"my-secret"` | Mount a secret under /etc/etcd for mtls usage. |
 | fullnameOverride | string | `""` | String to fully override apisix-dashboard.fullname template |
 | image.pullPolicy | string | `"IfNotPresent"` | Apache APISIX Dashboard image pull policy |
 | image.repository | string | `"apache/apisix-dashboard"` | Apache APISIX Dashboard image repository |

--- a/charts/apisix-dashboard/README.md
+++ b/charts/apisix-dashboard/README.md
@@ -71,6 +71,8 @@ _See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command documen
 | config.conf.log.accessLog.filePath | string | `"/dev/stdout"` | Error log path |
 | config.conf.log.errorLog | object | `{"filePath":"/dev/stderr","level":"warn"}` | Error log level. Supports levels, lower to higher: debug, info, warn, error, panic, fatal |
 | config.conf.log.errorLog.filePath | string | `"/dev/stderr"` | Access log path |
+| config.conf.etcd.mtls | object | `{"key_file": "/etc/etcd/server-client.key", "cert_file": "/etc/etcd/server-client.crt", "ca_file": "/etc/etcd/server-ca.crt"}` | Pass a mtls config directly to the dashboard. |
+| config.conf.etcd.existingSecret | string | `"my-secret"` | Mount a secret under /etc/etcd for mtls usage. |
 | fullnameOverride | string | `""` | String to fully override apisix-dashboard.fullname template |
 | image.pullPolicy | string | `"IfNotPresent"` | Apache APISIX Dashboard image pull policy |
 | image.repository | string | `"apache/apisix-dashboard"` | Apache APISIX Dashboard image repository |

--- a/charts/apisix-dashboard/templates/configmap.yaml
+++ b/charts/apisix-dashboard/templates/configmap.yaml
@@ -41,6 +41,10 @@ data:
         {{- if .password }}
         password: {{ .password }}
         {{- end }}
+        {{- if .mtls }}
+        mtls:
+          {{- toYaml .mtls | nindent 10 }}
+        {{- end }}
       {{- end }}
       {{- with .log }}
       log:

--- a/charts/apisix-dashboard/templates/deployment.yaml
+++ b/charts/apisix-dashboard/templates/deployment.yaml
@@ -74,10 +74,19 @@ spec:
             - mountPath: /usr/local/apisix-dashboard/conf/conf.yaml
               name: apisix-dashboard-config
               subPath: conf.yaml
+          {{- if .Values.config.conf.etcd.existingSecret }}
+            - mountPath: /etc/etcd
+              name: etcd-config
+          {{- end}}
       volumes:
         - configMap:
             name: {{ include "apisix-dashboard.fullname" . }}
           name: apisix-dashboard-config
+      {{- if .Values.config.conf.etcd.existingSecret }}
+        - secret:
+            secretName: {{ .Values.config.conf.etcd.existingSecret }}
+          name: etcd-config
+      {{- end}}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/apisix-dashboard/templates/deployment.yaml
+++ b/charts/apisix-dashboard/templates/deployment.yaml
@@ -74,7 +74,7 @@ spec:
             - mountPath: /usr/local/apisix-dashboard/conf/conf.yaml
               name: apisix-dashboard-config
               subPath: conf.yaml
-          {{- if .Values.config.conf.etcd.existingSecret }}
+          {{- if .Values.config.conf.etcd.mtlsExistingSecret }}
             - mountPath: /etc/etcd
               name: etcd-config
           {{- end}}
@@ -82,9 +82,9 @@ spec:
         - configMap:
             name: {{ include "apisix-dashboard.fullname" . }}
           name: apisix-dashboard-config
-      {{- if .Values.config.conf.etcd.existingSecret }}
+      {{- if .Values.config.conf.etcd.mtlsExistingSecret }}
         - secret:
-            secretName: {{ .Values.config.conf.etcd.existingSecret }}
+            secretName: {{ .Values.config.conf.etcd.mtlsExistingSecret }}
           name: etcd-config
       {{- end}}
       {{- with .Values.nodeSelector }}

--- a/charts/apisix-dashboard/values.yaml
+++ b/charts/apisix-dashboard/values.yaml
@@ -91,7 +91,7 @@ config:
       password: ~
 
       # -- Specifies a secret to be mounted on /etc/etcd for mtls usage
-      existingSecret: ""
+      mtlsExistingSecret: ""
 
       # MTLS configuration used for external etcd instances
       mtls:

--- a/charts/apisix-dashboard/values.yaml
+++ b/charts/apisix-dashboard/values.yaml
@@ -89,6 +89,16 @@ config:
       username: ~
       # -- Specifies etcd basic auth password if enable etcd auth
       password: ~
+
+      # -- Specifies a secret to be mounted on /etc/etcd for mtls usage
+      existingSecret: ""
+
+      # MTLS configuration used for external etcd instances
+      mtls:
+        {}
+        # key_file: /etc/etcd/server-client.key
+        # cert_file: /etc/etcd/server-client.crt
+        # ca_file: /etc/etcd/server-ca.crt
     log:
       # -- Error log level.
       # Supports levels, lower to higher: debug, info, warn, error, panic, fatal


### PR DESCRIPTION
Example values would be:

```yaml
config:
  conf:
    etcd:
      endpoints:
        - https://my-cname.domain.com:2379
      mtls:
        key_file: /etc/etcd/server-client.key
        cert_file: /etc/etcd/server-client.crt
        ca_file: /etc/etcd/server-ca.crt
      existingSecret: cluster-etcd-credentials
```