### PR TITLE
revert: apisix v1.10.0 helm chart

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -260,6 +260,38 @@ entries:
   - annotations:
       artifacthub.io/prerelease: "false"
     apiVersion: v2
+    appVersion: 3.8.0
+    created: "2024-01-15T10:03:40.575630339Z"
+    dependencies:
+    - condition: etcd.enabled
+      name: etcd
+      repository: https://charts.bitnami.com/bitnami
+      version: 9.7.3
+    - alias: dashboard
+      condition: dashboard.enabled
+      name: apisix-dashboard
+      repository: https://charts.apiseven.com
+      version: 0.8.1
+    - alias: ingress-controller
+      condition: ingress-controller.enabled
+      name: apisix-ingress-controller
+      repository: https://charts.apiseven.com
+      version: 0.13.0
+    description: A Helm chart for Apache APISIX v3
+    digest: 29c007f078589504e5a355d1bc071c6fde69886196d55e58f5d6f0b264832446
+    icon: https://apache.org/logos/res/apisix/apisix.png
+    maintainers:
+    - name: tao12345666333
+    name: apisix
+    sources:
+    - https://github.com/apache/apisix-helm-chart
+    type: application
+    urls:
+    - https://github.com/apache/apisix-helm-chart/releases/download/apisix-1.10.0/apisix-1.10.0.tgz
+    version: 1.10.0
+  - annotations:
+      artifacthub.io/prerelease: "false"
+    apiVersion: v2
     appVersion: 3.7.0
     created: "2023-12-18T03:46:00.535420741Z"
     dependencies:


### PR DESCRIPTION
It was deleted in this commit
https://github.com/apache/apisix-helm-chart/commit/a1570b28cb0fa702e55b1b128310b7e5282cc083