### PR TITLE
feat: allow to configure gateway.resources

### DIFF
--- a/charts/apisix-ingress-controller/README.md
+++ b/charts/apisix-ingress-controller/README.md
@@ -152,6 +152,7 @@ The same for container level, you need to set:
 | gateway.nginx.workerConnections | string | `"10620"` | Nginx worker connections |
 | gateway.nginx.workerProcesses | string | `"auto"` | Nginx worker processes |
 | gateway.nginx.workerRlimitNofile | string | `"20480"` | Nginx workerRlimitNoFile |
+| gateway.resources | object | `{}` |  |
 | gateway.securityContext | object | `{}` |  |
 | gateway.tls.additionalContainerPorts | list | `[]` | Support multiple https ports, See [Configuration](https://github.com/apache/apisix/blob/0bc65ea9acd726f79f80ae0abd8f50b7eb172e3d/conf/config-default.yaml#L99) |
 | gateway.tls.certCAFilename | string | `""` | Filename be used in the gateway.tls.existingCASecret |

--- a/charts/apisix-ingress-controller/templates/deployment.yaml
+++ b/charts/apisix-ingress-controller/templates/deployment.yaml
@@ -151,7 +151,8 @@ spec:
               name: prometheus
               protocol: TCP
             {{- end }}
-          resources: {}
+          resources:
+            {{- toYaml .Values.gateway.resources | nindent 12 }}
           securityContext:
             {{- toYaml .Values.gateway.securityContext | nindent 12 }}
           volumeMounts:

--- a/charts/apisix-ingress-controller/values.yaml
+++ b/charts/apisix-ingress-controller/values.yaml
@@ -235,6 +235,7 @@ gateway:
     errorLog: stderr
     # -- Nginx error logs level
     errorLogLevel: warn
+  resources: {}
   securityContext: {}
     # capabilities:
     #   add:


### PR DESCRIPTION
Currently, if `gateway` deployment is enabled, then the `apisix` gateway container in the pod is deployed without any resource requests or limits, and they are not even configurable. This PR tries to make them configurable.