### PR TITLE
feat: enable loki-logger plugin

### DIFF
--- a/charts/apisix-ingress-controller/templates/apisix-configmap.yaml
+++ b/charts/apisix-ingress-controller/templates/apisix-configmap.yaml
@@ -132,6 +132,7 @@ data:
       - public-api                     # priority: 501
       - prometheus                     # priority: 500
       - datadog                        # priority: 495
+      - loki-logger                    # priority: 414
       - elasticsearch-logger           # priority: 413
       - echo                           # priority: 412
       - loggly                         # priority: 411


### PR DESCRIPTION
Enable loki-logger plugin for apisix gateway in apisix-ingress-controller Helm Chart.