### PR TITLE
chore: release ingress 1.8.0 with chart version 0.14.0

### DIFF
--- a/charts/apisix-ingress-controller/Chart.yaml
+++ b/charts/apisix-ingress-controller/Chart.yaml
@@ -24,8 +24,8 @@ keywords:
   - nginx
   - crd
 type: application
-version: 0.13.0
-appVersion: 1.7.1
+version: 0.14.0
+appVersion: 1.8.0
 sources:
   - https://github.com/apache/apisix-helm-chart
 

--- a/charts/apisix-ingress-controller/README.md
+++ b/charts/apisix-ingress-controller/README.md
@@ -166,7 +166,7 @@ The same for container level, you need to set:
 | gateway.type | string | `"NodePort"` | Apache APISIX service type for user access itself |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"apache/apisix-ingress-controller"` |  |
-| image.tag | string | `"1.7.1"` |  |
+| image.tag | string | `"1.8.0"` |  |
 | imagePullSecrets | list | `[]` |  |
 | initContainer.image | string | `"busybox"` |  |
 | initContainer.tag | float | `1.28` |  |

--- a/charts/apisix-ingress-controller/values.yaml
+++ b/charts/apisix-ingress-controller/values.yaml
@@ -51,7 +51,7 @@ replicaCount: 1
 image:
   repository: apache/apisix-ingress-controller
   pullPolicy: IfNotPresent
-  tag: "1.7.1"
+  tag: "1.8.0"
 
 podAnnotations: {}
 


### PR DESCRIPTION
The new version of the apisix ingress controller was released - 1.8.0. The released chart is updated with a new image version and a new version of the chart itself.

Includes also:
- https://github.com/apache/apisix-helm-chart/pull/697
- https://github.com/apache/apisix-helm-chart/pull/698