### PR TITLE
feat: allow to enable/disable some plugins

### DIFF
--- a/charts/apisix-ingress-controller/README.md
+++ b/charts/apisix-ingress-controller/README.md
@@ -152,6 +152,9 @@ The same for container level, you need to set:
 | gateway.nginx.workerConnections | string | `"10620"` | Nginx worker connections |
 | gateway.nginx.workerProcesses | string | `"auto"` | Nginx worker processes |
 | gateway.nginx.workerRlimitNofile | string | `"20480"` | Nginx workerRlimitNoFile |
+| gateway.plugins.opentelemetry.enabled | bool | `false` |  |
+| gateway.plugins.skywalking.enabled | bool | `false` |  |
+| gateway.plugins.zipkin.enabled | bool | `true` |  |
 | gateway.resources | object | `{}` |  |
 | gateway.securityContext | object | `{}` |  |
 | gateway.tls.additionalContainerPorts | list | `[]` | Support multiple https ports, See [Configuration](https://github.com/apache/apisix/blob/0bc65ea9acd726f79f80ae0abd8f50b7eb172e3d/conf/config-default.yaml#L99) |

--- a/charts/apisix-ingress-controller/templates/apisix-configmap.yaml
+++ b/charts/apisix-ingress-controller/templates/apisix-configmap.yaml
@@ -82,9 +82,15 @@ data:
       - client-control                 # priority: 22000
       - proxy-control                  # priority: 21990
       - request-id                     # priority: 12015
+      {{- if .Values.gateway.plugins.zipkin.enabled }}
       - zipkin                         # priority: 12011
-      #- skywalking                    # priority: 12010
-      #- opentelemetry                 # priority: 12009
+      {{- end }}
+      {{- if .Values.gateway.plugins.skywalking.enabled }}
+      - skywalking                     # priority: 12010
+      {{- end }}
+      {{- if .Values.gateway.plugins.opentelemetry.enabled }}
+      - opentelemetry                  # priority: 12009
+      {{- end }}
       - ext-plugin-pre-req             # priority: 12000
       - fault-injection                # priority: 11000
       - mocking                        # priority: 10900

--- a/charts/apisix-ingress-controller/values.yaml
+++ b/charts/apisix-ingress-controller/values.yaml
@@ -245,6 +245,13 @@ gateway:
     errorLog: stderr
     # -- Nginx error logs level
     errorLogLevel: warn
+  plugins:
+    opentelemetry:
+      enabled: false
+    skywalking:
+      enabled: false
+    zipkin:
+      enabled: true
   resources: {}
   securityContext: {}
     # capabilities:


### PR DESCRIPTION
List of plugins for gateway (apisix container) is currently configured statically in the ConfigMap and there is no way to customize the list. That means that e.g. `zipkin` plugin for observability is always enabled, but `opentelemetry` is not and it is not possible to enabled it (easily).

This just a proposal, how it could be done in one way.

I was also thinking about:

```
gateway:
  pluginsOverride:
    - plugin1
    - plugin2
    - ...
```

Or instead of adjusting ConfigMap template to allow for swappping it with `existingConfigMap`, e.g.:

```
gateway:
  existingConfigMap: "my-apisix-configmap"
```

Which would cause to not render `apisix-configmap.yaml` at all and instead switch `configuration` volume to provided custom ConfigMap.

Feedback is welcome.