### PR TITLE
fix: disable default cpu affinity

### DIFF
--- a/charts/apisix/values.yaml
+++ b/charts/apisix/values.yaml
@@ -333,7 +333,7 @@ nginx:
   workerRlimitNofile: "20480"
   workerConnections: "10620"
   workerProcesses: auto
-  enableCPUAffinity: true
+  enableCPUAffinity: false
   envs: []
 
 # -- APISIX plugins to be enabled


### PR DESCRIPTION
Turn off the `worker_cpu_affinity` default switch for APISIX in Kubernetes to avoid performance anomalies under high load.