### PR TITLE
fix: config map admin/viewer secret key

### DIFF
--- a/charts/apisix/templates/configmap.yaml
+++ b/charts/apisix/templates/configmap.yaml
@@ -315,7 +315,7 @@ data:
           # admin: can everything for configuration data
           - name: "admin"
             {{- if .Values.admin.credentials.secretName }}
-            key: "{{"{{"}}APISIX_ADMIN_KEY{{"}}"}}"
+            key: {{"${{"}}APISIX_ADMIN_KEY{{"}}"}}
             {{- else }}
             key: {{ .Values.admin.credentials.admin }}
             {{- end }}
@@ -323,7 +323,7 @@ data:
           # viewer: only can view configuration data
           - name: "viewer"
             {{- if .Values.admin.credentials.secretName }}
-            key: "{{"{{"}}APISIX_VIEWER_KEY{{"}}"}}"
+            key: {{"${{"}}APISIX_VIEWER_KEY{{"}}"}}
             {{- else }}
             key: {{ .Values.admin.credentials.viewer }}
             {{- end }}

--- a/charts/apisix/templates/configmap.yaml
+++ b/charts/apisix/templates/configmap.yaml
@@ -315,7 +315,7 @@ data:
           # admin: can everything for configuration data
           - name: "admin"
             {{- if .Values.admin.credentials.secretName }}
-            key: {{"${{"}}APISIX_ADMIN_KEY{{"}}"}}
+            key: ${{"{{"}}APISIX_ADMIN_KEY{{"}}"}}
             {{- else }}
             key: {{ .Values.admin.credentials.admin }}
             {{- end }}
@@ -323,7 +323,7 @@ data:
           # viewer: only can view configuration data
           - name: "viewer"
             {{- if .Values.admin.credentials.secretName }}
-            key: {{"${{"}}APISIX_VIEWER_KEY{{"}}"}}
+            key: ${{"{{"}}APISIX_VIEWER_KEY{{"}}"}}
             {{- else }}
             key: {{ .Values.admin.credentials.viewer }}
             {{- end }}


### PR DESCRIPTION
The implementation of admin/view keys using kubernetes secret on #530 doesn't seem to work.
What happens is that on the resulting config.yaml file, the admin key ( and viewer ) will look like:
      - name: "admin"
        key: "{{APISIX_ADMIN_KEY}}" 

instead of the ' key: ${{APISIX_ADMIN_KEY}} '   that is described on [https://apisix.apache.org/docs/apisix/admin-api/](https://apisix.apache.org/docs/apisix/admin-api/).
The result is that the admin key is literally the value string above and not the value from the env/k8s secret.
-
This PR is the fix on the config map to have the proper key value format to reference the env variable ( filled from the configured secretName secret).

This change was tested, where the admin and viewer keys were correctly set and looked like this on the final config.yaml:

...
      - name: "admin"
        key: ${{APISIX_ADMIN_KEY}}
...
      - name: "viewer"
        key: ${{APISIX_VIEWER_KEY}}  
