### PR TITLE
Fix: Refactor ServiceMonitor template to avoid duplicates across releases

### DIFF
--- a/charts/apisix/templates/service-monitor.yaml
+++ b/charts/apisix/templates/service-monitor.yaml
@@ -18,15 +18,18 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: {{ .Values.metrics.serviceMonitor.name | default (include "apisix.fullname" .) }}
+  name: {{ .Values.metrics.serviceMonitor.name | default "apisix-service-monitor" }}
   namespace: {{ .Values.metrics.serviceMonitor.namespace | default .Release.Namespace }}
   labels:
-    {{- include "apisix.labels" . | nindent 4 }}
     {{- if .Values.metrics.serviceMonitor.labels }}
     {{- toYaml .Values.metrics.serviceMonitor.labels | nindent 4 }}
     {{- end }}
   {{- if .Values.metrics.serviceMonitor.annotations }}
-  annotations: {{- toYaml .Values.metrics.serviceMonitor.annotations | nindent 4 }}
+  annotations:
+    {{- toYaml .Values.metrics.serviceMonitor.annotations | nindent 4 }}
+    "helm.sh/hook": pre-install,post-install
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   {{- end }}
 spec:
   namespaceSelector:
@@ -34,8 +37,8 @@ spec:
     - {{ .Values.metrics.serviceMonitor.namespace | default .Release.Namespace }}
   selector:
     matchLabels:
-      {{- include "apisix.labels" . | nindent 6 }}
-      app.kubernetes.io/service: apisix-prometheus-metrics
+      app.kubernetes.io/name: {{ include "apisix.name" . }}
+      app.kubernetes.io/service: apisix-gateway
   endpoints:
   - scheme: http
     targetPort: prometheus

--- a/charts/apisix/templates/service-monitor.yaml
+++ b/charts/apisix/templates/service-monitor.yaml
@@ -14,19 +14,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- if .Values.metrics.serviceMonitor.enabled }}
+{{- if .Values.serviceMonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: {{ .Values.metrics.serviceMonitor.name | default "apisix-service-monitor" }}
-  namespace: {{ .Values.metrics.serviceMonitor.namespace | default .Release.Namespace }}
+  name: {{ .Values.serviceMonitor.name | default "apisix-service-monitor" }}
+  namespace: {{ .Values.serviceMonitor.namespace | default .Release.Namespace }}
   labels:
-    {{- if .Values.metrics.serviceMonitor.labels }}
-    {{- toYaml .Values.metrics.serviceMonitor.labels | nindent 4 }}
+    {{- if .Values.serviceMonitor.labels }}
+    {{- toYaml .Values.serviceMonitor.labels | nindent 4 }}
     {{- end }}
-  {{- if .Values.metrics.serviceMonitor.annotations }}
+  {{- if .Values.serviceMonitor.annotations }}
   annotations:
-    {{- toYaml .Values.metrics.serviceMonitor.annotations | nindent 4 }}
+    {{- toYaml .Values.serviceMonitor.annotations | nindent 4 }}
     "helm.sh/hook": pre-install,post-install
     "helm.sh/hook-weight": "-5"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
@@ -34,7 +34,7 @@ metadata:
 spec:
   namespaceSelector:
     matchNames:
-    - {{ .Values.metrics.serviceMonitor.namespace | default .Release.Namespace }}
+    - {{ .Values.serviceMonitor.namespace | default .Release.Namespace }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "apisix.name" . }}
@@ -42,6 +42,6 @@ spec:
   endpoints:
   - scheme: http
     targetPort: prometheus
-    path: {{ .Values.apisix.prometheus.path }}
-    interval: {{ .Values.metrics.serviceMonitor.interval }}
+    path: {{ .Values.serviceMonitor.path }}
+    interval: {{ .Values.serviceMonitor.interval }}
 {{- end }}


### PR DESCRIPTION
Description:

This pull request refactors the ServiceMonitor template in the APISIX Helm Chart to ensure that only one ServiceMonitor is created per namespace, even if there are multiple releases of the Chart.

Problem:
Currently, each release of the APISIX Helm Chart creates its own ServiceMonitor. This can lead to duplicate ServiceMonitors and unnecessary overhead in Prometheus when there are multiple releases of the Chart in the same namespace.

Solution:
We've utilized Helm's hook mechanism to ensure that only one ServiceMonitor is created per namespace, regardless of the number of releases.

Changes:

Removed release-specific labels and selectors from the ServiceMonitor template. The ServiceMonitor now selects all services with the labels app.kubernetes.io/name: {{ include "apisix.name" . }} and app.kubernetes.io/service: apisix-gateway, regardless of the release.
Added pre-install and post-install hooks to the ServiceMonitor. Before creating a new ServiceMonitor, these hooks check if one already exists with the name apisix-service-monitor. If it exists, it's deleted before creating a new one. This ensures that there's always only one ServiceMonitor.
Set the hook deletion policy to before-hook-creation and hook-succeeded. This means that the hook resource is deleted before a new one is created (if one already exists), and it's also deleted after the ServiceMonitor is successfully created.
Implications:

All releases of the APISIX Helm Chart in the same namespace will share the same ServiceMonitor. This is suitable when all releases can share the same ServiceMonitor configuration.
If a release is uninstalled, it won't delete the ServiceMonitor, as it may still be used by other releases.
If the ServiceMonitor is manually deleted, upgrading a release will recreate it, but other releases might need a manual upgrade to reconnect to the new ServiceMonitor.
This approach can work well in many cases, especially when you have multiple releases that can all share the same ServiceMonitor configuration. For more complex scenarios, other strategies like using relabeling in the Prometheus configuration to handle different ServiceMonitors might be considered.