### PR TITLE
feat: apisix dashboard custom plugins configuration support

### DIFF
--- a/charts/apisix-dashboard/README.md
+++ b/charts/apisix-dashboard/README.md
@@ -73,6 +73,8 @@ _See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command documen
 | config.conf.log.accessLog.filePath | string | `"/dev/stdout"` | Error log path |
 | config.conf.log.errorLog | object | `{"filePath":"/dev/stderr","level":"warn"}` | Error log level. Supports levels, lower to higher: debug, info, warn, error, panic, fatal |
 | config.conf.log.errorLog.filePath | string | `"/dev/stderr"` | Access log path |
+| config.conf.plugins | list | `[]` |  |
+| config.schema.configMapRef | object | `{}` |  |
 | fullnameOverride | string | `""` | String to fully override apisix-dashboard.fullname template |
 | image.pullPolicy | string | `"IfNotPresent"` | Apache APISIX Dashboard image pull policy |
 | image.repository | string | `"apache/apisix-dashboard"` | Apache APISIX Dashboard image repository |

--- a/charts/apisix-dashboard/README.md
+++ b/charts/apisix-dashboard/README.md
@@ -73,8 +73,8 @@ _See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command documen
 | config.conf.log.accessLog.filePath | string | `"/dev/stdout"` | Error log path |
 | config.conf.log.errorLog | object | `{"filePath":"/dev/stderr","level":"warn"}` | Error log level. Supports levels, lower to higher: debug, info, warn, error, panic, fatal |
 | config.conf.log.errorLog.filePath | string | `"/dev/stderr"` | Access log path |
-| config.conf.plugins | list | `[]` |  |
-| config.schema.configMapRef | object | `{}` |  |
+| config.conf.plugins | list | `[]` | Overrides plugins in the APISIX Dashboard conf |
+| config.schema.configMap | object | `{}` | Overrides APISIX Dashboard schema.json  by mounting configMap containing schema.json |
 | fullnameOverride | string | `""` | String to fully override apisix-dashboard.fullname template |
 | image.pullPolicy | string | `"IfNotPresent"` | Apache APISIX Dashboard image pull policy |
 | image.repository | string | `"apache/apisix-dashboard"` | Apache APISIX Dashboard image repository |

--- a/charts/apisix-dashboard/README.md
+++ b/charts/apisix-dashboard/README.md
@@ -74,7 +74,7 @@ _See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command documen
 | config.conf.log.errorLog | object | `{"filePath":"/dev/stderr","level":"warn"}` | Error log level. Supports levels, lower to higher: debug, info, warn, error, panic, fatal |
 | config.conf.log.errorLog.filePath | string | `"/dev/stderr"` | Access log path |
 | config.conf.plugins | list | `[]` | Overrides plugins in the APISIX Dashboard conf |
-| config.schema.configMap | object | `{}` | Overrides APISIX Dashboard schema.json  by mounting configMap containing schema.json |
+| config.schema.configMap | object | `{}` | Overrides APISIX Dashboard schema.json by mounting configMap containing schema.json |
 | fullnameOverride | string | `""` | String to fully override apisix-dashboard.fullname template |
 | image.pullPolicy | string | `"IfNotPresent"` | Apache APISIX Dashboard image pull policy |
 | image.repository | string | `"apache/apisix-dashboard"` | Apache APISIX Dashboard image repository |

--- a/charts/apisix-dashboard/templates/configmap.yaml
+++ b/charts/apisix-dashboard/templates/configmap.yaml
@@ -65,7 +65,9 @@ data:
           password: {{ .password }}
         {{- end }}
     {{- end }}
+    {{- with .Values.config.conf.plugins }}
     plugins:
-      {{- range .Values.config.conf.plugins }}
+      {{- range . }}
       - {{ . }}
       {{- end }}
+    {{- end }}

--- a/charts/apisix-dashboard/templates/configmap.yaml
+++ b/charts/apisix-dashboard/templates/configmap.yaml
@@ -65,3 +65,7 @@ data:
           password: {{ .password }}
         {{- end }}
     {{- end }}
+    plugins:
+      {{- range .Values.config.conf.plugins }}
+      - {{ . }}
+      {{- end }}

--- a/charts/apisix-dashboard/templates/deployment.yaml
+++ b/charts/apisix-dashboard/templates/deployment.yaml
@@ -77,6 +77,10 @@ spec:
             - mountPath: /usr/local/apisix-dashboard/conf/conf.yaml
               name: apisix-dashboard-config
               subPath: conf.yaml
