### PR TITLE
feat: support PDB in apisix-ingress-controller

### DIFF
--- a/charts/apisix-ingress-controller/README.md
+++ b/charts/apisix-ingress-controller/README.md
@@ -171,6 +171,10 @@ The same for container level, you need to set:
 | nameOverride | string | `""` | Default values for apisix-ingress-controller. This is a YAML-formatted file. Declare variables to be passed into your templates.  |
 | nodeSelector | object | `{}` |  |
 | podAnnotations | object | `{}` |  |
+| podDisruptionBudget | object | `{"enabled":false,"maxUnavailable":1,"minAvailable":"90%"}` | See https://kubernetes.io/docs/tasks/run-application/configure-pdb/ for more details |
+| podDisruptionBudget.enabled | bool | `false` | Enable or disable podDisruptionBudget |
+| podDisruptionBudget.maxUnavailable | int | `1` | Set the maxUnavailable of podDisruptionBudget |
+| podDisruptionBudget.minAvailable | string | `"90%"` | Set the `minAvailable` of podDisruptionBudget. You can specify only one of `maxUnavailable` and `minAvailable` in a single PodDisruptionBudget. See [Specifying a Disruption Budget for your Application](https://kubernetes.io/docs/tasks/run-application/configure-pdb/#specifying-a-poddisruptionbudget) for more details |
 | podSecurityContext | object | `{}` |  |
 | priorityClassName | string | `""` |  |
 | rbac.create | bool | `true` | Specifies whether RBAC resources should be created |

--- a/charts/apisix-ingress-controller/templates/pdb.yaml
+++ b/charts/apisix-ingress-controller/templates/pdb.yaml
@@ -1,0 +1,38 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{- if and .Values.podDisruptionBudget.enabled (or (and .Values.autoscaling.enabled (gt (.Values.autoscaling.minReplicas | int) 1)) (and (not .Values.autoscaling.enabled) (gt (.Values.replicaCount | int) 1))) }}
+{{ if semverCompare "<1.21-0" .Capabilities.KubeVersion.Version -}}
+apiVersion: policy/v1beta1
+{{- else -}}
+apiVersion: policy/v1
+{{- end }}
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "apisix-ingress-controller.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "apisix-ingress-controller.labels" . | nindent 4 }}
+spec:
+{{- if .Values.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+{{- else }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+{{- end }}
+  selector:
+    matchLabels:
+{{- include "apisix-ingress-controller.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/apisix-ingress-controller/values.yaml
+++ b/charts/apisix-ingress-controller/values.yaml
@@ -199,6 +199,16 @@ serviceMonitor:
   # ref: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs
   metricRelabelings: {}
 
+# -- See https://kubernetes.io/docs/tasks/run-application/configure-pdb/ for more details
+podDisruptionBudget:
+  # -- Enable or disable podDisruptionBudget
+  enabled: false
+  # -- Set the `minAvailable` of podDisruptionBudget. You can specify only one of `maxUnavailable` and `minAvailable` in a single PodDisruptionBudget.
+  # See [Specifying a Disruption Budget for your Application](https://kubernetes.io/docs/tasks/run-application/configure-pdb/#specifying-a-poddisruptionbudget)
+  # for more details
+  minAvailable: 90%
+  # -- Set the maxUnavailable of podDisruptionBudget
+  maxUnavailable: 1
 
 podSecurityContext: {}
   # fsGroup: 2000


### PR DESCRIPTION
Apisix Helm Chart [allows](https://github.com/apache/apisix-helm-chart/blob/master/charts/apisix/templates/pdb.yaml) to define `PodDisruptionBudget` policy, but this Helm Chart for `apisix-ingress-controller` does not. This PR adds supports for it.
The code is basically a copy of `PodDisruptionBudget` [template](https://github.com/apache/apisix-helm-chart/blob/master/charts/apisix/templates/pdb.yaml) from mentioned chart, while first if statement is inspired by template of `ingress-nginx` controller's `PodDisruptionBudget` template, if that's OK.