### PR TITLE
fix: gateway ssl config indentation

### DIFF
--- a/charts/apisix-ingress-controller/templates/apisix-configmap.yaml
+++ b/charts/apisix-ingress-controller/templates/apisix-configmap.yaml
@@ -51,15 +51,7 @@ data:
         udp:
           - 9200
 
-    nginx_config:
-      error_log: "{{ .Values.gateway.nginx.errorLog }}"
-      error_log_level: "{{ .Values.gateway.nginx.errorLogLevel }}"    # warn,error
-      worker_processes: "{{ .Values.gateway.nginx.workerProcesses }}"
-      worker_rlimit_nofile: {{ .Values.gateway.nginx.workerRlimitNofile }}  # the number of files a worker process can open, should be larger than worker_connections
-      event:
-        worker_connections: {{ .Values.gateway.nginx.workerConnections  }}
-    
-    ssl:
+      ssl:
         enable: {{ .Values.gateway.tls.enabled }}
         listen:
           - port: {{ .Values.gateway.tls.containerPort }}
@@ -76,6 +68,14 @@ data:
         fallback_sni: {{ .Values.gateway.tls.fallbackSNI | quote }}
         {{- end }}
 
+    nginx_config:
+      error_log: "{{ .Values.gateway.nginx.errorLog }}"
+      error_log_level: "{{ .Values.gateway.nginx.errorLogLevel }}"    # warn,error
+      worker_processes: "{{ .Values.gateway.nginx.workerProcesses }}"
+      worker_rlimit_nofile: {{ .Values.gateway.nginx.workerRlimitNofile }}  # the number of files a worker process can open, should be larger than worker_connections
+      event:
+        worker_connections: {{ .Values.gateway.nginx.workerConnections  }}
+    
     plugins:                          # plugin list (sorted by priority)
       - real-ip                        # priority: 23000
       - ai                             # priority: 22900


### PR DESCRIPTION
Support for TLS (SSL) configuration was added in this [PR](https://github.com/apache/apisix-helm-chart/pull/657/files), but it seems that indentation of ssl stanza is incorrect, since changing some values does take effect, e.g. changing port from 9443 to 443.
Port is changed in configMap, also in container definition, but internally, `nginx.conf` is still rendered with port 9443. 

According to [this line](https://github.com/apache/apisix/blob/ec77fb8ca2e797aa90d6547a1e323d4f40e27527/apisix/cli/ops.lua#L456), configuration is extracted from YAML file at `apisix.ssl.listen`, not at `ssl.listen`.

If is I manually re-write the configMap and move the section then the port is changed as expected.