### PR TITLE
adding fallback_sni to apisix conf

### DIFF
--- a/charts/apisix/README.md
+++ b/charts/apisix/README.md
@@ -170,8 +170,8 @@ The command removes all the Kubernetes components associated with the chart and 
 | gateway.tls.additionalContainerPorts | list | `[]` | Support multiple https ports, See [Configuration](https://github.com/apache/apisix/blob/0bc65ea9acd726f79f80ae0abd8f50b7eb172e3d/conf/config-default.yaml#L99) |
 | gateway.tls.certCAFilename | string | `""` | Filename be used in the gateway.tls.existingCASecret |
 | gateway.tls.existingCASecret | string | `""` | Specifies the name of Secret contains trusted CA certificates in the PEM format used to verify the certificate when APISIX needs to do SSL/TLS handshaking with external services (e.g. etcd) |
-| gateway.tls.sslProtocols | string | `"TLSv1.2 TLSv1.3"` | TLS protocols allowed to use. |
 | gateway.tls.fallbackSni | string | `""` | Define sni to fallback if none is presented by client |
+| gateway.tls.sslProtocols | string | `"TLSv1.2 TLSv1.3"` | TLS protocols allowed to use. |
 | gateway.type | string | `"NodePort"` | Apache APISIX service type for user access itself |
 | global.imagePullSecrets | list | `[]` | Global Docker registry secret names as an array |
 | ingress-controller | object | `{"config":{"apisix":{"adminAPIVersion":"v3"}},"enabled":false}` | Ingress controller configuration |

--- a/charts/apisix/README.md
+++ b/charts/apisix/README.md
@@ -166,12 +166,12 @@ The command removes all the Kubernetes components associated with the chart and 
 | gateway.ingress.annotations | object | `{}` | Ingress annotations |
 | gateway.labelsOverride | object | `{}` | Override default labels assigned to Apache APISIX gateway resources |
 | gateway.stream | object | `{"enabled":false,"only":false,"tcp":[],"udp":[]}` | Apache APISIX service settings for stream. L4 proxy (TCP/UDP) |
-| gateway.tls | object | `{"additionalContainerPorts":[],"certCAFilename":"","containerPort":9443,"enabled":false,"existingCASecret":"","http2":{"enabled":true},"servicePort":443,"sslProtocols":"TLSv1.2 TLSv1.3","fallbackSni":""}` | Apache APISIX service settings for tls |
+| gateway.tls | object | `{"additionalContainerPorts":[],"certCAFilename":"","containerPort":9443,"enabled":false,"existingCASecret":"","fallbackSni":"","http2":{"enabled":true},"servicePort":443,"sslProtocols":"TLSv1.2 TLSv1.3"}` | Apache APISIX service settings for tls |
 | gateway.tls.additionalContainerPorts | list | `[]` | Support multiple https ports, See [Configuration](https://github.com/apache/apisix/blob/0bc65ea9acd726f79f80ae0abd8f50b7eb172e3d/conf/config-default.yaml#L99) |
 | gateway.tls.certCAFilename | string | `""` | Filename be used in the gateway.tls.existingCASecret |
 | gateway.tls.existingCASecret | string | `""` | Specifies the name of Secret contains trusted CA certificates in the PEM format used to verify the certificate when APISIX needs to do SSL/TLS handshaking with external services (e.g. etcd) |
 | gateway.tls.sslProtocols | string | `"TLSv1.2 TLSv1.3"` | TLS protocols allowed to use. |
-| gateway.tls.fallbackSni | string | `""` | Fallback TLS Server Name Indication to use when SNI is not sent by client during TLS handshake |
+| gateway.tls.fallbackSni | string | `""` | Define sni to fallback if none is presented by client |
 | gateway.type | string | `"NodePort"` | Apache APISIX service type for user access itself |
 | global.imagePullSecrets | list | `[]` | Global Docker registry secret names as an array |
 | ingress-controller | object | `{"config":{"apisix":{"adminAPIVersion":"v3"}},"enabled":false}` | Ingress controller configuration |

--- a/charts/apisix/README.md
+++ b/charts/apisix/README.md
@@ -166,11 +166,11 @@ The command removes all the Kubernetes components associated with the chart and 
 | gateway.ingress.annotations | object | `{}` | Ingress annotations |
 | gateway.labelsOverride | object | `{}` | Override default labels assigned to Apache APISIX gateway resources |
 | gateway.stream | object | `{"enabled":false,"only":false,"tcp":[],"udp":[]}` | Apache APISIX service settings for stream. L4 proxy (TCP/UDP) |
-| gateway.tls | object | `{"additionalContainerPorts":[],"certCAFilename":"","containerPort":9443,"enabled":false,"existingCASecret":"","fallbackSni":"","http2":{"enabled":true},"servicePort":443,"sslProtocols":"TLSv1.2 TLSv1.3"}` | Apache APISIX service settings for tls |
+| gateway.tls | object | `{"additionalContainerPorts":[],"certCAFilename":"","containerPort":9443,"enabled":false,"existingCASecret":"","fallbackSNI":"","http2":{"enabled":true},"servicePort":443,"sslProtocols":"TLSv1.2 TLSv1.3"}` | Apache APISIX service settings for tls |
 | gateway.tls.additionalContainerPorts | list | `[]` | Support multiple https ports, See [Configuration](https://github.com/apache/apisix/blob/0bc65ea9acd726f79f80ae0abd8f50b7eb172e3d/conf/config-default.yaml#L99) |
 | gateway.tls.certCAFilename | string | `""` | Filename be used in the gateway.tls.existingCASecret |
 | gateway.tls.existingCASecret | string | `""` | Specifies the name of Secret contains trusted CA certificates in the PEM format used to verify the certificate when APISIX needs to do SSL/TLS handshaking with external services (e.g. etcd) |
-| gateway.tls.fallbackSni | string | `""` | Define sni to fallback if none is presented by client |
+| gateway.tls.fallbackSNI | string | `""` | Define SNI to fallback if none is presented by client |
 | gateway.tls.sslProtocols | string | `"TLSv1.2 TLSv1.3"` | TLS protocols allowed to use. |
 | gateway.type | string | `"NodePort"` | Apache APISIX service type for user access itself |
 | global.imagePullSecrets | list | `[]` | Global Docker registry secret names as an array |

--- a/charts/apisix/README.md
+++ b/charts/apisix/README.md
@@ -166,11 +166,12 @@ The command removes all the Kubernetes components associated with the chart and 
 | gateway.ingress.annotations | object | `{}` | Ingress annotations |
 | gateway.labelsOverride | object | `{}` | Override default labels assigned to Apache APISIX gateway resources |
 | gateway.stream | object | `{"enabled":false,"only":false,"tcp":[],"udp":[]}` | Apache APISIX service settings for stream. L4 proxy (TCP/UDP) |
-| gateway.tls | object | `{"additionalContainerPorts":[],"certCAFilename":"","containerPort":9443,"enabled":false,"existingCASecret":"","http2":{"enabled":true},"servicePort":443,"sslProtocols":"TLSv1.2 TLSv1.3"}` | Apache APISIX service settings for tls |
+| gateway.tls | object | `{"additionalContainerPorts":[],"certCAFilename":"","containerPort":9443,"enabled":false,"existingCASecret":"","http2":{"enabled":true},"servicePort":443,"sslProtocols":"TLSv1.2 TLSv1.3","fallbackSni":""}` | Apache APISIX service settings for tls |
 | gateway.tls.additionalContainerPorts | list | `[]` | Support multiple https ports, See [Configuration](https://github.com/apache/apisix/blob/0bc65ea9acd726f79f80ae0abd8f50b7eb172e3d/conf/config-default.yaml#L99) |
 | gateway.tls.certCAFilename | string | `""` | Filename be used in the gateway.tls.existingCASecret |
 | gateway.tls.existingCASecret | string | `""` | Specifies the name of Secret contains trusted CA certificates in the PEM format used to verify the certificate when APISIX needs to do SSL/TLS handshaking with external services (e.g. etcd) |
 | gateway.tls.sslProtocols | string | `"TLSv1.2 TLSv1.3"` | TLS protocols allowed to use. |
+| gateway.tls.fallbackSni | string | `""` | Fallback TLS Server Name Indication to use when SNI is not sent by client during TLS handshake |
 | gateway.type | string | `"NodePort"` | Apache APISIX service type for user access itself |
 | global.imagePullSecrets | list | `[]` | Global Docker registry secret names as an array |
 | ingress-controller | object | `{"config":{"apisix":{"adminAPIVersion":"v3"}},"enabled":false}` | Ingress controller configuration |

--- a/charts/apisix/templates/configmap.yaml
+++ b/charts/apisix/templates/configmap.yaml
@@ -149,8 +149,8 @@ data:
         {{- if and .Values.gateway.tls.enabled .Values.gateway.tls.existingCASecret }}
         ssl_trusted_certificate: "/usr/local/apisix/conf/ssl/{{ .Values.gateway.tls.certCAFilename }}"
         {{- end }}
-        {{- if and .Values.gateway.tls.enabled .Values.gateway.tls.fallbackSni }}
-        fallback_sni: {{ .Values.gateway.tls.fallbackSni | quote }}
+        {{- if and .Values.gateway.tls.enabled .Values.gateway.tls.fallbackSNI }}
+        fallback_sni: {{ .Values.gateway.tls.fallbackSNI | quote }}
         {{- end }}
 
     nginx_config:    # config for render the template to genarate nginx.conf

--- a/charts/apisix/templates/configmap.yaml
+++ b/charts/apisix/templates/configmap.yaml
@@ -149,6 +149,9 @@ data:
         {{- if and .Values.gateway.tls.enabled .Values.gateway.tls.existingCASecret }}
         ssl_trusted_certificate: "/usr/local/apisix/conf/ssl/{{ .Values.gateway.tls.certCAFilename }}"
         {{- end }}
+        {{- if and .Values.gateway.tls.enabled .Values.gateway.tls.fallbackSni }}
+        fallback_sni: {{ .Values.gateway.tls.fallbackSni | quote }}
+        {{- end }}
 
     nginx_config:    # config for render the template to genarate nginx.conf
       error_log: "{{ .Values.logs.errorLog }}"

--- a/charts/apisix/values.yaml
+++ b/charts/apisix/values.yaml
@@ -258,6 +258,8 @@ gateway:
       enabled: true
     # -- TLS protocols allowed to use.
     sslProtocols: "TLSv1.2 TLSv1.3"
+    # -- Define sni to fallback if none is presented by client
+    fallbackSni: "" 
   # -- Apache APISIX service settings for stream. L4 proxy (TCP/UDP)
   stream:
     enabled: false

--- a/charts/apisix/values.yaml
+++ b/charts/apisix/values.yaml
@@ -258,8 +258,8 @@ gateway:
       enabled: true
     # -- TLS protocols allowed to use.
     sslProtocols: "TLSv1.2 TLSv1.3"
-    # -- Define sni to fallback if none is presented by client
-    fallbackSni: ""
+    # -- Define SNI to fallback if none is presented by client
+    fallbackSNI: ""
   # -- Apache APISIX service settings for stream. L4 proxy (TCP/UDP)
   stream:
     enabled: false

--- a/charts/apisix/values.yaml
+++ b/charts/apisix/values.yaml
@@ -259,7 +259,7 @@ gateway:
     # -- TLS protocols allowed to use.
     sslProtocols: "TLSv1.2 TLSv1.3"
     # -- Define sni to fallback if none is presented by client
-    fallbackSni: "" 
+    fallbackSni: ""
   # -- Apache APISIX service settings for stream. L4 proxy (TCP/UDP)
   stream:
     enabled: false


### PR DESCRIPTION
Some "clients", like AWS Application Load balancer, when forwarding HTTPS requests to upstream servers ( like APISIX ) do not present SNI on the TLS handshake, resulting on APISIX not to be able to fetch the appropriate certificate to establish the connection.
This change is to be able to define and include the "fallback_sni" property on apisix configuration, so that a last resort SNI can be defined and a proper certificate can be retrieved.