### PR TITLE
fix: render ServiceMonitor regardless of presented CRDs

### DIFF
--- a/charts/apisix-ingress-controller/templates/servicemonitor.yaml
+++ b/charts/apisix-ingress-controller/templates/servicemonitor.yaml
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-{{- if and ( .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" ) .Values.serviceMonitor.enabled }}
+{{- if .Values.serviceMonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:


### PR DESCRIPTION
Remove the check of `monitoring.coreos.com/v1` API to make it possible to render the ServiceMonitor resource without connection to the target Kubernetes cluster and without supplying `--api-versions` flag for `helm`.

Fixes #330