### PR TITLE
Add support for custom ports

### DIFF
--- a/charts/apisix/Chart.yaml
+++ b/charts/apisix/Chart.yaml
@@ -31,7 +31,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.11.0
+version: 1.11.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/apisix/README.md
+++ b/charts/apisix/README.md
@@ -162,6 +162,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | fullnameOverride | string | `""` |  |
 | gateway.externalIPs | list | `[]` |  |
 | gateway.externalTrafficPolicy | string | `"Cluster"` |  |
+| gateway.additionalContainerPorts | list | `[]` | Expose additional ports from the container (without impact on apisix configuration) |
 | gateway.http | object | `{"additionalContainerPorts":[],"containerPort":9080,"enabled":true,"servicePort":80}` | Apache APISIX service settings for http |
 | gateway.http.additionalContainerPorts | list | `[]` | Support multiple http ports, See [Configuration](https://github.com/apache/apisix/blob/0bc65ea9acd726f79f80ae0abd8f50b7eb172e3d/conf/config-default.yaml#L24) |
 | gateway.ingress | object | `{"annotations":{},"enabled":false,"hosts":[{"host":"apisix.local","paths":[]}],"tls":[]}` | Using ingress access Apache APISIX service |

--- a/charts/apisix/templates/_pod.tpl
+++ b/charts/apisix/templates/_pod.tpl
@@ -123,6 +123,11 @@ spec:
         {{- end }}
         {{- end }}
         {{- end }}
+        {{- range .Values.gateway.additionalContainerPorts }}
+        - name: {{ .name }}
+          containerPort: {{ .port }}
+          protocol: {{ .protocol }}
+        {{- end }}     
 
       {{- if ne .Values.deployment.role "control_plane" }}
       readinessProbe:

--- a/charts/apisix/values.yaml
+++ b/charts/apisix/values.yaml
@@ -230,6 +230,10 @@ gateway:
   # annotations:
   #   service.beta.kubernetes.io/aws-load-balancer-type: nlb
   externalIPs: []
+  # -- Expose the port on the container only (no config changes applied on apisix process)
+  additionalContainerPorts: []
+  # - ip: 127.0.0.3           # Specific IP, If not set, the default value is `0.0.0.0`.
+  #   port: 9445
   # -- Apache APISIX service settings for http
   http:
     enabled: true

--- a/charts/apisix/values.yaml
+++ b/charts/apisix/values.yaml
@@ -232,8 +232,9 @@ gateway:
   externalIPs: []
   # -- Expose the port on the container only (no config changes applied on apisix process)
   additionalContainerPorts: []
-  # - ip: 127.0.0.3           # Specific IP, If not set, the default value is `0.0.0.0`.
-  #   port: 9445
+  #   port: 9091
+  #   protocol: TCP
+  #  name: prometheus
   # -- Apache APISIX service settings for http
   http:
     enabled: true


### PR DESCRIPTION
This PR add supports for custom ports without impacting the apisix configuration by itself.

It is useful to expose ports that may be exposed from specific apisix configuration like Prometheus.

This makes possible to monitor APISIX with Prometheus using only standard Kubernetes annotations and without requiring ServiceMonitor CRD support (it can also likely solve others usercases)

Fixed #720 