+          {{- if .Values.config.schema.configMapRef }}
+            - mountPath: /usr/local/apisix-dashboard/conf/schema.json
+              name: schema-json
+          {{- end}}
           {{- if .Values.config.conf.etcd.mtlsExistingSecret }}
             - mountPath: /etc/etcd
               name: etcd-config
@@ -85,6 +89,11 @@ spec:
         - configMap:
             name: {{ include "apisix-dashboard.fullname" . }}
           name: apisix-dashboard-config
+      {{- if .Values.config.schema.configMapRef }}
+        - configMap:
+            name: {{ .Values.config.schema.configMapRef }}
+          name: schema-json
+      {{- end}}
       {{- if .Values.config.conf.etcd.mtlsExistingSecret }}
         - secret:
             secretName: {{ .Values.config.conf.etcd.mtlsExistingSecret }}

--- a/charts/apisix-dashboard/templates/deployment.yaml
+++ b/charts/apisix-dashboard/templates/deployment.yaml
@@ -77,9 +77,10 @@ spec:
             - mountPath: /usr/local/apisix-dashboard/conf/conf.yaml
               name: apisix-dashboard-config
               subPath: conf.yaml
-          {{- if .Values.config.schema.configMapRef }}
+          {{- with .Values.config.schema.configMap }}
             - mountPath: /usr/local/apisix-dashboard/conf/schema.json
               name: schema-json
+              subPath: {{ .key }}
           {{- end}}
           {{- if .Values.config.conf.etcd.mtlsExistingSecret }}
             - mountPath: /etc/etcd
@@ -89,9 +90,9 @@ spec:
         - configMap:
             name: {{ include "apisix-dashboard.fullname" . }}
           name: apisix-dashboard-config
-      {{- if .Values.config.schema.configMapRef }}
+      {{- with .Values.config.schema.configMap }}
         - configMap:
-            name: {{ .Values.config.schema.configMapRef }}
+            name: {{ .name }}
           name: schema-json
       {{- end}}
       {{- if .Values.config.conf.etcd.mtlsExistingSecret }}

--- a/charts/apisix-dashboard/values.yaml
+++ b/charts/apisix-dashboard/values.yaml
@@ -71,8 +71,10 @@ securityContext: {}
   # runAsUser: 1000
 
 config:
-  schema: 
-    configMapRef: {}
+  schema:
+    # -- Overrides APISIX Dashboard schema.json 
+    # by mounting configMap containing schema.json
+    configMap: {}
       # name: apisix-dashboard-schema
       # key: schema.json
   conf:
@@ -113,6 +115,7 @@ config:
       accessLog:
         # -- Error log path
         filePath: /dev/stdout
+    # -- Overrides plugins in the APISIX Dashboard conf
     plugins: []
   authentication:
     # -- Secret for jwt token generation

--- a/charts/apisix-dashboard/values.yaml
+++ b/charts/apisix-dashboard/values.yaml
@@ -72,7 +72,7 @@ securityContext: {}
 
 config:
   schema:
-    # -- Overrides APISIX Dashboard schema.json 
+    # -- Overrides APISIX Dashboard schema.json
     # by mounting configMap containing schema.json
     configMap: {}
       # name: apisix-dashboard-schema

--- a/charts/apisix-dashboard/values.yaml
+++ b/charts/apisix-dashboard/values.yaml
@@ -71,6 +71,10 @@ securityContext: {}
   # runAsUser: 1000
 
 config:
+  schema: 
+    configMapRef: {}
+      # name: apisix-dashboard-schema
+      # key: schema.json
   conf:
     listen:
       # -- The address on which the Manager API should listen.

--- a/charts/apisix-dashboard/values.yaml
+++ b/charts/apisix-dashboard/values.yaml
@@ -109,7 +109,7 @@ config:
       accessLog:
         # -- Error log path
         filePath: /dev/stdout
-
+    plugins: []
   authentication:
     # -- Secret for jwt token generation
     secret: secret


### PR DESCRIPTION
In more custom apisix deployments with custom plugins being used overriding schema.json and plugins in the configuration are useful features.

- feat: add support for plugins conf
- feat: add support for mounting custom schema.json
- docs: update apisix-dashboard docs