### PR TITLE
feat: allow deploying additional kubernetes resources

### DIFF
--- a/charts/apisix/README.md
+++ b/charts/apisix/README.md
@@ -170,6 +170,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | externalEtcd.secretPasswordKey | string | `"etcd-root-password"` | externalEtcd.secretPasswordKey Key inside the secret containing the external etcd password |
 | externalEtcd.user | string | `"root"` | if etcd.enabled is false, user for external etcd. Set empty to disable authentication |
 | extraContainers | list | `[]` | Additional `containers`, See [Kubernetes containers](https://kubernetes.io/docs/concepts/containers/) for the detail. |
+| extraDeploy | list | `[]` | Additional Kubernetes resources to deploy with the release. |
 | extraEnvVars | list | `[]` | extraEnvVars An array to add extra env vars e.g: extraEnvVars:   - name: FOO     value: "bar"   - name: FOO2     valueFrom:       secretKeyRef:         name: SECRET_NAME         key: KEY |
 | extraInitContainers | list | `[]` | Additional `initContainers`, See [Kubernetes initContainers](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/) for the detail. |
 | extraVolumeMounts | list | `[]` | Additional `volume`, See [Kubernetes Volumes](https://kubernetes.io/docs/concepts/storage/volumes/) for the detail. |

--- a/charts/apisix/templates/extra-list.yaml
+++ b/charts/apisix/templates/extra-list.yaml
@@ -1,0 +1,8 @@
+{{- range .Values.extraDeploy }}
+---
+{{- if typeIs "string" . }}
+  {{- tpl . $ }}
+{{- else }}
+  {{- tpl (. | toYaml) $ }}
+{{- end }}
+{{- end }}

--- a/charts/apisix/values.yaml
+++ b/charts/apisix/values.yaml
@@ -108,6 +108,9 @@ extraEnvVars: []
 updateStrategy: {}
   # type: RollingUpdate
 
+# -- Additional Kubernetes resources to deploy with the release.
+extraDeploy: []
+
 # -- Additional `volume`, See [Kubernetes Volumes](https://kubernetes.io/docs/concepts/storage/volumes/) for the detail.
 extraVolumes: []
 # - name: extras


### PR DESCRIPTION
The `extraDeploy` option is something that is available in many helm charts (expecially bitnami charts). It is useful for deploying extra resources with the release. E.g. with Apisix you could deploy ApisixGlobalRule.

This commit adds a very simple version of the extraDeploy.

E.g. Using as a string:

```
extraDeploy:
  - |
    apiVersion: apisix.apache.org/v2
    kind: ApisixGlobalRule
    metadata:
      name: global
    spec:
      plugins:
        - name: response-rewrite
          enable: true
          config:
            headers:
              remove:
                - Server
```

can also use it as a map:

```
  - apiVersion: apisix.apache.org/v2
    kind: ApisixGlobalRule
    metadata:
      name: global
    spec:
      plugins:
        - name: response-rewrite
          enable: true
          config:
            headers:
              remove:
                - Server
```