### PR TITLE
fix: enable gateway sidecar only when replicasCount of controller is 1

### DIFF
--- a/charts/apisix-ingress-controller/Chart.yaml
+++ b/charts/apisix-ingress-controller/Chart.yaml
@@ -24,7 +24,7 @@ keywords:
   - nginx
   - crd
 type: application
-version: 0.14.0
+version: 0.14.1
 appVersion: 1.8.0
 sources:
   - https://github.com/apache/apisix-helm-chart

--- a/charts/apisix-ingress-controller/README.md
+++ b/charts/apisix-ingress-controller/README.md
@@ -122,9 +122,6 @@ The same for container level, you need to set:
 | config.certFile | string | `"/etc/webhook/certs/cert.pem"` | the TLS certificate file path. |
 | config.enableProfiling | bool | `true` | enable profiling via web interfaces host:port/debug/pprof, default is true. |
 | config.etcdserver.enabled | bool | `false` | Enable etcd server or not, default is false. |
-| config.etcdserver.image.pullPolicy | string | `"IfNotPresent"` | Apache APISIX image pull policy |
-| config.etcdserver.image.repository | string | `"apache/apisix"` | Apache APISIX image repository |
-| config.etcdserver.image.tag | string | `"3.5.0-debian"` | Apache APISIX image tag Overrides the image tag whose default is the chart appVersion. |
 | config.httpListen | string | `":8080"` | the HTTP Server listen address, default is ":8080" |
 | config.httpsListen | string | `":8443"` | the HTTPS Server listen address, default is ":8443" |
 | config.ingressPublishService | string | `""` | the controller will use the Endpoint of this Service to update the status information of the Ingress resource. The format is "namespace/svc-name" to solve the situation that the data plane and the controller are not deployed in the same namespace. |
@@ -145,8 +142,12 @@ The same for container level, you need to set:
 | config.logOutput | string | `"stderr"` | the output file path of error log, default is stderr, when the file path is "stderr" or "stdout", logs are marshalled plainly, which is more readable for human; otherwise logs are marshalled in JSON format, which can be parsed by programs easily. |
 | config.pluginMetadataCM | string | `""` | Pluginmetadata in APISIX can be controlled through ConfigMap. default is "" |
 | fullnameOverride | string | `""` |  |
+| gateway.enabled | bool | `false` | Enable deploying APISIX gateway as sidecar |
 | gateway.externalIPs | list | `[]` | load balancer ips |
 | gateway.externalTrafficPolicy | string | `"Cluster"` |  |
+| gateway.image.pullPolicy | string | `"IfNotPresent"` | Apache APISIX image pull policy |
+| gateway.image.repository | string | `"apache/apisix"` | Apache APISIX image repository |
+| gateway.image.tag | string | `"3.5.0-debian"` | Apache APISIX image tag Overrides the image tag whose default is the chart appVersion. |
 | gateway.nginx.errorLog | string | `"stderr"` | Nginx error logs path |
 | gateway.nginx.errorLogLevel | string | `"warn"` | Nginx error logs level |
 | gateway.nginx.workerConnections | string | `"10620"` | Nginx worker connections |

