### PR TITLE
Enable the gateway to set static clustering capabilities

### DIFF
--- a/charts/apisix/README.md
+++ b/charts/apisix/README.md
@@ -157,6 +157,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | extraVolumeMounts | list | `[]` | Additional `volume`, See [Kubernetes Volumes](https://kubernetes.io/docs/concepts/storage/volumes/) for the detail. |
 | extraVolumes | list | `[]` | Additional `volume`, See [Kubernetes Volumes](https://kubernetes.io/docs/concepts/storage/volumes/) for the detail. |
 | fullnameOverride | string | `""` |  |
+| gateway.clusterIP | string | `""` |  |
 | gateway.externalIPs | list | `[]` |  |
 | gateway.externalTrafficPolicy | string | `"Cluster"` |  |
 | gateway.http | object | `{"additionalContainerPorts":[],"containerPort":9080,"enabled":true,"servicePort":80}` | Apache APISIX service settings for http |

--- a/charts/apisix/templates/service-gateway.yaml
+++ b/charts/apisix/templates/service-gateway.yaml
@@ -29,6 +29,9 @@ metadata:
     app.kubernetes.io/service: apisix-gateway
 spec:
   type: {{ .Values.gateway.type }}
+  {{- if .Values.gateway.clusterIP }}
+  clusterIP: {{ .Values.gateway.clusterIP }}
+  {{- end }}
   externalTrafficPolicy: {{ .Values.gateway.externalTrafficPolicy }}
   {{- if eq .Values.gateway.type "LoadBalancer" }}
   {{- if .Values.gateway.loadBalancerIP }}

--- a/docs/en/latest/apisix.md
+++ b/docs/en/latest/apisix.md
@@ -2,7 +2,7 @@
 title: Apache APISIX Helm Chart
 ---
 
-<!--
+<!--[apisix-dashboard.md](apisix-dashboard.md)
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with


### PR DESCRIPTION
In some scenarios, without a loadBalancer, the nodeport method cannot meet the requirements. For example, in a testing environment shared by multiple people, it is necessary to set up a static cluster IP. Moreover, most company application scenarios use nginx as the primary proxy, so simply changing the nginx of the primary proxy to forward to the cluster IP of the Apisix gateway on k8s is sufficient

