### PR TITLE
fix: fix missing permissions for kubernetes api gateway tcproute and …

### DIFF
--- a/charts/apisix-ingress-controller/templates/rbac.yaml
+++ b/charts/apisix-ingress-controller/templates/rbac.yaml
@@ -110,6 +110,8 @@ rules:
   - apiGroups:
       - gateway.networking.k8s.io
     resources:
+      - tcproutes
+      - udproutes
       - httproutes
       - tlsroutes
       - gateways
@@ -121,6 +123,8 @@ rules:
   - apiGroups:
       - gateway.networking.k8s.io
     resources:
+      - tcproutes/status
+      - udproutes/status
       - httproutes/status
       - tlsroutes/status
       - gateways/status


### PR DESCRIPTION
APISIX ingress controller supports TCPRoute and UDPRoute since [1.6.0](https://github.com/apache/apisix-ingress-controller/blob/master/CHANGELOG.md#160). So we need to add missing permissions for TCPRoute and UDPRoute for Kubernetes API gateway. 

Issue report: https://github.com/apache/apisix-helm-chart/issues/600