### PR TITLE
docs: specify ServiceMonitor requirements in values.yaml

### DIFF
--- a/charts/apisix-ingress-controller/README.md
+++ b/charts/apisix-ingress-controller/README.md
@@ -159,7 +159,7 @@ The same for container level, you need to set:
 | serviceAccount.automountServiceAccountToken | bool | `true` | Whether automounting API credentials for a service account |
 | serviceAccount.create | bool | `true` | Specifies whether a ServiceAccount should be created |
 | serviceAccount.name | string | `""` | The name of the ServiceAccount to use. If not set and create is true, a name is generated using the fullname template |
-| serviceMonitor | object | `{"annotations":{},"enabled":false,"interval":"15s","labels":{},"metricRelabelings":{},"namespace":"monitoring"}` | namespace: "ingress-apisix" |
+| serviceMonitor | object | `{"annotations":{},"enabled":false,"interval":"15s","labels":{},"metricRelabelings":{},"namespace":"monitoring"}` | Enable creating ServiceMonitor objects for Prometheus operator. Requires Prometheus operator v0.38.0 or higher. |
 | serviceMonitor.annotations | object | `{}` | @param serviceMonitor.annotations ServiceMonitor annotations |
 | serviceMonitor.labels | object | `{}` | @param serviceMonitor.labels ServiceMonitor extra labels |
 | serviceMonitor.metricRelabelings | object | `{}` | @param serviceMonitor.metricRelabelings MetricRelabelConfigs to apply to samples before ingestion. ref: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs |

--- a/charts/apisix-ingress-controller/values.yaml
+++ b/charts/apisix-ingress-controller/values.yaml
@@ -167,8 +167,10 @@ updateStrategy: {}
 nodeSelector: {}
 tolerations: []
 
-# -- namespace: "ingress-apisix"
+#  namespace: "ingress-apisix"
 
+# -- Enable creating ServiceMonitor objects for Prometheus operator.
+# Requires Prometheus operator v0.38.0 or higher.
 serviceMonitor:
   enabled: false
   namespace: "monitoring"


### PR DESCRIPTION
Add a note that enabling ServiceMonitor requires Prometheus operator CRDs to be installed.

It's a follow-up on [this comment](https://github.com/apache/apisix-helm-chart/pull/571#issuecomment-1620938165).

Ref: #571