--- a/charts/apisix-ingress-controller/templates/apisix-configmap.yaml
+++ b/charts/apisix-ingress-controller/templates/apisix-configmap.yaml
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-{{ if .Values.config.etcdserver.enabled }}
+{{ if and .Values.gateway.enabled .Values.config.etcdserver.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/apisix-ingress-controller/templates/configmap.yaml
+++ b/charts/apisix-ingress-controller/templates/configmap.yaml
@@ -57,7 +57,7 @@ data:
       apisix_version: {{ .Values.config.kubernetes.apiVersion | quote }}
     apisix:
       admin_api_version: {{ .Values.config.apisix.adminAPIVersion | quote }}
-      {{- if .Values.config.etcdserver.enabled }}
+      {{- if and .Values.gateway.enabled .Values.config.etcdserver.enabled }}
       default_cluster_base_url: http://127.0.0.1:9180/apisix/admin
       {{ else }}
       {{- if .Values.config.apisix.serviceFullname }}

--- a/charts/apisix-ingress-controller/templates/deployment.yaml
+++ b/charts/apisix-ingress-controller/templates/deployment.yaml
@@ -64,7 +64,7 @@ spec:
             items:
               - key: config.yaml
                 path: config.yaml
-      {{ if .Values.config.etcdserver.enabled }}
+      {{ if and .Values.gateway.enabled ( eq (.Values.replicaCount | int) 1 ) .Values.config.etcdserver.enabled }}
         - name: apisix-config
           configMap:
             name: {{ .Release.Name }}-gw-configmap
@@ -132,10 +132,10 @@ spec:
                 name: {{ .Values.config.apisix.existingSecret | quote }}
                 key: {{ include "apisix-ingress-controller.credentials.secretAdminKey" . }}
           {{- end }}
-        {{ if .Values.config.etcdserver.enabled }}
+        {{ if and .Values.gateway.enabled ( eq (.Values.replicaCount | int) 1 ) .Values.config.etcdserver.enabled }}
         - name: apisix
-          image: "{{ .Values.config.etcdserver.image.repository }}:{{ .Values.config.etcdserver.image.tag }}"
-          imagePullPolicy: {{ .Values.config.etcdserver.image.pullPolicy }}
+          image: "{{ .Values.gateway.image.repository }}:{{ .Values.gateway.image.tag }}"
+          imagePullPolicy: {{ .Values.gateway.image.pullPolicy }}
           ports:
             - name: http
               containerPort: 9080

--- a/charts/apisix-ingress-controller/templates/service-apisix.yaml
+++ b/charts/apisix-ingress-controller/templates/service-apisix.yaml
@@ -1,3 +1,4 @@
+{{- if and .Values.gateway.enabled ( eq (.Values.replicaCount | int) 1 ) .Values.config.etcdserver.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -40,5 +41,6 @@ spec:
   externalIPs:
   {{- range $ip := .Values.gateway.externalIPs }}
   - {{ $ip }}
+  {{- end }}
   {{- end }}
   {{- end }}

--- a/charts/apisix-ingress-controller/templates/service.yaml
+++ b/charts/apisix-ingress-controller/templates/service.yaml
@@ -28,5 +28,11 @@ spec:
       targetPort: {{ (.Values.config.httpListen | split ":")._1 }}
       protocol: TCP
       name: http
+    {{- if and ( eq (.Values.replicaCount | int) 1 ) .Values.config.etcdserver.enabled }}
+    - port: 12379
+      targetPort: etcd
+      protocol: TCP
+      name: etcd
+    {{- end }}
   selector:
     {{- include "apisix-ingress-controller.selectorLabels" . | nindent 4 }}

--- a/charts/apisix-ingress-controller/values.yaml
+++ b/charts/apisix-ingress-controller/values.yaml
@@ -45,7 +45,6 @@ serviceAccount:
   # -- Whether automounting API credentials for a service account
   automountServiceAccountToken: true
 
-
 replicaCount: 1
 
 image:
@@ -67,14 +66,6 @@ config:
   etcdserver:
     # -- Enable etcd server or not, default is false.
     enabled: false
-    image:
-      # -- Apache APISIX image repository
-      repository: apache/apisix
-      # -- Apache APISIX image pull policy
-      pullPolicy: IfNotPresent
-      # -- Apache APISIX image tag
-      # Overrides the image tag whose default is the chart appVersion.
-      tag: 3.5.0-debian
   # -- the error log level, default is info, optional values are: debug, info, warn, error, panic, fatal
   logLevel: "info"
   # -- the output file path of error log, default is stderr, when
@@ -140,7 +131,6 @@ config:
     # -- the resource API version, support "apisix.apache.org/v2beta3" and "apisix.apache.org/v2".
     # default is "apisix.apache.org/v2"
     apiVersion: "apisix.apache.org/v2"
-
 
   # -- APISIX related configurations.
   apisix:
@@ -224,6 +214,16 @@ securityContext: {}
   # runAsNonRoot: true
   # runAsUser: 1000
 gateway:
+  # -- Enable deploying APISIX gateway as sidecar
+  enabled: false
+  image:
+    # -- Apache APISIX image repository
+    repository: apache/apisix
+    # -- Apache APISIX image pull policy
+    pullPolicy: IfNotPresent
+    # -- Apache APISIX image tag
+    # Overrides the image tag whose default is the chart appVersion.
+    tag: 3.5.0-debian
   # -- Apache APISIX service type for user access itself
   type: NodePort
   externalTrafficPolicy: Cluster

--- a/charts/apisix/templates/configmap.yaml
+++ b/charts/apisix/templates/configmap.yaml
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# .Subcharts require helm version >= 3.7
+{{- $apisixIngressControllerFullname := (include "apisix-ingress-controller.fullname" (index .Subcharts "ingress-controller")) }}
 {{- if .Values.apisix.enabled }}
 apiVersion: v1
 kind: ConfigMap
@@ -360,19 +362,20 @@ data:
       {{- end }}
       {{- if not (eq .Values.deployment.mode "standalone")}}
       etcd:
-      {{- if .Values.etcd.enabled }}
         host:                          # it's possible to define multiple etcd hosts addresses of the same etcd cluster.
+        {{- if .Values.etcd.enabled }}
           {{- if .Values.etcd.fullnameOverride }}
           - "{{ include "apisix.etcd.auth.scheme" . }}://{{ .Values.etcd.fullnameOverride }}:{{ .Values.etcd.service.port }}"
           {{- else }}
           - "{{ include "apisix.etcd.auth.scheme" . }}://{{ .Release.Name }}-etcd.{{ .Release.Namespace }}.svc.{{ .Values.etcd.clusterDomain }}:{{ .Values.etcd.service.port }}"
           {{- end}}
-      {{- else }}
-        host:                          # it's possible to define multiple etcd hosts addresses of the same etcd cluster.
+        {{- else if (and (index .Values "ingress-controller" "enabled") (index .Values "ingress-controller" "config" "etcdserver" "enabled")) }}
+          - http://{{ $apisixIngressControllerFullname }}:12379
+        {{- else }}
           {{- range $value := .Values.etcd.host }}
           - "{{ $value }}"             # multiple etcd address
           {{- end}}
-      {{- end }}
+        {{- end }}
         prefix: {{ .Values.etcd.prefix | quote }}    # configuration prefix in etcd
         timeout: {{ .Values.etcd.timeout }}    # 30 seconds
         {{- include "apisix.etcd.credentials.config" . | nindent 8 }}
@@ -384,7 +387,5 @@ data:
           sni: "{{ .Values.etcd.auth.tls.sni }}"
         {{- end }}
       {{- end }}
-      {{- end }}
-
-      
+      {{- end }}    
 {{- end }}


### PR DESCRIPTION
When running the ingress-controller, we usually scale the replicas to more than 1 to ensure HA. but in experimental mode which start the built-in etcd grpcserver, as all the controllers had enabled leader election, then only one of then can actually serve grpc requests from APISIX gateway. In another words, only the gateway that live with the working ingress-controller can process requests from clients.

This PR restricts gateway related manifests to be rendered only when the `replicasCount=1` and `gateway.enabled=true`.

changes in the `charts/apisix/templates/configmap.yaml` allow us to test this feature without too much modifications.