### PR TITLE
chore: bump apisix-ingress-controller to 0.13.0

### DIFF
--- a/charts/apisix-ingress-controller/Chart.yaml
+++ b/charts/apisix-ingress-controller/Chart.yaml
@@ -24,7 +24,7 @@ keywords:
   - nginx
   - crd
 type: application
-version: 0.12.2
+version: 0.13.0
 appVersion: 1.7.1
 sources:
   - https://github.com/apache/apisix-helm-chart

--- a/charts/apisix-ingress-controller/Chart.yaml
+++ b/charts/apisix-ingress-controller/Chart.yaml
@@ -25,7 +25,7 @@ keywords:
   - crd
 type: application
 version: 0.12.2
-appVersion: 1.7.0
+appVersion: 1.7.1
 sources:
   - https://github.com/apache/apisix-helm-chart
 

--- a/charts/apisix-ingress-controller/README.md
+++ b/charts/apisix-ingress-controller/README.md
@@ -163,7 +163,7 @@ The same for container level, you need to set:
 | gateway.type | string | `"NodePort"` | Apache APISIX service type for user access itself |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"apache/apisix-ingress-controller"` |  |
-| image.tag | string | `"1.7.0"` |  |
+| image.tag | string | `"1.7.1"` |  |
 | imagePullSecrets | list | `[]` |  |
 | initContainer.image | string | `"busybox"` |  |
 | initContainer.tag | float | `1.28` |  |

--- a/charts/apisix-ingress-controller/values.yaml
+++ b/charts/apisix-ingress-controller/values.yaml
@@ -48,7 +48,7 @@ replicaCount: 1
 image:
   repository: apache/apisix-ingress-controller
   pullPolicy: IfNotPresent
-  tag: "1.7.0"
+  tag: "1.7.1"
 
 podAnnotations: {}
 


### PR DESCRIPTION
Changes since 0.12.2:
* 0c05e7c feat: support configure gateway.tls and adding ingress class (#657)
* 2461821 feat: adding nginx configuration & gateway type in composite architecture  (#644)
* f70b01b fix: plugin_metadata_cm path (#646)
* 2ba669d feat: auto populate ingress_publish_service when using etcdserver (#643)
* c2d4f35 chore: update ApisixRoute crd paths pattern rule (#638)
* a54c769 Enable promethus plugins for service monitoring (#632)
* be31a91 docs: specify ServiceMonitor requirements in values.yaml (#585)

We need the update because of the plugin_metadata_cm fix. Otherwise, we cannot enable datadog metrics.