### PR TITLE
feat: allow changing service port in the Ingress manifest

### DIFF
--- a/charts/apisix/README.md
+++ b/charts/apisix/README.md
@@ -179,9 +179,10 @@ The command removes all the Kubernetes components associated with the chart and 
 | image.pullPolicy | string | `"IfNotPresent"` | Apache APISIX image pull policy |
 | image.repository | string | `"apache/apisix"` | Apache APISIX image repository |
 | image.tag | string | `"3.5.0-debian"` | Apache APISIX image tag Overrides the image tag whose default is the chart appVersion. |
-| ingress | object | `{"annotations":{},"enabled":false,"hosts":[{"host":"apisix.local","paths":[]}],"tls":[]}` | Using ingress access Apache APISIX service |
+| ingress | object | `{"annotations":{},"enabled":false,"hosts":[{"host":"apisix.local","paths":[]}],"servicePort":null,"tls":[]}` | Using ingress access Apache APISIX service |
 | ingress-controller | object | `{"config":{"apisix":{"adminAPIVersion":"v3"}},"enabled":false}` | Ingress controller configuration |
 | ingress.annotations | object | `{}` | Ingress annotations |
+| ingress.servicePort | number | `nil` | Service port to send traffic. Defaults to `service.http.servicePort`. |
 | initContainer.image | string | `"busybox"` | Init container image |
 | initContainer.tag | float | `1.28` | Init container tag |
 | metrics | object | `{"serviceMonitor":{"annotations":{},"enabled":false,"interval":"15s","labels":{},"name":"","namespace":""}}` | Observability configuration. |

--- a/charts/apisix/templates/ingress.yaml
+++ b/charts/apisix/templates/ingress.yaml
@@ -16,7 +16,7 @@
 
 {{- if (.Values.ingress.enabled) -}}
 {{- $fullName := include "apisix.fullname" . -}}
-{{- $svcPort := .Values.service.http.servicePort -}}
+{{- $svcPort := .Values.ingress.servicePort | default .Values.service.http.servicePort -}}
 {{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
   {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
   {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}

--- a/charts/apisix/values.yaml
+++ b/charts/apisix/values.yaml
@@ -197,6 +197,8 @@ service:
 # -- Using ingress access Apache APISIX service
 ingress:
   enabled: false
+  # -- (number) Service port to send traffic. Defaults to `service.http.servicePort`.
+  servicePort:
   # -- Ingress annotations
   annotations: {}
     # kubernetes.io/ingress.class: nginx


### PR DESCRIPTION
Previously it used `service.http.servicePort` in the Ingress manifest. This made it impossible to forward ingress traffic to TLS port. One option was to disable `http` and change `http.servicePort` to `443`, but then regular HTTP couldn't be used.

This commit allows changing Ingress service port using `ingress.servicePort`. It still falls back to `service.http.servicePort` to keep backward compatibility.

We found this useful to enable encryption between AWS ALB and APISIX. This allowed us to use:
```
    alb.ingress.kubernetes.io/backend-protocol: HTTPS
```