### PR TITLE
feat: auto populate ingress_publish_service when using etcdserver

### DIFF
--- a/charts/apisix-ingress-controller/templates/configmap.yaml
+++ b/charts/apisix-ingress-controller/templates/configmap.yaml
@@ -24,7 +24,11 @@ data:
     key_file: {{ .Values.config.keyFile | quote }}
     http_listen: {{ .Values.config.httpListen | quote }}
     https_listen: {{ .Values.config.httpsListen | quote }}
+    {{- if and (eq .Values.config.ingressPublishService "") (.Values.config.etcdserver.enabled)  }}
+    ingress_publish_service: {{ .Release.Namespace }}/{{ include "apisix-ingress-controller.fullname" . }}-apisix-gateway
+    {{- else }}
     ingress_publish_service: {{ .Values.config.ingressPublishService | quote }}
+    {{- end }}
     {{- if gt (len .Values.config.ingressStatusAddress) 0 }}
     ingress_status_address:
     {{- range .Values.config.ingressStatusAddress }}


### PR DESCRIPTION
When using the new composite architecture, ingress resources will throw out this error due to the service of the gateway not being set
```
error	ingress/ingress.go:502	failed to get APISIX gateway external IPs	{"error": "service \"\" not found"}
```

This PR set the `ingress_publish_service` to the default gateway service when etcdserver is enabled and the `ingressPublishService` values is empty