### PR TITLE
chore: release APISIX 3.9.1

### DIFF
--- a/charts/apisix/Chart.yaml
+++ b/charts/apisix/Chart.yaml
@@ -31,12 +31,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.6.0
+version: 2.7.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 3.8.0
+appVersion: 3.9.1
 sources:
   - https://github.com/apache/apisix-helm-chart
 

--- a/charts/apisix/README.md
+++ b/charts/apisix/README.md
@@ -75,6 +75,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | apisix.dns.resolvers[5] | string | `"8.8.8.8"` |  |
 | apisix.dns.timeout | int | `5` |  |
 | apisix.dns.validity | int | `30` |  |
+| apisix.enableHTTP2 | bool | `true` |  |
 | apisix.enableIPv6 | bool | `true` | Enable nginx IPv6 resolver |
 | apisix.enableServerTokens | bool | `true` | Whether the APISIX version number should be shown in Server header |
 | apisix.extPlugin.cmd | list | `["/path/to/apisix-plugin-runner/runner","run"]` | the command and its arguements to run as a subprocess |
@@ -113,10 +114,10 @@ The command removes all the Kubernetes components associated with the chart and 
 | apisix.ssl.additionalContainerPorts | list | `[]` | Support multiple https ports, See [Configuration](https://github.com/apache/apisix/blob/0bc65ea9acd726f79f80ae0abd8f50b7eb172e3d/conf/config-default.yaml#L99) |
 | apisix.ssl.certCAFilename | string | `""` | Filename be used in the apisix.ssl.existingCASecret |
 | apisix.ssl.containerPort | int | `9443` |  |
+| apisix.ssl.enableHTTP3 | bool | `false` |  |
 | apisix.ssl.enabled | bool | `false` |  |
 | apisix.ssl.existingCASecret | string | `""` | Specifies the name of Secret contains trusted CA certificates in the PEM format used to verify the certificate when APISIX needs to do SSL/TLS handshaking with external services (e.g. etcd) |
 | apisix.ssl.fallbackSNI | string | `""` | Define SNI to fallback if none is presented by client |
-| apisix.ssl.http2.enabled | bool | `true` |  |
 | apisix.ssl.sslProtocols | string | `"TLSv1.2 TLSv1.3"` | TLS protocols allowed to use. |
 | apisix.stream_plugins | list | `[]` | Customize the list of APISIX stream_plugins to enable. By default, APISIX's default stream_plugins are automatically used. See [config-default.yaml](https://github.com/apache/apisix/blob/master/conf/config-default.yaml) |
 | apisix.vault.enabled | bool | `false` | Enable or disable the vault integration |
@@ -167,7 +168,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | hostNetwork | bool | `false` |  |
 | image.pullPolicy | string | `"IfNotPresent"` | Apache APISIX image pull policy |
 | image.repository | string | `"apache/apisix"` | Apache APISIX image repository |
-| image.tag | string | `"3.8.0-debian"` | Apache APISIX image tag Overrides the image tag whose default is the chart appVersion. |
+| image.tag | string | `"3.9.1-debian"` | Apache APISIX image tag Overrides the image tag whose default is the chart appVersion. |
 | ingress | object | `{"annotations":{},"enabled":false,"hosts":[{"host":"apisix.local","paths":[]}],"servicePort":null,"tls":[]}` | Using ingress access Apache APISIX service |
 | ingress-controller | object | `{"config":{"apisix":{"adminAPIVersion":"v3"}},"enabled":false}` | Ingress controller configuration |
 | ingress.annotations | object | `{}` | Ingress annotations |

--- a/charts/apisix/templates/configmap.yaml
+++ b/charts/apisix/templates/configmap.yaml
@@ -66,6 +66,7 @@ data:
       enable_dev_mode: false                       # Sets nginx worker_processes to 1 if set to true
       enable_reuseport: true                       # Enable nginx SO_REUSEPORT switch if set to true.
       enable_ipv6: {{ .Values.apisix.enableIPv6 }} # Enable nginx IPv6 resolver
+      enable_http2: {{ .Values.apisix.enableHTTP2 }}
       enable_server_tokens: {{ .Values.apisix.enableServerTokens }} # Whether the APISIX version number should be shown in Server header
 
       # proxy_protocol:                   # Proxy Protocol configuration
@@ -149,7 +150,7 @@ data:
         enable: {{ .Values.apisix.ssl.enabled }}
         listen:
           - port: {{ .Values.apisix.ssl.containerPort }}
-            enable_http2: {{ .Values.apisix.ssl.http2.enabled }}
+            enable_http3: {{ .Values.apisix.ssl.enableHTTP3 }}
           {{- with .Values.apisix.ssl.additionalContainerPorts }}
           {{- toYaml . | nindent 10}}
           {{- end }}

--- a/charts/apisix/values.yaml
+++ b/charts/apisix/values.yaml
@@ -29,7 +29,7 @@ image:
   pullPolicy: IfNotPresent
   # -- Apache APISIX image tag
   # Overrides the image tag whose default is the chart appVersion.
-  tag: 3.8.0-debian
+  tag: 3.9.1-debian
 
 # -- set false to use `Deployment`, set true to use `DaemonSet`
 useDaemonSet: false
@@ -233,6 +233,7 @@ metrics:
 apisix:
   # -- Enable nginx IPv6 resolver
   enableIPv6: true
+  enableHTTP2: true
 
   # -- Whether the APISIX version number should be shown in Server header
   enableServerTokens: true
@@ -266,13 +267,12 @@ apisix:
     additionalContainerPorts: []
       # - ip: 127.0.0.3           # Specific IP, If not set, the default value is `0.0.0.0`.
       #   port: 9445
-      #   enable_http2: true
+      #   enable_http3: true
     # -- Specifies the name of Secret contains trusted CA certificates in the PEM format used to verify the certificate when APISIX needs to do SSL/TLS handshaking with external services (e.g. etcd)
     existingCASecret: ""
     # -- Filename be used in the apisix.ssl.existingCASecret
     certCAFilename: ""
-    http2:
-      enabled: true
+    enableHTTP3: false
     # -- TLS protocols allowed to use.
     sslProtocols: "TLSv1.2 TLSv1.3"
     # -- Define SNI to fallback if none is presented by client


### PR DESCRIPTION
change(http2):  https://github.com/apache/apisix/pull/11032
* remove `apisix.ssl.http2.enabled`
* add `apisix.enableHTTP2`

feat(http3): https://github.com/apache/apisix/pull/11010
* add `apisix.ssl.enableHTTP3`