### PR TITLE
chore: add release trigger for dev branch (#558)

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -44,3 +44,6 @@ github:
       legacy:
         required_pull_request_reviews:
           required_approving_review_count: 2
+      dev:
+        required_pull_request_reviews:
+          required_approving_review_count: 2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
       - legacy
+      - dev
 
 jobs:
   release:


### PR DESCRIPTION
Due to the refactoring of APISIX Helm chart, we plan to maintain it through the dev branch.