### PR TITLE
feat: support adding annotations to Deployment

### DIFF
--- a/charts/apisix-ingress-controller/README.md
+++ b/charts/apisix-ingress-controller/README.md
@@ -106,6 +106,7 @@ The same for container level, you need to set:
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` |  |
+| annotations | object | `{}` | Add annotations to Apache APISIX ingress controller resource |
 | autoscaling.enabled | bool | `false` |  |
 | autoscaling.maxReplicas | int | `100` |  |
 | autoscaling.minReplicas | int | `1` |  |

--- a/charts/apisix-ingress-controller/templates/deployment.yaml
+++ b/charts/apisix-ingress-controller/templates/deployment.yaml
@@ -19,6 +19,10 @@ kind: Deployment
 metadata:
   name: {{ include "apisix-ingress-controller.fullname" . }}
   namespace: {{ .Release.Namespace }}
+  annotations:
+  {{- range $key, $value := .Values.annotations }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
   labels:
     {{- include "apisix-ingress-controller.labels" . | nindent 4 }}
 spec:

--- a/charts/apisix-ingress-controller/values.yaml
+++ b/charts/apisix-ingress-controller/values.yaml
@@ -29,6 +29,9 @@ labelsOverride: {}
 #   app.kubernetes.io/name: "{{ .Release.Name }}"
 #   app.kubernetes.io/instance: '{{ include "apisix-ingress-controller.name" . }}'
 
+# -- Add annotations to Apache APISIX ingress controller resource
+annotations: {}
+
 rbac:
   # -- Specifies whether RBAC resources should be created
   create: true


### PR DESCRIPTION
Allowing to add annotations for Deployment object of `apisix-ingress-controller` makes usage of 3rd party tools like `reloader` possible, e.g.:

```
apiVersion: apps/v1
kind: Deployment
metadata:
  annotations:
    meta.helm.sh/release-name: ingress-apisix
    meta.helm.sh/release-namespace: ingress-apisix
    reloader.stakater.com/auto: "true"
[...]
```

**Use case**: We are delivering admin key to Kubernetes using `external-secrets-operator` and then passing into apisix via environment variable, and we want ingress controllers to be automatically reloaded when update of secret happens. For this purpose, we need to be able to add `reloader` annotation to the deployment object.