### PR TITLE
feat: Allow setting nodePort for LoadBalancer services

### DIFF
--- a/charts/apisix/Chart.yaml
+++ b/charts/apisix/Chart.yaml
@@ -31,7 +31,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.10.0
+version: 1.10.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/apisix/templates/service-admin.yaml
+++ b/charts/apisix/templates/service-admin.yaml
@@ -49,7 +49,7 @@ spec:
   - name: apisix-admin
     port: {{ .Values.admin.servicePort }}
     targetPort: {{ .Values.admin.port }}
-  {{- if (and (eq .Values.admin.type "NodePort") (not (empty .Values.admin.nodePort))) }}
+  {{- if (and (or (eq .Values.admin.type "LoadBalancer") (eq .Values.admin.type "NodePort")) (not (empty .Values.admin.nodePort))) }}
     nodePort: {{ .Values.admin.nodePort }}
   {{- end }}
     protocol: TCP

--- a/charts/apisix/templates/service-gateway.yaml
+++ b/charts/apisix/templates/service-gateway.yaml
@@ -54,7 +54,7 @@ spec:
   - name: apisix-gateway
     port: {{ .Values.gateway.http.servicePort }}
     targetPort: {{ .Values.gateway.http.containerPort }}
-  {{- if (and (eq .Values.gateway.type "NodePort") (not (empty .Values.gateway.http.nodePort))) }}
+  {{- if (and (or (eq .Values.gateway.type "LoadBalancer") (eq .Values.gateway.type "NodePort")) (not (empty .Values.gateway.http.nodePort))) }}
     nodePort: {{ .Values.gateway.http.nodePort }}
   {{- end }}
     protocol: TCP
@@ -69,7 +69,7 @@ spec:
   - name: apisix-gateway-tls
     port: {{ .Values.gateway.tls.servicePort }}
     targetPort: {{ .Values.gateway.tls.containerPort }}
-  {{- if (and (eq .Values.gateway.type "NodePort") (not (empty .Values.gateway.tls.nodePort))) }}
+  {{- if (and (or (eq .Values.gateway.type "LoadBalancer") (eq .Values.gateway.type "NodePort")) (not (empty .Values.gateway.tls.nodePort))) }}
     nodePort: {{ .Values.gateway.tls.nodePort }}
   {{- end }}
     protocol: TCP
@@ -83,7 +83,7 @@ spec:
   - name: apisix-gateway-pp-http
     port: {{ .Values.gateway.proxyProtocol.http.servicePort }}
     targetPort: {{ .Values.gateway.proxyProtocol.http.containerPort }}
-  {{- if (and (eq .Values.gateway.type "NodePort") (not (empty .Values.gateway.proxyProtocol.http.nodePort))) }}
+  {{- if (and (or (eq .Values.gateway.type "LoadBalancer") (eq .Values.gateway.type "NodePort")) (not (empty .Values.gateway.proxyProtocol.http.nodePort))) }}
     nodePort: {{ .Values.gateway.proxyProtocol.http.nodePort }}
   {{- end }}
     protocol: TCP
@@ -92,7 +92,7 @@ spec:
   - name: apisix-gateway-pp-https
     port: {{ .Values.gateway.proxyProtocol.https.servicePort }}
     targetPort: {{ .Values.gateway.proxyProtocol.https.containerPort }}
-  {{- if (and (eq .Values.gateway.type "NodePort") (not (empty .Values.gateway.proxyProtocol.https.nodePort))) }}
+  {{- if (and (or (eq .Values.gateway.type "LoadBalancer") (eq .Values.gateway.type "NodePort")) (not (empty .Values.gateway.proxyProtocol.https.nodePort))) }}
     nodePort: {{ .Values.gateway.proxyProtocol.https.nodePort }}
   {{- end }}
     protocol: TCP


### PR DESCRIPTION
Allow nodePort setting to take effect if the service type is NodePort or LoadBalancer.