### PR TITLE
fix: delete the condition of deployment role

### DIFF
--- a/charts/apisix/templates/configmap.yaml
+++ b/charts/apisix/templates/configmap.yaml
@@ -296,7 +296,6 @@ data:
 
     deployment:
       role: {{ .Values.deployment.role }}
-      {{- if or (eq .Values.deployment.role "traditional") (eq .Values.deployment.role "control_plane") }}
 
       {{- if eq .Values.deployment.role "traditional" }}
       role_traditional:
@@ -305,6 +304,11 @@ data:
 
       {{- if eq .Values.deployment.role "control_plane" }}
       role_control_plane:
+        config_provider: etcd
+      {{- end }}
+
+      {{- if eq .Values.deployment.role "data_plane" }}
+      role_data_plane:
         config_provider: etcd
       {{- end }}
 
@@ -348,7 +352,6 @@ data:
             {{- end }}
             role: viewer
 
-      {{- if not (eq .Values.deployment.role "data_plane") }}
       etcd:
       {{- if .Values.etcd.enabled }}
         host:                          # it's possible to define multiple etcd hosts addresses of the same etcd cluster.
@@ -373,13 +376,7 @@ data:
           verify: {{ .Values.etcd.auth.tls.verify }}
           sni: "{{ .Values.etcd.auth.tls.sni }}"
         {{- end }}
-    {{- end }}
-    {{- end }}
       {{- end }}
 
-      {{- if eq .Values.deployment.role "data_plane" }}
-      role_data_plane:
-        config_provider: etcd
-      {{- end }}
-
+      
 {{- end }}


### PR DESCRIPTION
Before: we can't generate `etcd` config in config-map.
So we should delete the condition of deployment role.