### PR TITLE
feat: support securityContext for gateway container

### DIFF
--- a/charts/apisix-ingress-controller/README.md
+++ b/charts/apisix-ingress-controller/README.md
@@ -151,6 +151,7 @@ The same for container level, you need to set:
 | gateway.nginx.workerConnections | string | `"10620"` | Nginx worker connections |
 | gateway.nginx.workerProcesses | string | `"auto"` | Nginx worker processes |
 | gateway.nginx.workerRlimitNofile | string | `"20480"` | Nginx workerRlimitNoFile |
+| gateway.securityContext | object | `{}` |  |
 | gateway.tls.additionalContainerPorts | list | `[]` | Support multiple https ports, See [Configuration](https://github.com/apache/apisix/blob/0bc65ea9acd726f79f80ae0abd8f50b7eb172e3d/conf/config-default.yaml#L99) |
 | gateway.tls.certCAFilename | string | `""` | Filename be used in the gateway.tls.existingCASecret |
 | gateway.tls.containerPort | int | `9443` |  |

--- a/charts/apisix-ingress-controller/templates/deployment.yaml
+++ b/charts/apisix-ingress-controller/templates/deployment.yaml
@@ -148,6 +148,8 @@ spec:
               protocol: TCP
             {{- end }}
           resources: {}
+          securityContext:
+            {{- toYaml .Values.gateway.securityContext | nindent 12 }}
           volumeMounts:
             - name: apisix-config
               mountPath: /usr/local/apisix/conf/config.yaml

--- a/charts/apisix-ingress-controller/values.yaml
+++ b/charts/apisix-ingress-controller/values.yaml
@@ -232,6 +232,15 @@ gateway:
     errorLog: stderr
     # -- Nginx error logs level
     errorLogLevel: warn
+  securityContext: {}
+    # capabilities:
+    #   add:
+    #   - NET_BIND_SERVICE
+    #   drop:
+    #   - ALL
+    # readOnlyRootFilesystem: true
+    # runAsNonRoot: true
+    # runAsUser: 636
   tls:
     enabled: false
     servicePort: 443


### PR DESCRIPTION
Currently, if `gateway` deployment is enabled, then the `apisix` gateway container in the pod is deployed without any securityContext, and they it is not even configurable. This PR tries to make it configurable.

_Use-case: This is useful, if you want to add_ `NET_BIND_SERVICE` _capability and make_ `apisix` _gateway container listen on privileged port, e.g. 443._