### PR TITLE
improve: don't add admin block if the role is data plane

### DIFF
--- a/charts/apisix/templates/configmap.yaml
+++ b/charts/apisix/templates/configmap.yaml
@@ -312,6 +312,7 @@ data:
         config_provider: etcd
       {{- end }}
 
+      {{- if not (eq .Values.deployment.role "data_plane") }}
       admin:
         allow_admin:    # http://nginx.org/en/docs/http/ngx_http_access_module.html#allow
         {{- if .Values.admin.allow.ipList }}
@@ -351,6 +352,7 @@ data:
             key: {{ .Values.admin.credentials.viewer }}
             {{- end }}
             role: viewer
+      {{- end }}
 
       etcd:
       {{- if .Values.etcd.enabled }}


### PR DESCRIPTION
Before this PR: apisix-helm-chart will generate the config as follow:

```
`
 deployment:
      role: data_plane
      role_data_plane:
        config_provider: etcd

      admin:
        allow_admin:    # http://nginx.org/en/docs/http/ngx_http_access_module.html#allow
          - 127.0.0.1/24
        #   - "::/64"
        admin_listen:
          ip: 0.0.0.0
          port: 9180
        # Default token when use API to call for Admin API.
        # *NOTE*: Highly recommended to modify this value to protect APISIX's Admin API.
        # Disabling this configuration item means that the Admin API does not
        # require any authentication.
        admin_key:
          # admin: can everything for configuration data
          - name: "admin"
            key: edd1c9f034335f136f87ad84b625c8f1
            role: admin
          # viewer: only can view configuration data
          - name: "viewer"
            key: 4054f7cf07e344346cd3f287985e76a2
            role: viewer

      etcd:
        host:                          # it's possible to define multiple etcd hosts addresses of the same etcd cluster.
          - "http://apisix-etcd.default.svc.cluster.local:2379"
        prefix: "/apisix"    # configuration prefix in etcd
        timeout: 30    # 30 seconds``
```

After this PR:

```
deployment:
  role: data_plane
  role_data_plane:
    config_provider: etcd

  etcd:
    host:                          # it's possible to define multiple etcd hosts addresses of the same etcd cluster.
      - "http://test4-etcd.default.svc.cluster.local:2379"
    prefix: "/apisix"    # configuration prefix in etcd
    timeout: 30    # 30 second
```