### PR TITLE
feat: Support config merge from Kubernetes Secret

### DIFF
--- a/charts/apisix-dashboard/templates/configmap.yaml
+++ b/charts/apisix-dashboard/templates/configmap.yaml
@@ -25,49 +25,10 @@ data:
   conf.yaml: |-
     {{- with .Values.config.conf }}
     conf:
-      listen:
-        host: {{ .listen.host }}
-        port: {{ .listen.port }}
-      {{- with .etcd }}
-      etcd:
-        prefix: {{ .prefix | quote }}
-        endpoints:
-          {{- range .endpoints }}
-          - {{ . }}
-          {{- end }}
-        {{- if .username }}
-        username: {{ .username }}
-        {{- end }}
-        {{- if .password }}
-        password: {{ .password }}
-        {{- end }}
-        {{- if .mtls }}
-        mtls:
-          {{- toYaml .mtls | nindent 10 }}
-        {{- end }}
-      {{- end }}
-      {{- with .log }}
-      log:
-        error_log:
-          level: {{ .errorLog.level }}
-          file_path: {{ .errorLog.filePath }}
-        access_log:
-          file_path: {{ .accessLog.filePath }}
-      {{- end }}
+    {{- . | toYaml | nindent 6 }}
     {{- end }}
+
     {{- with .Values.config.authentication }}
     authentication:
-      secret: {{ .secret }}
-      expire_time: {{ .expireTime }}
-      users:
-        {{- range .users }}
-        - username: {{ .username }}
-          password: {{ .password }}
-        {{- end }}
-    {{- end }}
-    {{- with .Values.config.conf.plugins }}
-    plugins:
-      {{- range . }}
-      - {{ . }}
-      {{- end }}
+    {{- . | toYaml | nindent 6 }}
     {{- end }}

--- a/charts/apisix-dashboard/templates/deployment.yaml
+++ b/charts/apisix-dashboard/templates/deployment.yaml
@@ -53,12 +53,42 @@ spec:
       serviceAccountName: {{ include "apisix-dashboard.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{/* Merge config and secret only when the user needs it */}}
+      {{- if and .Values.config.mergedConfigSecret.name .Values.config.mergedConfigSecret.key }}
+      initContainers:
+        - name: config-builder
+          image: mikefarah/yq
+          command: [ "/bin/sh" ]
+          args:
+            - -c
+            - |
+              yq '. *= load("/tmp/conf.yaml")' {{ printf "/tmp/%s" .Values.config.mergedConfigSecret.key }} > /usr/local/apisix-dashboard/alternative-conf/conf.yaml
+          volumeMounts:
+            - mountPath: /tmp/conf.yaml
+              name: apisix-dashboard-config
+              subPath: conf.yaml
+            - mountPath: {{ printf "/tmp/%s" .Values.config.mergedConfigSecret.key | quote }}
+              name: apisix-dashboard-credentials
+              subPath: {{ .Values.config.mergedConfigSecret.key | quote }}
+            - mountPath: /usr/local/apisix-dashboard/alternative-conf/
+              name: config-data
+
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - /usr/local/apisix-dashboard/manager-api
+
+          {{/* Use alternative config file when configuration merge is performed*/}}
+          {{- if and .Values.config.mergedConfigSecret.name .Values.config.mergedConfigSecret.key }}
+          args:
+            - --config
+            - /usr/local/apisix-dashboard/alternative-conf/conf.yaml
+          {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.config.conf.listen.port }}
@@ -86,6 +116,11 @@ spec:
             - mountPath: /etc/etcd
               name: etcd-config
           {{- end}}
+          {{/* Config merge is performed so load the config into another directory */}}
+          {{- if and .Values.config.mergedConfigSecret.name .Values.config.mergedConfigSecret.key }}
+            - mountPath: /usr/local/apisix-dashboard/alternative-conf/
+              name: config-data
+          {{- end }}
       volumes:
         - configMap:
             name: {{ include "apisix-dashboard.fullname" . }}
@@ -100,6 +135,14 @@ spec:
             secretName: {{ .Values.config.conf.etcd.mtlsExistingSecret }}
           name: etcd-config
       {{- end}}
+      {{/* Config merge is performed so TODO */}}
+      {{- if and .Values.config.mergedConfigSecret.name .Values.config.mergedConfigSecret.key }}
+        - name: apisix-dashboard-credentials
+          secret:
+            secretName: {{ .Values.config.mergedConfigSecret.name }}
+        - name: config-data
+          emptyDir: {}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/apisix-dashboard/values.yaml
+++ b/charts/apisix-dashboard/values.yaml
@@ -71,6 +71,19 @@ securityContext: {}
   # runAsUser: 1000
 
 config:
+  # -- Describe an existing Kubernetes Secret with config params to be merged with the main config section
+  # Useful to provide fields which contain credentials that should be secret
+  # Syntax is the same as fields: config.conf and config.authentication.
+  # For example, the key 'conf.authentication.credentials.yaml' inside Secret 'apisix-dashboard'
+  # could contain the following syntax:
+  # authentication:
+  #   users:
+  #     - username: admin
+  #       password: password
+  mergedConfigSecret: {}
+  #name: "apisix-dashboard"
+  #key: "conf.authentication.credentials.yaml"
+
   schema:
     # -- Overrides APISIX Dashboard schema.json
     # by mounting configMap containing schema.json
@@ -97,7 +110,7 @@ config:
       password: ~
 
       # -- Specifies a secret to be mounted on /etc/etcd for mtls usage
-      mtlsExistingSecret: ""
+      mtls_existing_secret: ""
 
       # MTLS configuration used for external etcd instances
       mtls:
@@ -108,20 +121,20 @@ config:
     log:
       # -- Error log level.
       # Supports levels, lower to higher: debug, info, warn, error, panic, fatal
-      errorLog:
+      error_log:
         level: warn
         # -- Access log path
-        filePath: /dev/stderr
-      accessLog:
+        file_path: /dev/stderr
+      access_log:
         # -- Error log path
-        filePath: /dev/stdout
+        file_ath: /dev/stdout
     # -- Overrides plugins in the APISIX Dashboard conf
     plugins: []
   authentication:
     # -- Secret for jwt token generation
     secret: secret
     # -- JWT token expire time, in second
-    expireTime: 3600
+    expire_time: 3600
     # -- Specifies username and password for login manager api.
     users:
       - username: admin


### PR DESCRIPTION
Hello,

We have detected that some of the credentials regarding configuration are hardcoded on `values.yaml`. We needed to fix this for our company as we use ExternalSecrets operator to provide the credentials dynamically to the Kubernetes clusters. 

We have patched the Helm chart to be able to merge some config coming from a Kubernetes Secret with the main config coming from the dashboard's configmap. This way we cover all the potential secret fields across config (etc, authentication users, etc)

For merging we are using the official `yq` image so we expect you like it

WDYT about changes?