### PR TITLE
feat: add enable_server_tokens option

### DIFF
--- a/charts/apisix-ingress-controller/README.md
+++ b/charts/apisix-ingress-controller/README.md
@@ -145,7 +145,7 @@ The same for container level, you need to set:
 | config.logOutput | string | `"stderr"` | the output file path of error log, default is stderr, when the file path is "stderr" or "stdout", logs are marshalled plainly, which is more readable for human; otherwise logs are marshalled in JSON format, which can be parsed by programs easily. |
 | config.pluginMetadataCM | string | `""` | Pluginmetadata in APISIX can be controlled through ConfigMap. default is "" |
 | fullnameOverride | string | `""` |  |
-| gateway.enableServerTokens | bool | `` |  |
+| gateway.enableServerTokens | bool | true | If set to true, shows APISIX version in the `Server` response header. |
 | gateway.externalIPs | list | `[]` | load balancer ips |
 | gateway.externalTrafficPolicy | string | `"Cluster"` |  |
 | gateway.nginx.errorLog | string | `"stderr"` | Nginx error logs path |

--- a/charts/apisix-ingress-controller/README.md
+++ b/charts/apisix-ingress-controller/README.md
@@ -145,6 +145,7 @@ The same for container level, you need to set:
 | config.logOutput | string | `"stderr"` | the output file path of error log, default is stderr, when the file path is "stderr" or "stdout", logs are marshalled plainly, which is more readable for human; otherwise logs are marshalled in JSON format, which can be parsed by programs easily. |
 | config.pluginMetadataCM | string | `""` | Pluginmetadata in APISIX can be controlled through ConfigMap. default is "" |
 | fullnameOverride | string | `""` |  |
+| gateway.enableServerTokens | bool | `` |  |
 | gateway.externalIPs | list | `[]` | load balancer ips |
 | gateway.externalTrafficPolicy | string | `"Cluster"` |  |
 | gateway.nginx.errorLog | string | `"stderr"` | Nginx error logs path |

--- a/charts/apisix-ingress-controller/templates/apisix-configmap.yaml
+++ b/charts/apisix-ingress-controller/templates/apisix-configmap.yaml
@@ -41,7 +41,7 @@ data:
     apisix:
       enable_control: true
       enable_reuseport: true
-      {{- if hasKey .Values.gateway "enableServerTokens" }}
+      {{- if and (not (eq .Values.gateway.enableServerTokens nil)) (hasKey .Values.gateway "enableServerTokens") }}
       enable_server_tokens: {{ .Values.gateway.enableServerTokens }}
       {{- end }}
 

--- a/charts/apisix-ingress-controller/templates/apisix-configmap.yaml
+++ b/charts/apisix-ingress-controller/templates/apisix-configmap.yaml
@@ -41,6 +41,9 @@ data:
     apisix:
       enable_control: true
       enable_reuseport: true
+      {{- if hasKey .Values.gateway "enableServerTokens" }}
+      enable_server_tokens: {{ .Values.gateway.enableServerTokens }}
+      {{- end }}
 
       stream_proxy:
         only: false

--- a/charts/apisix-ingress-controller/values.yaml
+++ b/charts/apisix-ingress-controller/values.yaml
@@ -234,7 +234,9 @@ gateway:
   #   - "143.231.0.0/16"
   # -- load balancer ips
   externalIPs: []
-  # enableServerTokens: false
+  # -- (bool) If set to true, shows APISIX version in the `Server` response header.
+  # @default -- true
+  enableServerTokens:
   nginx:
     # -- Nginx workerRlimitNoFile
     workerRlimitNofile: "20480"

--- a/charts/apisix-ingress-controller/values.yaml
+++ b/charts/apisix-ingress-controller/values.yaml
@@ -234,6 +234,7 @@ gateway:
   #   - "143.231.0.0/16"
   # -- load balancer ips
   externalIPs: []
+  # enableServerTokens: false
   nginx:
     # -- Nginx workerRlimitNoFile
     workerRlimitNofile: "20480"


### PR DESCRIPTION
APISIX/nginx server tokens are enabled by default, and leak APISIX version is form of a header - `Server: APISIX/3.8.0`. Add option to allow to disable version leak, turning header into `Server: APISIX` (full removal of the header is probably possible only using header-manipulating plugins).