### PR TITLE
feat: allow adjusting nginx keepalive timeout

### DIFF
--- a/charts/apisix/README.md
+++ b/charts/apisix/README.md
@@ -107,6 +107,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | apisix.nginx.customLuaSharedDicts | list | `[]` | Add custom [lua_shared_dict](https://github.com/openresty/lua-nginx-module#toc88) settings, click [here](https://github.com/apache/apisix-helm-chart/blob/master/charts/apisix/values.yaml#L27-L30) to learn the format of a shared dict |
 | apisix.nginx.enableCPUAffinity | bool | `true` |  |
 | apisix.nginx.envs | list | `[]` |  |
+| apisix.nginx.keepaliveTimeout | string | `"60s"` | Timeout during which a keep-alive client connection will stay open on the server side. |
 | apisix.nginx.logs.accessLog | string | `"/dev/stdout"` | Access log path |
 | apisix.nginx.logs.accessLogFormat | string | `"$remote_addr - $remote_user [$time_local] $http_host \\\"$request\\\" $status $body_bytes_sent $request_time \\\"$http_referer\\\" \\\"$http_user_agent\\\" $upstream_addr $upstream_status $upstream_response_time \\\"$upstream_scheme://$upstream_host$upstream_uri\\\""` | Access log format |
 | apisix.nginx.logs.accessLogFormatEscape | string | `"default"` | Allows setting json or default characters escaping in variables |

--- a/charts/apisix/templates/configmap.yaml
+++ b/charts/apisix/templates/configmap.yaml
@@ -180,7 +180,7 @@ data:
         access_log_format: '{{ .Values.apisix.nginx.logs.accessLogFormat }}'
         access_log_format_escape: {{ .Values.apisix.nginx.logs.accessLogFormatEscape }}
         {{- end }}
-        keepalive_timeout: 60s         # timeout during which a keep-alive client connection will stay open on the server side.
+        keepalive_timeout: {{ .Values.apisix.nginx.keepaliveTimeout | quote }}
         client_header_timeout: 60s     # timeout for reading client request header, then 408 (Request Time-out) error is returned to the client
         client_body_timeout: 60s       # timeout for reading client request body, then 408 (Request Time-out) error is returned to the client
         send_timeout: 10s              # timeout for transmitting a response to the client.then the connection is closed

--- a/charts/apisix/values.yaml
+++ b/charts/apisix/values.yaml
@@ -385,6 +385,8 @@ apisix:
     workerConnections: "10620"
     workerProcesses: auto
     enableCPUAffinity: true
+    # -- Timeout during which a keep-alive client connection will stay open on the server side.
+    keepaliveTimeout: 60s
     envs: []
     # access log and error log configuration
     logs:


### PR DESCRIPTION
Depending on the setup, it can be useful to change this value. For example, if using load balancer which already has 60 second timeout, then this timeout should be larger to avoid ungraceful TCP connection closes.

This is the same as `upstream-keepalive-timeout` in ingress nginx controller.

E.g. From AWS [docs][1]:

> We also recommend that you configure the idle timeout of your
application to be larger than the idle timeout configured for the load balancer. Otherwise, if the application closes the TCP connection to the load balancer ungracefully, the load balancer might send a request to the application before it receives the packet indicating that the connection is closed. If this is the case, the server refuses the request from the load balancer and then the load balancer sends an HTTP 502 Bad Gateway error to the application.

[1]: https://docs.aws.amazon.com/elasticloadbalancing/latest/application/application-load-balancers.html#connection-idle-timeout