### PR TITLE
fix: ingress support for the lower version k8s server

### DIFF
--- a/charts/apisix-dashboard/templates/ingress.yaml
+++ b/charts/apisix-dashboard/templates/ingress.yaml
@@ -62,7 +62,7 @@ spec:
                 name: {{ $fullName }}
                 port:
                   number:  {{ $svcPort }}
-            {{- else -}}
+            {{- else }}
             backend:
               serviceName: {{ $fullName }}
               servicePort: {{ $svcPort }}

--- a/charts/apisix/templates/ingress-admin.yaml
+++ b/charts/apisix/templates/ingress-admin.yaml
@@ -66,7 +66,7 @@ spec:
                 name: {{ $fullName }}-admin
                 port:
                   number:  {{ $svcPort }}
-            {{- else -}}
+            {{- else }}
             backend:
               serviceName: {{ $fullName }}-admin
               servicePort: {{ $svcPort }}

--- a/charts/apisix/templates/ingress.yaml
+++ b/charts/apisix/templates/ingress.yaml
@@ -66,7 +66,7 @@ spec:
                 name: {{ $fullName }}-gateway
                 port:
                   number:  {{ $svcPort }}
-            {{- else -}}
+            {{- else }}
             backend:
               serviceName: {{ $fullName }}-gateway
               servicePort: {{ $svcPort }}


### PR DESCRIPTION
When the version of the K8S server is lower than 1.14-0, ingress cannot be used because of the indentation problem of this else, which caused the incorrect deletion of an extra line