### PR TITLE
feat: Capable of overriding the configurations of the nginx http `lua_shared_dict`

### DIFF
--- a/charts/apisix/README.md
+++ b/charts/apisix/README.md
@@ -57,7 +57,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | admin.servicePort | int | `9180` | Service port to use for Apache APISIX admin API |
 | admin.type | string | `"ClusterIP"` | admin service type |
 | apisix.affinity | object | `{}` | Set affinity for Apache APISIX deploy |
-| apisix.customLuaSharedDicts | list | `[]` | Add custom [lua_shared_dict](https://github.com/openresty/lua-nginx-module#toc88) settings, click [here](https://github.com/apache/apisix-helm-chart/blob/master/charts/apisix/values.yaml#L27-L30) to learn the format of a shared dict |
+| apisix.customLuaSharedDicts | list | `[]` | Add custom [lua_shared_dict](https://github.com/openresty/lua-nginx-module#toc88) settings, click [here](https://github.com/apache/apisix-helm-chart/blob/master/charts/apisix/values.yaml#L48-L51) to learn the format of a shared dict |
 | apisix.customizedConfig | object | `{}` | If apisix.enableCustomizedConfig is true, full customized config.yaml. Please note that other settings about APISIX config will be ignored |
 | apisix.data_encryption | object | `{"enabled":false,"keyring":[]}` | Enable Data Encryption |
 | apisix.data_encryption.keyring | list | `[]` | An array of 16 character strings used to encrypt/decrypt fields with AES-128-CBC |
@@ -79,6 +79,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | apisix.luaModuleHook.configMapRef.name | string | `""` | Name of the ConfigMap where the lua module codes store |
 | apisix.luaModuleHook.hookPoint | string | `""` | the hook module which will be used to inject third party code into APISIX use the lua require style like: "module.say_hello" |
 | apisix.luaModuleHook.luaPath | string | `""` | extend lua_package_path to load third party code |
+| apisix.luaSharedDictsOverride | object | `{}` | Overrides [lua_shared_dict](https://github.com/openresty/lua-nginx-module#toc88) settings, click [here](https://github.com/apache/apisix/blob/master/conf/config-default.yaml#L258) to view the default values. |
 | apisix.nodeSelector | object | `{}` | Node labels for Apache APISIX pod assignment |
 | apisix.podAnnotations | object | `{}` | Annotations to add to each pod |
 | apisix.podDisruptionBudget | object | `{"enabled":false,"maxUnavailable":1,"minAvailable":"90%"}` | See https://kubernetes.io/docs/tasks/run-application/configure-pdb/ for more details |

--- a/charts/apisix/templates/configmap.yaml
+++ b/charts/apisix/templates/configmap.yaml
@@ -216,6 +216,9 @@ data:
           {{ $dict.name }}: {{ $dict.size }}
         {{- end }}
         {{- end }}
+        {{- if .Values.apisix.luaSharedDictsOverride }}
+        lua_shared_dict: {{- toYaml .Values.apisix.luaSharedDictsOverride | nindent 10 }}
+        {{- end }}
       {{- if .Values.configurationSnippet.main }}
       main_configuration_snippet: {{- toYaml .Values.configurationSnippet.main | indent 6 }}
       {{- end }}

--- a/charts/apisix/values.yaml
+++ b/charts/apisix/values.yaml
@@ -46,7 +46,7 @@ apisix:
   # click [here](https://github.com/apache/apisix-helm-chart/blob/master/charts/apisix/values.yaml#L48-L51) to learn the format of a shared dict
   customLuaSharedDicts: []
     # - name: foo
-      # size: 10k
+    #   size: 10k
     # - name: bar
     #   size: 1m
   # -- Overrides [lua_shared_dict](https://github.com/openresty/lua-nginx-module#toc88) settings,

--- a/charts/apisix/values.yaml
+++ b/charts/apisix/values.yaml
@@ -43,12 +43,16 @@ apisix:
   setIDFromPodUID: false
 
   # -- Add custom [lua_shared_dict](https://github.com/openresty/lua-nginx-module#toc88) settings,
-  # click [here](https://github.com/apache/apisix-helm-chart/blob/master/charts/apisix/values.yaml#L27-L30) to learn the format of a shared dict
+  # click [here](https://github.com/apache/apisix-helm-chart/blob/master/charts/apisix/values.yaml#L48-L51) to learn the format of a shared dict
   customLuaSharedDicts: []
     # - name: foo
-    #   size: 10k
+      # size: 10k
     # - name: bar
     #   size: 1m
+  # -- Overrides [lua_shared_dict](https://github.com/openresty/lua-nginx-module#toc88) settings,
+  # click [here](https://github.com/apache/apisix/blob/master/conf/config-default.yaml#L258) to view the default values.
+  luaSharedDictsOverride: {}
+    # prometheus-metrics: 100m
   # -- Whether to add a custom lua module
   luaModuleHook:
     enabled: false


### PR DESCRIPTION
### feat: Capable of overriding the configurations of the nginx http `lua_shared_dict`

The Lua shared dictionary `prometheus-metrics` is initially configured with a default size of `10m` as specified in the [config-default.yaml](https://github.com/apache/apisix/blob/master/conf/config-default.yaml#L262) file. However, due to the growing number of routes, the dictionary size has been exceeded. Hence, customization of this configuration would prove advantageous.
