### PR TITLE
feat: add option to control fallback_sni

### DIFF
--- a/charts/apisix/README.md
+++ b/charts/apisix/README.md
@@ -115,6 +115,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | apisix.ssl.containerPort | int | `9443` |  |
 | apisix.ssl.enabled | bool | `false` |  |
 | apisix.ssl.existingCASecret | string | `""` | Specifies the name of Secret contains trusted CA certificates in the PEM format used to verify the certificate when APISIX needs to do SSL/TLS handshaking with external services (e.g. etcd) |
+| apisix.ssl.fallbackSNI | string | `""` | Define SNI to fallback if none is presented by client |
 | apisix.ssl.http2.enabled | bool | `true` |  |
 | apisix.ssl.sslProtocols | string | `"TLSv1.2 TLSv1.3"` | TLS protocols allowed to use. |
 | apisix.stream_plugins | list | `[]` | Customize the list of APISIX stream_plugins to enable. By default, APISIX's default stream_plugins are automatically used. See [config-default.yaml](https://github.com/apache/apisix/blob/master/conf/config-default.yaml) |

--- a/charts/apisix/templates/configmap.yaml
+++ b/charts/apisix/templates/configmap.yaml
@@ -158,6 +158,9 @@ data:
         {{- if and .Values.apisix.ssl.enabled .Values.apisix.ssl.existingCASecret }}
         ssl_trusted_certificate: "/usr/local/apisix/conf/ssl/{{ .Values.apisix.ssl.certCAFilename }}"
         {{- end }}
+        {{- if and .Values.apisix.ssl.enabled .Values.apisix.ssl.fallbackSNI }}
+        fallback_sni: {{ .Values.apisix.ssl.fallbackSNI | quote }}
+        {{- end }}
 
     nginx_config:    # config for render the template to genarate nginx.conf
       error_log: "{{ .Values.apisix.nginx.logs.errorLog }}"

--- a/charts/apisix/values.yaml
+++ b/charts/apisix/values.yaml
@@ -275,6 +275,8 @@ apisix:
       enabled: true
     # -- TLS protocols allowed to use.
     sslProtocols: "TLSv1.2 TLSv1.3"
+    # -- Define SNI to fallback if none is presented by client
+    fallbackSNI: ""
 
   router:
     # -- Defines how apisix handles routing:


### PR DESCRIPTION
This was introduced for the chart v1 in [546][1]. This commit introduced the same functionality for the chart v2 as well.

[1]: https://github.com/apache/apisix-helm-chart/pull/546