### PR TITLE
feat: Capable of overriding the configurations of the nginx http `lua_shared_dict`

### DIFF
--- a/charts/apisix/README.md
+++ b/charts/apisix/README.md
@@ -89,7 +89,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | apisix.luaModuleHook.hookPoint | string | `""` | the hook module which will be used to inject third party code into APISIX use the lua require style like: "module.say_hello" |
 | apisix.luaModuleHook.luaPath | string | `""` | extend lua_package_path to load third party code |
 | apisix.nginx.configurationSnippet | object | `{"httpAdmin":"","httpEnd":"","httpSrv":"","httpStart":"","main":"","stream":""}` | Custom configuration snippet. |
-| apisix.nginx.customLuaSharedDicts | list | `[]` | Add custom [lua_shared_dict](https://github.com/openresty/lua-nginx-module#toc88) settings, click [here](https://github.com/apache/apisix-helm-chart/blob/master/charts/apisix/values.yaml#L27-L30) to learn the format of a shared dict |
+| apisix.nginx.customLuaSharedDicts | list | `[]` | Add custom [lua_shared_dict](https://github.com/openresty/lua-nginx-module#toc88) settings, click [here](https://github.com/apache/apisix-helm-chart/blob/master/charts/apisix/values.yaml#L48-L51) to learn the format of a shared dict |
 | apisix.nginx.enableCPUAffinity | bool | `true` |  |
 | apisix.nginx.envs | list | `[]` |  |
 | apisix.nginx.keepaliveTimeout | string | `"60s"` | Timeout during which a keep-alive client connection will stay open on the server side. |
@@ -99,6 +99,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | apisix.nginx.logs.enableAccessLog | bool | `true` | Enable access log or not, default true |
 | apisix.nginx.logs.errorLog | string | `"/dev/stderr"` | Error log path |
 | apisix.nginx.logs.errorLogLevel | string | `"warn"` | Error log level |
+| apisix.nginx.luaSharedDictsOverride | object | `{}` | Overrides [lua_shared_dict](https://github.com/openresty/lua-nginx-module#toc88) settings, click [here](https://github.com/apache/apisix/blob/master/conf/config-default.yaml#L258) to view the default values. |
 | apisix.nginx.workerConnections | string | `"10620"` |  |
 | apisix.nginx.workerProcesses | string | `"auto"` |  |
 | apisix.nginx.workerRlimitNofile | string | `"20480"` |  |

--- a/charts/apisix/templates/configmap.yaml
+++ b/charts/apisix/templates/configmap.yaml
@@ -198,6 +198,9 @@ data:
           {{ $dict.name }}: {{ $dict.size }}
         {{- end }}
         {{- end }}
+        {{- if .Values.apisix.nginx.luaSharedDictsOverride }}
+        lua_shared_dict: {{- toYaml .Values.apisix.nginx.luaSharedDictsOverride | nindent 10 }}
+        {{- end }}
       {{- if .Values.apisix.nginx.configurationSnippet.main }}
       main_configuration_snippet: {{- toYaml .Values.apisix.nginx.configurationSnippet.main | indent 6 }}
       {{- end }}

--- a/charts/apisix/values.yaml
+++ b/charts/apisix/values.yaml
@@ -392,12 +392,17 @@ apisix:
       stream: |
 
     # -- Add custom [lua_shared_dict](https://github.com/openresty/lua-nginx-module#toc88) settings,
-    # click [here](https://github.com/apache/apisix-helm-chart/blob/master/charts/apisix/values.yaml#L27-L30) to learn the format of a shared dict
+    # click [here](https://github.com/apache/apisix-helm-chart/blob/master/charts/apisix/values.yaml#L48-L51) to learn the format of a shared dict
     customLuaSharedDicts: []
       # - name: foo
       #   size: 10k
       # - name: bar
       #   size: 1m
+
+    # -- Overrides [lua_shared_dict](https://github.com/openresty/lua-nginx-module#toc88) settings,
+    # click [here](https://github.com/apache/apisix/blob/master/conf/config-default.yaml#L258) to view the default values.
+    luaSharedDictsOverride: {}
+      # prometheus-metrics: 100m
 
   discovery:
     # -- Enable or disable Apache APISIX integration service discovery


### PR DESCRIPTION
### feat: Capable of overriding the configurations of the nginx http `lua_shared_dict`

The Lua shared dictionary `prometheus-metrics` is initially configured with a default size of `10m` as specified in the [config-default.yaml](https://github.com/apache/apisix/blob/master/conf/config-default.yaml#L262) file. However, due to the growing number of routes, the dictionary size has been exceeded. Hence, customization of this configuration would prove advantageous.
