### PR TITLE
chore: upgrade APISIX to 3.4.1

### DIFF
--- a/charts/apisix/Chart.yaml
+++ b/charts/apisix/Chart.yaml
@@ -31,12 +31,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.5.0
+version: 1.5.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 3.4.0
+appVersion: 3.4.1
 sources:
   - https://github.com/apache/apisix-helm-chart
 

--- a/charts/apisix/README.md
+++ b/charts/apisix/README.md
@@ -68,7 +68,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | apisix.httpRouter | string | `"radixtree_host_uri"` | Defines how apisix handles routing: - radixtree_uri: match route by uri(base on radixtree) - radixtree_host_uri: match route by host + uri(base on radixtree) - radixtree_uri_with_parameter: match route by uri with parameters |
 | apisix.image.pullPolicy | string | `"IfNotPresent"` | Apache APISIX image pull policy |
 | apisix.image.repository | string | `"apache/apisix"` | Apache APISIX image repository |
-| apisix.image.tag | string | `"3.4.0-debian"` | Apache APISIX image tag Overrides the image tag whose default is the chart appVersion. |
+| apisix.image.tag | string | `"3.4.1-debian"` | Apache APISIX image tag Overrides the image tag whose default is the chart appVersion. |
 | apisix.kind | string | `"Deployment"` | Use a `DaemonSet` or `Deployment` |
 | apisix.luaModuleHook | object | `{"configMapRef":{"mounts":[{"key":"","path":""}],"name":""},"enabled":false,"hookPoint":"","luaPath":""}` | Whether to add a custom lua module |
 | apisix.luaModuleHook.configMapRef | object | `{"mounts":[{"key":"","path":""}],"name":""}` | configmap that stores the codes |

--- a/charts/apisix/values.yaml
+++ b/charts/apisix/values.yaml
@@ -99,7 +99,7 @@ apisix:
     pullPolicy: IfNotPresent
     # -- Apache APISIX image tag
     # Overrides the image tag whose default is the chart appVersion.
-    tag: 3.4.0-debian
+    tag: 3.4.1-debian
 
   # -- Use a `DaemonSet` or `Deployment`
   kind: Deployment


### PR DESCRIPTION
# install at local machine

try install 3.4.1

```shell
helm install apisix charts/apisix \
                                          --set gateway.type=NodePort \
                                          --set ingress-controller.enabled=true \
                                          --namespace ingress-apisix \
                                          --set ingress-controller.config.apisix.serviceNamespace=ingress-apisix
NAME: apisix
LAST DEPLOYED: Wed Jul 26 18:23:45 2023
NAMESPACE: ingress-apisix
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
1. Get the application URL by running these commands:
  export NODE_PORT=$(kubectl get --namespace ingress-apisix -o jsonpath="{.spec.ports[0].nodePort}" services apisix-gateway)
  export NODE_IP=$(kubectl get nodes --namespace ingress-apisix -o jsonpath="{.items[0].status.addresses[0].address}")
  echo http://$NODE_IP:$NODE_PORT
```

```shell
$ kubectl get pod --all-namespaces
NAMESPACE            NAME                                         READY   STATUS              RESTARTS   AGE
ingress-apisix       apisix-5dcbf46bd-f8zsw                       0/1     Init:0/2            0          20s
ingress-apisix       apisix-etcd-0                                0/1     ContainerCreating   0          20s
ingress-apisix       apisix-etcd-1                                0/1     ContainerCreating   0          20s
ingress-apisix       apisix-etcd-2                                0/1     ContainerCreating   0          20s
ingress-apisix       apisix-ingress-controller-77b54bcf65-gq8ds   0/1     Init:0/1            0          20s
kube-system          coredns-5d78c9869d-c84nn                     1/1     Running             0          3m33s
kube-system          coredns-5d78c9869d-l8zqt                     1/1     Running             0          3m33s
kube-system          etcd-kind-control-plane                      1/1     Running             0          3m47s
kube-system          kindnet-nc8sc                                1/1     Running             0          3m33s
kube-system          kube-apiserver-kind-control-plane            1/1     Running             0          3m48s
kube-system          kube-controller-manager-kind-control-plane   1/1     Running             0          3m47s
kube-system          kube-proxy-58svb                             1/1     Running             0          3m33s
kube-system          kube-scheduler-kind-control-plane            1/1     Running             0          3m47s
local-path-storage   local-path-provisioner-6bc4bddd6b-vmpnw      1/1     Running             0          3m33s
```

```shell
$ kubectl get pod apisix-5dcbf46bd-f8zsw -n ingress-apisix
NAME                     READY   STATUS     RESTARTS   AGE
apisix-5dcbf46bd-f8zsw   0/1     Init:0/2   0          32s
```

