### PR TITLE
feat: allow customize meta in `nginx_config`

### DIFF
--- a/charts/apisix/README.md
+++ b/charts/apisix/README.md
@@ -197,6 +197,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | nameOverride | string | `""` |  |
 | nginx.enableCPUAffinity | bool | `true` |  |
 | nginx.envs | list | `[]` |  |
+| nginx.meta | string | `"lua_shared_dict:\n  prometheus-metrics: 15m\n"` | allow customize meta in `nginx_config` section |
 | nginx.workerConnections | string | `"10620"` |  |
 | nginx.workerProcesses | string | `"auto"` |  |
 | nginx.workerRlimitNofile | string | `"20480"` |  |

--- a/charts/apisix/templates/configmap.yaml
+++ b/charts/apisix/templates/configmap.yaml
@@ -163,6 +163,8 @@ data:
       worker_rlimit_nofile: {{ default "20480" .Values.nginx.workerRlimitNofile }}  # the number of files a worker process can open, should be larger than worker_connections
       event:
         worker_connections: {{ default "10620" .Values.nginx.workerConnections  }}
+      meta:
+        {{- .Values.nginx.meta | nindent 8 }}
       {{- with .Values.nginx.envs }}
       envs:
       {{- range $env := . }}

--- a/charts/apisix/values.yaml
+++ b/charts/apisix/values.yaml
@@ -387,6 +387,10 @@ nginx:
   workerProcesses: auto
   enableCPUAffinity: true
   envs: []
+  # allow customize meta in nginx_config section
+  meta: |
+    lua_shared_dict:
+      prometheus-metrics: 15m
 
 # -- Customize the list of APISIX plugins to enable. By default, APISIX's default plugins are automatically used. See [config-default.yaml](https://github.com/apache/apisix/blob/master/conf/config-default.yaml)
 plugins: []

--- a/charts/apisix/values.yaml
+++ b/charts/apisix/values.yaml
@@ -387,7 +387,7 @@ nginx:
   workerProcesses: auto
   enableCPUAffinity: true
   envs: []
-  # allow customize meta in nginx_config section
+  # -- allow customize meta in `nginx_config` section
   meta: |
     lua_shared_dict:
       prometheus-metrics: 15m


### PR DESCRIPTION
if we configure prometheus plugin with extra labels like bellow

```
pluginAttrs:
  prometheus:
    metrics:
      http_status:
        extra_labels:
          - request_uri: $uri
          - request_method: $request_method
      http_latency:
        extra_labels:
          - request_uri: $uri
          - request_method: $request_method
```

then we might run into situation like https://github.com/apache/apisix/issues/7349.

this PR allow user to set the max size of `lua_shared_dict.prometheus-metrics`, incase we'll have more properties in this `meta` field in the future, so I make it as a string type.