### PR TITLE
chore: The metrics interface should not be provided by apisix-gateway…

### DIFF
--- a/charts/apisix/templates/service-gateway.yaml
+++ b/charts/apisix/templates/service-gateway.yaml
@@ -77,12 +77,6 @@ spec:
     port: {{ .port }}
     targetPort: {{ .port }}
   {{- end }}
-  {{- if .Values.serviceMonitor.enabled }}
-  - name: prometheus
-    port: {{ .Values.serviceMonitor.containerPort }}
-    targetPort: {{ .Values.serviceMonitor.containerPort }}
-    protocol: TCP
-  {{- end }}
   {{- if and .Values.gateway.stream.enabled (or (gt (len .Values.gateway.stream.tcp) 0) (gt (len .Values.gateway.stream.udp) 0)) }}
   {{- with .Values.gateway.stream }}
   {{- if (gt (len .tcp) 0) }}

--- a/charts/apisix/templates/service-metrics.yaml
+++ b/charts/apisix/templates/service-metrics.yaml
@@ -1,0 +1,34 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+{{- if .Values.serviceMonitor.enabled}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "apisix.fullname" . }}-prometheus-metrics
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "apisix.labels" . | nindent 4 }}
+    app.kubernetes.io/service: apisix-prometheus-metrics
+spec:
+  type: ClusterIP
+  ports:
+  - name: prometheus
+    port: {{ .Values.serviceMonitor.containerPort }}
+    targetPort: {{ .Values.serviceMonitor.containerPort }}
+    protocol: TCP
+  selector:
+    {{- include "apisix.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/apisix/templates/service-monitor.yaml
+++ b/charts/apisix/templates/service-monitor.yaml
@@ -35,7 +35,7 @@ spec:
   selector:
     matchLabels:
       {{- include "apisix.labels" . | nindent 6 }}
-      app.kubernetes.io/service: apisix-gateway
+      app.kubernetes.io/service: apisix-prometheus-metrics
   endpoints:
   - scheme: http
     targetPort: prometheus


### PR DESCRIPTION
The apisix gateway is usually exposed to the external network, and the metrics interface is also exposed to the external network, which is not secure.