### PR TITLE
fix wrong namespaceSelector in service monitor

### DIFF
--- a/charts/apisix/templates/service-monitor.yaml
+++ b/charts/apisix/templates/service-monitor.yaml
@@ -31,7 +31,7 @@ metadata:
 spec:
   namespaceSelector:
     matchNames:
-    - {{ .Values.serviceMonitor.namespace | default .Release.Namespace }}
+    - {{ .Release.Namespace }}
   selector:
     matchLabels:
       {{- include "apisix.labels" . | nindent 6 }}


### PR DESCRIPTION
namespaceSelector should always be Release.Namespace