```shell
apiVersion: v1
kind: Pod
metadata:
  annotations:
    checksum/config: 810cf395f6f28b99dd0f20504cc6fe318a1f1e1efb5c8f73f6a782343b84a8ad
  creationTimestamp: "2023-07-26T10:23:51Z"
  generateName: apisix-5dcbf46bd-
  labels:
    app.kubernetes.io/instance: apisix
    app.kubernetes.io/name: apisix
    pod-template-hash: 5dcbf46bd
  name: apisix-5dcbf46bd-f8zsw
  namespace: ingress-apisix
  ownerReferences:
  - apiVersion: apps/v1
    blockOwnerDeletion: true
    controller: true
    kind: ReplicaSet
    name: apisix-5dcbf46bd
    uid: 9af24a80-d82b-49ea-92a6-38fd529227cb
  resourceVersion: "877"
  uid: ed235f85-8144-41cf-b7e0-0f7567a4fc08
spec:
  containers:
  - image: apache/apisix:3.4.1-debian
    imagePullPolicy: IfNotPresent
    lifecycle:
      preStop:
        exec:
          command:
          - /bin/sh
          - -c
          - sleep 30
    name: apisix
    ports:
    - containerPort: 9080
      name: http
      protocol: TCP
    - containerPort: 9443
      name: tls
      protocol: TCP
    - containerPort: 9180
      name: admin
      protocol: TCP
    readinessProbe:
      failureThreshold: 6
      initialDelaySeconds: 10
      periodSeconds: 10
      successThreshold: 1
      tcpSocket:
        port: 9080
      timeoutSeconds: 1
    resources: {}
    terminationMessagePath: /dev/termination-log
    terminationMessagePolicy: File
    volumeMounts:
    - mountPath: /usr/local/apisix/conf/config.yaml
      name: apisix-config
      subPath: config.yaml
    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
      name: kube-api-access-qg9qn
      readOnly: true
  dnsPolicy: ClusterFirst
  enableServiceLinks: true
  initContainers:
  - command:
    - sh
    - -c
    - until nc -z apisix-etcd.ingress-apisix.svc.cluster.local 2379; do echo waiting
      for etcd `date`; sleep 2; done;
    image: busybox:1.28
    imagePullPolicy: IfNotPresent
    name: wait-etcd
    resources: {}
    terminationMessagePath: /dev/termination-log
    terminationMessagePolicy: File
    volumeMounts:
    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
      name: kube-api-access-qg9qn
      readOnly: true
  - command:
    - /bin/sh
    - -c
    - |
      sysctl -w net.core.somaxconn=65535
      sysctl -w net.ipv4.ip_local_port_range="1024 65535"
      sysctl -w net.ipv4.tcp_max_syn_backlog=8192
      sysctl -w fs.file-max=1048576
      sysctl -w fs.inotify.max_user_instances=16384
      sysctl -w fs.inotify.max_user_watches=524288
      sysctl -w fs.inotify.max_queued_events=16384
    image: busybox:1.28
    imagePullPolicy: IfNotPresent
    name: init-sysctl
    resources: {}
    securityContext:
      privileged: true
    terminationMessagePath: /dev/termination-log
    terminationMessagePolicy: File
    volumeMounts:
    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
      name: kube-api-access-qg9qn
      readOnly: true
  nodeName: kind-control-plane
  preemptionPolicy: PreemptLowerPriority
  priority: 0
  restartPolicy: Always
  schedulerName: default-scheduler
  securityContext: {}
  serviceAccount: default
  serviceAccountName: default
  terminationGracePeriodSeconds: 30
  tolerations:
  - effect: NoExecute
    key: node.kubernetes.io/not-ready
    operator: Exists
    tolerationSeconds: 300
  - effect: NoExecute
    key: node.kubernetes.io/unreachable
    operator: Exists
    tolerationSeconds: 300
  volumes:
  - configMap:
      defaultMode: 420
      name: apisix
    name: apisix-config
  - name: kube-api-access-qg9qn
    projected:
      defaultMode: 420
      sources:
      - serviceAccountToken:
          expirationSeconds: 3607
          path: token
      - configMap:
          items:
          - key: ca.crt
            path: ca.crt
          name: kube-root-ca.crt
      - downwardAPI:
          items:
          - fieldRef:
              apiVersion: v1
              fieldPath: metadata.namespace
            path: namespace
status:
  conditions:
  - lastProbeTime: null
    lastTransitionTime: "2023-07-26T10:23:51Z"
    message: 'containers with incomplete status: [wait-etcd init-sysctl]'
    reason: ContainersNotInitialized
    status: "False"
    type: Initialized
  - lastProbeTime: null
    lastTransitionTime: "2023-07-26T10:23:51Z"
    message: 'containers with unready status: [apisix]'
    reason: ContainersNotReady
    status: "False"
    type: Ready
  - lastProbeTime: null
    lastTransitionTime: "2023-07-26T10:23:51Z"
    message: 'containers with unready status: [apisix]'
    reason: ContainersNotReady
    status: "False"
    type: ContainersReady
  - lastProbeTime: null
    lastTransitionTime: "2023-07-26T10:23:51Z"
    status: "True"
    type: PodScheduled
  containerStatuses:
  - image: apache/apisix:3.4.1-debian
    imageID: ""
    lastState: {}
    name: apisix
    ready: false
    restartCount: 0
    started: false
    state:
      waiting:
        reason: PodInitializing
  hostIP: 172.18.0.2
  initContainerStatuses:
  - containerID: containerd://ebf3fc7d0ba306dcd69d26927f3a420bd85f64ccf3a13a9e5282dd47d3e67e86
    image: docker.io/library/busybox:1.28
    imageID: docker.io/library/busybox@sha256:141c253bc4c3fd0a201d32dc1f493bcf3fff003b6df416dea4f41046e0f37d47
    lastState: {}
    name: wait-etcd
    ready: false
    restartCount: 0
    state:
      running:
        startedAt: "2023-07-26T10:24:00Z"
  - image: busybox:1.28
    imageID: ""
    lastState: {}
    name: init-sysctl
    ready: false
    restartCount: 0
    state:
      waiting:
        reason: PodInitializing
  phase: Pending
  podIP: 10.244.0.5
  podIPs:
  - ip: 10.244.0.5
  qosClass: BestEffort
  startTime: "2023-07-26T10:23:51Z"
```