### PR TITLE
feat: add serviceMonitor for apisix-gateway

### DIFF
--- a/charts/apisix-ingress-controller/README.md
+++ b/charts/apisix-ingress-controller/README.md
@@ -154,6 +154,11 @@ The same for container level, you need to set:
 | gateway.nginx.workerRlimitNofile | string | `"20480"` | Nginx workerRlimitNoFile |
 | gateway.resources | object | `{}` |  |
 | gateway.securityContext | object | `{}` |  |
+| gateway.serviceMonitor | object | `{"annotations":{},"enabled":false,"interval":"15s","labels":{},"metricRelabelings":{},"namespace":"monitoring","path":"/apisix/prometheus/metrics"}` | Create ServiceMonitor object for apisix gateway for Prometheus operator Requires Prometheus operator v0.38.0 or higher. |
+| gateway.serviceMonitor.annotations | object | `{}` | @param serviceMonitor.annotations ServiceMonitor annotations |
+| gateway.serviceMonitor.labels | object | `{}` | @param serviceMonitor.labels ServiceMonitor extra labels |
+| gateway.serviceMonitor.metricRelabelings | object | `{}` | @param serviceMonitor.metricRelabelings MetricRelabelConfigs to apply to samples before ingestion. ref: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs |
+| gateway.serviceMonitor.path | string | `"/apisix/prometheus/metrics"` | @param serviceMonitor.path ServiceMonitor scrape path |
 | gateway.tls.additionalContainerPorts | list | `[]` | Support multiple https ports, See [Configuration](https://github.com/apache/apisix/blob/0bc65ea9acd726f79f80ae0abd8f50b7eb172e3d/conf/config-default.yaml#L99) |
 | gateway.tls.certCAFilename | string | `""` | Filename be used in the gateway.tls.existingCASecret |
 | gateway.tls.containerPort | int | `9443` |  |

--- a/charts/apisix-ingress-controller/templates/apisix-configmap.yaml
+++ b/charts/apisix-ingress-controller/templates/apisix-configmap.yaml
@@ -164,12 +164,12 @@ data:
 
     plugin_attr:
       prometheus:
-        enable_export_server: {{ .Values.serviceMonitor.enabled }}
-      {{- if .Values.serviceMonitor.enabled }}
+        enable_export_server: {{ .Values.gateway.serviceMonitor.enabled }}
+      {{- if .Values.gateway.serviceMonitor.enabled }}
         export_addr:
           ip: 0.0.0.0
           port: 9091
-          export_uri: /apisix/prometheus/metrics
+          export_uri: {{ .Values.gateway.serviceMonitor.path }}
           metric_prefix: apisix_
       {{- end }}
 {{ end }}

--- a/charts/apisix-ingress-controller/templates/deployment.yaml
+++ b/charts/apisix-ingress-controller/templates/deployment.yaml
@@ -94,7 +94,7 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
-            - name: http
+            - name: http-controller
               containerPort: {{ (.Values.config.httpListen | split ":")._1 }}
               protocol: TCP
             {{ if .Values.config.etcdserver.enabled }}
@@ -146,7 +146,7 @@ spec:
             - name: https
               containerPort: {{ .Values.gateway.tls.containerPort }}
               protocol: TCP
-            {{- if .Values.serviceMonitor.enabled }}
+            {{- if .Values.gateway.serviceMonitor.enabled }}
             - containerPort: 9091
               name: prometheus
               protocol: TCP

--- a/charts/apisix-ingress-controller/templates/service-apisix.yaml
+++ b/charts/apisix-ingress-controller/templates/service-apisix.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.config.etcdserver.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -40,5 +41,6 @@ spec:
   externalIPs:
   {{- range $ip := .Values.gateway.externalIPs }}
   - {{ $ip }}
+  {{- end }}
   {{- end }}
   {{- end }}

--- a/charts/apisix-ingress-controller/templates/servicemonitor-apisix.yaml
+++ b/charts/apisix-ingress-controller/templates/servicemonitor-apisix.yaml
@@ -14,34 +14,34 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-{{- if .Values.serviceMonitor.enabled }}
+{{- if and .Values.config.etcdserver.enabled .Values.gateway.serviceMonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: {{ template "apisix-ingress-controller.fullname" . }}
-  {{- if .Values.serviceMonitor.namespace }}
-  namespace: {{ .Values.serviceMonitor.namespace }}
+  name: {{ template "apisix-ingress-controller.fullname" . }}-apisix-gateway
+  {{- if .Values.gateway.serviceMonitor.namespace }}
+  namespace: {{ .Values.gateway.serviceMonitor.namespace }}
   {{- end }}
-  {{- if .Values.serviceMonitor.labels }}
-  labels: {{- toYaml .Values.serviceMonitor.labels | nindent 4 }}
+  {{- if .Values.gateway.serviceMonitor.labels }}
+  labels: {{- toYaml .Values.gateway.serviceMonitor.labels | nindent 4 }}
   {{- end }}
-  {{- if .Values.serviceMonitor.annotations }}
-  annotations: {{- toYaml .Values.serviceMonitor.annotations | nindent 4 }}
+  {{- if .Values.gateway.serviceMonitor.annotations }}
+  annotations: {{- toYaml .Values.gateway.serviceMonitor.annotations | nindent 4 }}
   {{- end }}
 spec:
   endpoints:
-  - targetPort: http-controller
+  - targetPort: prometheus
     scheme: http
-    {{- if .Values.serviceMonitor.interval }}
-    interval: {{ .Values.serviceMonitor.interval }}
+    path: {{ .Values.gateway.serviceMonitor.path }}
+    {{- if .Values.gateway.serviceMonitor.interval }}
+    interval: {{ .Values.gateway.serviceMonitor.interval }}
     {{- end }}
-    {{- with .Values.serviceMonitor.metricRelabelings }}
+    {{- with .Values.gateway.serviceMonitor.metricRelabelings }}
     metricRelabelings: {{ toYaml . | nindent 6 }}
     {{- end }}
   namespaceSelector:
     matchNames:
     - {{ template "apisix-ingress-controller.namespace" . }}
-
   selector:
     matchLabels:
       {{- include "apisix-ingress-controller.labels" . | nindent 6 }}

--- a/charts/apisix-ingress-controller/values.yaml
+++ b/charts/apisix-ingress-controller/values.yaml
@@ -255,6 +255,21 @@ gateway:
     # readOnlyRootFilesystem: true
     # runAsNonRoot: true
     # runAsUser: 636
+  # -- Create ServiceMonitor object for apisix gateway for Prometheus operator
+  # Requires Prometheus operator v0.38.0 or higher.
+  serviceMonitor:
+    enabled: false
+    namespace: "monitoring"
+    # -- @param serviceMonitor.path ServiceMonitor scrape path
+    path: "/apisix/prometheus/metrics"
+    interval: 15s
+    # -- @param serviceMonitor.labels ServiceMonitor extra labels
+    labels: {}
+    # -- @param serviceMonitor.annotations ServiceMonitor annotations
+    annotations: {}
+    # -- @param serviceMonitor.metricRelabelings MetricRelabelConfigs to apply to samples before ingestion.
+    # ref: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs
+    metricRelabelings: {}
   tls:
     enabled: false
     servicePort: 443


### PR DESCRIPTION
Metrics' port & URL is defined [here](https://github.com/apache/apisix-helm-chart/blob/f14f58dc7fbe8a963b346ab322a93c662f191b3a/charts/apisix-ingress-controller/templates/apisix-configmap.yaml#L170-L171) (port 9091 & URL `/apisix/prometheus/metrics`).

And it doesn't match what's in the [serviceMonitor](https://github.com/apache/apisix-helm-chart/blob/master/charts/apisix-ingress-controller/templates/servicemonitor.yaml#L33). TargetPort should be `prometheus`, a.k.a. 9091, and path is not specified which defaults to `/metrics` which is incorrect.

Fact that it's not working in default configuration is visible in my logs:
```
apisix-ingress-controller-6b4d5cc778-f582v apisix 10.254.82.207 - - [17/Jan/2024:11:00:22 +0000] 10.254.83.238:9080 "GET /metrics HTTP/1.1" 404 47 0.000 "-" "Prometheus/2.48.1" - - - "http://10.254.83.238:9080"
```