### PR TITLE
chore: update ApisixRoute crd paths pattern rule

### DIFF
--- a/charts/apisix-ingress-controller/crds/ApisixRoute.yaml
+++ b/charts/apisix-ingress-controller/crds/ApisixRoute.yaml
@@ -183,7 +183,7 @@ spec:
                             type: array
                           paths:
                             items:
-                              pattern: ^/[a-zA-Z0-9\-._~%!$&'()+,;=:@/]*\*?$
+                              pattern: ^/[a-zA-Z0-9\-._~%!$&'()+,;=:@/\*]*\*?$
                               type: string
                             minItems: 1
                             type: array
@@ -505,7 +505,7 @@ spec:
                             type: array
                           paths:
                             items:
-                              pattern: ^/[a-zA-Z0-9\-._~%!$&'()+,;=:@/]*\*?$
+                              pattern: ^/[a-zA-Z0-9\-._~%!$&'()+,;=:@/\*]*\*?$
                               type: string
                             minItems: 1
                             type: array


### PR DESCRIPTION
## Description
The current paths item pattern regex doesn't accept to have wildcards in the middle of the path, meanwhile it's possible to create this Apisix route calling the Apisix API or through Apisix Dashboard.

My currently issue is that I need to match the following URLs:
```
/my/api/country/br/cities
/my/api/country/us/cities
```

But with the current pattern set on the CRD, I'm not able to create the spec.http.match.paths `/my/api/country/*/cities`  through the CRD.