### PR TITLE
fix: apply correct cluster key from secret for 553

### DIFF
--- a/charts/apisix-ingress-controller/templates/configmap.yaml
+++ b/charts/apisix-ingress-controller/templates/configmap.yaml
@@ -58,7 +58,9 @@ data:
       {{ else }}
       default_cluster_base_url: http://{{ .Values.config.apisix.serviceName }}.{{ .Values.config.apisix.serviceNamespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.config.apisix.servicePort }}/apisix/admin
       {{- end}}
-      {{- if not .Values.config.apisix.existingSecret }}
+      {{- if .Values.config.apisix.existingSecret }}
+      default_cluster_admin_key: "{{"{{"}}.DEFAULT_CLUSTER_ADMIN_KEY{{"}}"}}"
+      {{- else }}
       default_cluster_admin_key: {{ .Values.config.apisix.adminKey | quote }}
       {{- end }}
       default_cluster_name: {{ .Values.config.apisix.clusterName | quote }}


### PR DESCRIPTION
Fix for https://github.com/apache/apisix-helm-chart/pull/553, the assumption that DEFAULT_CLUSTER_ADMIN_KEY will be populated automatically was incorrect.

https://github.com/apache/apisix-helm-chart/issues/552 should be reopened.