### PR TITLE
Fix: helm validation and install fails when service.type is ClusterIP 

### DIFF
--- a/charts/apisix/templates/service-gateway.yaml
+++ b/charts/apisix/templates/service-gateway.yaml
@@ -29,7 +29,9 @@ metadata:
     app.kubernetes.io/service: apisix-gateway
 spec:
   type: {{ .Values.gateway.type }}
+  {{- if or (eq .Values.gateway.type "LoadBalancer") (eq .Values.gateway.type "NodePort") }}
   externalTrafficPolicy: {{ .Values.gateway.externalTrafficPolicy }}
+  {{- end }}
   {{- if eq .Values.gateway.type "LoadBalancer" }}
   {{- if .Values.gateway.loadBalancerIP }}
   loadBalancerIP: {{ .Values.gateway.loadBalancerIP }}


### PR DESCRIPTION
Closes https://github.com/apache/apisix-helm-chart/issues/588