### PR TITLE
More options for standalone configuration

### DIFF
--- a/charts/apisix/README.md
+++ b/charts/apisix/README.md
@@ -65,7 +65,8 @@ The command removes all the Kubernetes components associated with the chart and 
 | apisix.customPlugins.plugins[0].configMap.name | string | `"configmap-name"` | name of configmap. |
 | apisix.deployment.mode | string | `"traditional"` | Apache APISIX deployment mode Optional: traditional, decoupled, standalone  ref: https://apisix.apache.org/docs/apisix/deployment-modes/ |
 | apisix.deployment.role | string | `"traditional"` | Deployment role Optional: traditional, data_plane, control_plane  ref: https://apisix.apache.org/docs/apisix/deployment-modes/ |
-| apisix.deployment.standaloneConfig | string | `""` | Standalone rules configuration  ref: https://apisix.apache.org/docs/apisix/deployment-modes/#standalone |
+| apisix.deployment.standalone.config | string | `"routes: - uri: /hi upstream: nodes: "127.0.0.1:1980": 1 type: roundrobin"` | Standalone rules configuration  ref: https://apisix.apache.org/docs/apisix/deployment-modes/#standalone |
+| apisix.deployment.standalone.existingConfigMap | string | `""` | Specifies the name of the ConfigMap that contains the rule configurations. |
 | apisix.discovery.enabled | bool | `false` | Enable or disable Apache APISIX integration service discovery |
 | apisix.discovery.registry | object | `{}` | Registry is the same to the one in APISIX [config-default.yaml](https://github.com/apache/apisix/blob/master/conf/config-default.yaml#L281), and refer to such file for more setting details. also refer to [this documentation for integration service discovery](https://apisix.apache.org/docs/apisix/discovery) |
 | apisix.dns.resolvers[0] | string | `"127.0.0.1"` |  |

--- a/charts/apisix/README.md
+++ b/charts/apisix/README.md
@@ -65,6 +65,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | apisix.customPlugins.plugins[0].configMap.name | string | `"configmap-name"` | name of configmap. |
 | apisix.deployment.mode | string | `"traditional"` | Apache APISIX deployment mode Optional: traditional, decoupled, standalone  ref: https://apisix.apache.org/docs/apisix/deployment-modes/ |
 | apisix.deployment.role | string | `"traditional"` | Deployment role Optional: traditional, data_plane, control_plane  ref: https://apisix.apache.org/docs/apisix/deployment-modes/ |
+| apisix.deployment.standaloneConfig | string | `""` | Standalone rules configuration  ref: https://apisix.apache.org/docs/apisix/deployment-modes/#standalone |
 | apisix.discovery.enabled | bool | `false` | Enable or disable Apache APISIX integration service discovery |
 | apisix.discovery.registry | object | `{}` | Registry is the same to the one in APISIX [config-default.yaml](https://github.com/apache/apisix/blob/master/conf/config-default.yaml#L281), and refer to such file for more setting details. also refer to [this documentation for integration service discovery](https://apisix.apache.org/docs/apisix/discovery) |
 | apisix.dns.resolvers[0] | string | `"127.0.0.1"` |  |

--- a/charts/apisix/templates/apisix-config-cm.yml
+++ b/charts/apisix/templates/apisix-config-cm.yml
@@ -21,12 +21,6 @@ metadata:
   name: apisix.yaml
 data:
   apisix.yaml: |
-    routes:
-    -
-      uri: /hi
-      upstream:
-        nodes:
-          "127.0.0.1:1980": 1
-        type: roundrobin
+    {{- .Values.deployment.standaloneConfig | nindent 4 }}
     #END
 {{- end }}

--- a/charts/apisix/templates/apisix-config-cm.yml
+++ b/charts/apisix/templates/apisix-config-cm.yml
@@ -21,6 +21,6 @@ metadata:
   name: apisix.yaml
 data:
   apisix.yaml: |
-    {{- .Values.deployment.standaloneConfig | nindent 4 }}
+    {{- .Values.apisix.deployment.standaloneConfig | nindent 4 }}
     #END
 {{- end }}

--- a/charts/apisix/templates/apisix-config-cm.yml
+++ b/charts/apisix/templates/apisix-config-cm.yml
@@ -14,13 +14,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- if eq .Values.apisix.deployment.mode "standalone" }}
+{{- if and (eq .Values.apisix.deployment.mode "standalone") (not .Values.apisix.deployment.standalone.existingConfigMap) }}
 kind: ConfigMap
 apiVersion: v1
 metadata:
   name: apisix.yaml
 data:
   apisix.yaml: |
-    {{- .Values.apisix.deployment.standaloneConfig | nindent 4 }}
+    {{- .Values.apisix.deployment.standalone.config | nindent 4 }}
     #END
 {{- end }}

--- a/charts/apisix/templates/deployment.yaml
+++ b/charts/apisix/templates/deployment.yaml
@@ -238,7 +238,7 @@ spec:
       volumes:
         {{- if eq .Values.apisix.deployment.mode "standalone" }}
         - configMap:
-            name: apisix.yaml
+            name: {{ .Values.apisix.deployment.standalone.existingConfigMap | default "apisix.yaml" }}
           name: apisix-admin
         {{- end }}
         - configMap:

--- a/charts/apisix/values.yaml
+++ b/charts/apisix/values.yaml
@@ -308,14 +308,20 @@ apisix:
     # -- Standalone rules configuration
     #
     # ref: https://apisix.apache.org/docs/apisix/deployment-modes/#standalone
-    standaloneConfig: |
-      routes:
-      -
-        uri: /hi
-        upstream:
-          nodes:
-            "127.0.0.1:1980": 1
-          type: roundrobin
+    standalone:
+      # -- Rules which are set to the default apisix.yaml configmap.
+      # -- if apisix.delpoyment.standalone.existingConfigMap is empty, these are used.
+      config: |
+        routes:
+        -
+          uri: /hi
+          upstream:
+            nodes:
+              "127.0.0.1:1980": 1
+            type: roundrobin
+      # -- Specifies the name of the ConfigMap that contains the rule configurations.
+      # The configuration must be set to the key named `apisix.yaml` in the configmap.
+      existingConfigMap: ""
 
   admin:
     # -- Enable Admin API

--- a/charts/apisix/values.yaml
+++ b/charts/apisix/values.yaml
@@ -305,6 +305,18 @@ apisix:
     # ref: https://apisix.apache.org/docs/apisix/deployment-modes/
     role: "traditional"
 
+    # -- Standalone rules configuration
+    #
+    # ref: https://apisix.apache.org/docs/apisix/deployment-modes/#standalone
+    standaloneConfig: |
+      routes:
+      -
+        uri: /hi
+        upstream:
+          nodes:
+            "127.0.0.1:1980": 1
+          type: roundrobin
+
   admin:
     # -- Enable Admin API
     enabled: true


### PR DESCRIPTION
Related to issue: #705

Allow to set standalone configuration with chart values or by using existing ConfigMap.