### PR TITLE
feat: allow to override admin token for ingress controller

### DIFF
--- a/charts/apisix-ingress-controller/README.md
+++ b/charts/apisix-ingress-controller/README.md
@@ -111,8 +111,10 @@ The same for container level, you need to set:
 | autoscaling.targetCPUUtilizationPercentage | int | `80` |  |
 | autoscaling.version | string | `"v2"` | HPA version, the value is "v2" or "v2beta1", default "v2" |
 | clusterDomain | string | `"cluster.local"` |  |
-| config.apisix | object | `{"adminAPIVersion":"v2","adminKey":"edd1c9f034335f136f87ad84b625c8f1","clusterName":"default","serviceName":"apisix-admin","serviceNamespace":"ingress-apisix","servicePort":9180}` | APISIX related configurations. |
+| config.apisix | object | `{"adminAPIVersion":"v2","adminKey":"edd1c9f034335f136f87ad84b625c8f1","clusterName":"default","secretAdminKey":"","secretName":"","serviceName":"apisix-admin","serviceNamespace":"ingress-apisix","servicePort":9180}` | APISIX related configurations. |
 | config.apisix.adminAPIVersion | string | `"v2"` | the APISIX admin API version. can be "v2" or "v3", default is "v2". |
+| config.apisix.secretAdminKey | string | `""` | Name of the admin token key in the secret, overrides the default key name "adminKey" |
+| config.apisix.secretName | string | `""` | The APISIX Helm chart supports storing user credentials in a secret. The secret needs to contain a single key for admin token with key adminKey by default. |
 | config.apisix.serviceName | string | `"apisix-admin"` | Enabling this value, overrides serviceName and serviceNamespace. serviceFullname: "apisix-admin.apisix.svc.local" |
 | config.apisixResourceSyncInterval | string | `"1h"` | Default interval for synchronizing Kubernetes resources to APISIX |
 | config.certFile | string | `"/etc/webhook/certs/cert.pem"` | the TLS certificate file path. |

--- a/charts/apisix-ingress-controller/templates/_helpers.tpl
+++ b/charts/apisix-ingress-controller/templates/_helpers.tpl
@@ -85,3 +85,14 @@ Create the name of the service account to use
 {{- define "apisix-ingress-controller.namespace" -}}
 {{- default .Release.Namespace .Values.namespace -}}
 {{- end -}}
+
+{{/*
+Key to use to fetch admin token from secret
+*/}}
+{{- define "apisix-ingress-controller.credentials.secretAdminKey" -}}
+{{- if .Values.config.apisix.secretAdminKey }}
+{{- .Values.config.apisix.secretAdminKey }}
+{{- else }}
+{{- "adminKey" }}
+{{- end }}
+{{- end }}

--- a/charts/apisix-ingress-controller/templates/configmap.yaml
+++ b/charts/apisix-ingress-controller/templates/configmap.yaml
@@ -58,7 +58,11 @@ data:
       {{ else }}
       default_cluster_base_url: http://{{ .Values.config.apisix.serviceName }}.{{ .Values.config.apisix.serviceNamespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.config.apisix.servicePort }}/apisix/admin
       {{- end}}
+      {{- if .Values.config.apisix.secretName }}
+      default_cluster_admin_key: "{{"{{"}}.APISIX_ADMIN_KEY{{"}}"}}"
+      {{- else }}
       default_cluster_admin_key: {{ .Values.config.apisix.adminKey | quote }}
+      {{- end }}
       default_cluster_name: {{ .Values.config.apisix.clusterName | quote }}
 kind: ConfigMap
 metadata:

--- a/charts/apisix-ingress-controller/templates/deployment.yaml
+++ b/charts/apisix-ingress-controller/templates/deployment.yaml
@@ -103,6 +103,13 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.name
+          {{- if .Values.config.apisix.secretName }}
+          - name: APISIX_ADMIN_KEY
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.config.apisix.secretName | quote }}
+                key: {{ include "apisix-ingress-controller.credentials.secretAdminKey" . }}
+          {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/apisix-ingress-controller/values.yaml
+++ b/charts/apisix-ingress-controller/values.yaml
@@ -139,6 +139,12 @@ config:
     # -- the APISIX admin API version. can be "v2" or "v3", default is "v2".
     adminAPIVersion: "v2"
 
+    # -- The APISIX Helm chart supports storing user credentials in a secret.
+    # The secret needs to contain a single key for admin token with key adminKey by default.
+    secretName: ""
+    # -- Name of the admin token key in the secret, overrides the default key name "adminKey"
+    secretAdminKey: ""
+
 resources: {}
 
 initContainer:


### PR DESCRIPTION
Provides a way to override admin key for ingress controller using secrets, as per proposal https://github.com/apache/apisix-helm-chart/issues/552.