### PR TITLE
feat: timezone and extra env vars configurable in apisix ingress controller

### DIFF
--- a/charts/apisix-ingress-controller/README.md
+++ b/charts/apisix-ingress-controller/README.md
@@ -143,6 +143,7 @@ The same for container level, you need to set:
 | config.logLevel | string | `"info"` | the error log level, default is info, optional values are: debug, info, warn, error, panic, fatal |
 | config.logOutput | string | `"stderr"` | the output file path of error log, default is stderr, when the file path is "stderr" or "stdout", logs are marshalled plainly, which is more readable for human; otherwise logs are marshalled in JSON format, which can be parsed by programs easily. |
 | config.pluginMetadataCM | string | `""` | Pluginmetadata in APISIX can be controlled through ConfigMap. default is "" |
+| extraEnvVars | list | `[]` | extraEnvVars An array to add extra env vars e.g: extraEnvVars:   - name: FOO     value: "bar"   - name: FOO2     valueFrom:       secretKeyRef:         name: SECRET_NAME         key: KEY |
 | fullnameOverride | string | `""` |  |
 | gateway.externalIPs | list | `[]` | load balancer ips |
 | gateway.externalTrafficPolicy | string | `"Cluster"` |  |
@@ -185,6 +186,7 @@ The same for container level, you need to set:
 | serviceMonitor.annotations | object | `{}` | @param serviceMonitor.annotations ServiceMonitor annotations |
 | serviceMonitor.labels | object | `{}` | @param serviceMonitor.labels ServiceMonitor extra labels |
 | serviceMonitor.metricRelabelings | object | `{}` | @param serviceMonitor.metricRelabelings MetricRelabelConfigs to apply to samples before ingestion. ref: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs |
+| timezone | string | `""` | timezone is the timezone where apisix uses. For example: "UTC" or "Asia/Shanghai" This value will be set on apisix-ingress-controller container's environment variable TZ. You may need to set the timezone to be consistent with your local time zone, otherwise the apisix-ingress-controller's logs may be used to retrieve event in wrong timezone. |
 | tolerations | list | `[]` |  |
 | topologySpreadConstraints | list | `[]` | Topology Spread Constraints for pod assignment spread across your cluster among failure-domains ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/#spread-constraints-for-pods |
 | updateStrategy | object | `{}` | Update strategy for apisix ingress controller deployment |

--- a/charts/apisix-ingress-controller/templates/_helpers.tpl
+++ b/charts/apisix-ingress-controller/templates/_helpers.tpl
@@ -96,3 +96,16 @@ Key to use to fetch admin token from secret
 {{- "adminKey" }}
 {{- end }}
 {{- end }}
+
+{{/*
+Renders a value that contains template.
+Usage:
+{{ include "apisix-ingress-controller.tplvalues.render" ( dict "value" .Values.path.to.the.Value "context" $) }}
+*/}}
+{{- define "apisix-ingress-controller.tplvalues.render" -}}
+    {{- if typeIs "string" .value }}
+        {{- tpl .value .context }}
+    {{- else }}
+        {{- tpl (.value | toYaml) .context }}
+    {{- end }}
+{{- end -}}

--- a/charts/apisix-ingress-controller/templates/deployment.yaml
+++ b/charts/apisix-ingress-controller/templates/deployment.yaml
@@ -121,6 +121,13 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.name
+          {{- if .Values.timezone }}
+          - name: TZ
+            value: {{ .Values.timezone }}
+          {{- end }}
+          {{- if .Values.extraEnvVars }}
+          {{- include "apisix-ingress-controller.tplvalues.render" (dict "value" .Values.extraEnvVars "context" $) | nindent 10 }}
+          {{- end }}
           {{- if .Values.config.apisix.existingSecret }}
           - name: DEFAULT_CLUSTER_ADMIN_KEY
             valueFrom:

--- a/charts/apisix-ingress-controller/values.yaml
+++ b/charts/apisix-ingress-controller/values.yaml
@@ -183,6 +183,25 @@ affinity: {}
 # ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/#spread-constraints-for-pods
 topologySpreadConstraints: []
 
+# -- timezone is the timezone where apisix uses.
+# For example: "UTC" or "Asia/Shanghai"
+# This value will be set on apisix-ingress-controller container's environment variable TZ.
+# You may need to set the timezone to be consistent with your local time zone,
+# otherwise the apisix-ingress-controller's logs may be used to retrieve event in wrong timezone.
+timezone: ""
+
+# -- extraEnvVars An array to add extra env vars
+# e.g:
+# extraEnvVars:
+#   - name: FOO
+#     value: "bar"
+#   - name: FOO2
+#     valueFrom:
+#       secretKeyRef:
+#         name: SECRET_NAME
+#         key: KEY
+extraEnvVars: []
+
 #  namespace: "ingress-apisix"
 
 # -- Enable creating ServiceMonitor objects for Prometheus operator.


### PR DESCRIPTION
Apisix helm chart has TZ and extra env vars config, these would be useful in apisix-ingress-controller too.
Currently it runs in UTC+8, we would like to set it to another timezone.
issue: https://github.com/apache/apisix-helm-chart/issues/681