### PR TITLE
feat: support adding labels to APISIX Pods

### DIFF
--- a/charts/apisix/README.md
+++ b/charts/apisix/README.md
@@ -85,6 +85,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | apisix.podDisruptionBudget.enabled | bool | `false` | Enable or disable podDisruptionBudget |
 | apisix.podDisruptionBudget.maxUnavailable | int | `1` | Set the maxUnavailable of podDisruptionBudget |
 | apisix.podDisruptionBudget.minAvailable | string | `"90%"` | Set the `minAvailable` of podDisruptionBudget. You can specify only one of `maxUnavailable` and `minAvailable` in a single PodDisruptionBudget. See [Specifying a Disruption Budget for your Application](https://kubernetes.io/docs/tasks/run-application/configure-pdb/#specifying-a-poddisruptionbudget) for more details |
+| apisix.podLabels | object | `{}` | Labels to add to each pod |
 | apisix.podSecurityContext | object | `{}` | Set the securityContext for Apache APISIX pods |
 | apisix.priorityClassName | string | `""` | Set [priorityClassName](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#pod-priority) for Apache APISIX pods |
 | apisix.proxyProtocol | object | `{"enabled":false,"listenHttpPort":9181,"listenHttpsPort":9182,"tcp":true,"upstream":true}` | Enable Proxy Protocol |

--- a/charts/apisix/templates/_pod.tpl
+++ b/charts/apisix/templates/_pod.tpl
@@ -7,6 +7,9 @@ metadata:
     {{- end }}
   labels:
     {{- include "apisix.selectorLabels" . | nindent 4 }}
+    {{- with .Values.apisix.podLabels }}
+      {{ tpl (toYaml .) $ | nindent 4}}
+    {{- end }}
 spec:
   {{- with .Values.global.imagePullSecrets }}
   imagePullSecrets:

--- a/charts/apisix/values.yaml
+++ b/charts/apisix/values.yaml
@@ -116,6 +116,8 @@ apisix:
   priorityClassName: ""
   # -- Annotations to add to each pod
   podAnnotations: {}
+  # -- Labels to add to each pod
+  podLabels: {}
   # -- Set the securityContext for Apache APISIX pods
   podSecurityContext: {}
     # fsGroup: 2000


### PR DESCRIPTION
Allowing to add labels for APISIX Pods makes possible the usage of tools like [Istio sidecar injection](https://istio.io/latest/docs/setup/additional-setup/sidecar-injection/#controlling-the-injection-policy).