### PR TITLE
PDB updated to Kubernetes 1.25

### DIFF
--- a/charts/apisix/templates/pdb.yaml
+++ b/charts/apisix/templates/pdb.yaml
@@ -15,7 +15,11 @@
 # limitations under the License.
 
 {{- if (and .Values.apisix.enabled .Values.apisix.podDisruptionBudget.enabled) }}
+{{ if semverCompare "<1.21-0" .Capabilities.KubeVersion.Version -}}
 apiVersion: policy/v1beta1
+{{- else -}}
+apiVersion: policy/v1
+{{- end }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "apisix.fullname" . }}


### PR DESCRIPTION
Why:
* Chart could not be installed in Kubernetes 1.25
* The PodDisruptionBudget used apiVersion that is deprecated before and unavailable in 1.25.

How:
* PodDisruptionBudget apiVersion is updated to match the Kubernetes version. No spec adjustments needed.
* Changes are applied also to k8s versions in which old api versions were deprecated.

Reference:
* https://kubernetes.io/docs/reference/using-api/deprecation-guide/#poddisruptionbudget-v125
   
I have tested the changes on a 1.25 cluster and reviewed templates visually for older version.
