### PR TITLE
feat: re-enable proxy-protocol configuration nodes

### DIFF
--- a/charts/apisix/Chart.yaml
+++ b/charts/apisix/Chart.yaml
@@ -31,7 +31,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.8.1
+version: 2.8.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/apisix/README.md
+++ b/charts/apisix/README.md
@@ -111,6 +111,11 @@ The command removes all the Kubernetes components associated with the chart and 
 | apisix.prometheus.enabled | bool | `false` |  |
 | apisix.prometheus.metricPrefix | string | `"apisix_"` | prefix of the metrics |
 | apisix.prometheus.path | string | `"/apisix/prometheus/metrics"` | path of the metrics endpoint |
+| apisix.proxyProtocol | object | `{"enabled":false,"listenHttpPort":9181,"listenHttpsPort":9182,"tcp":true,"upstream":true}` | Enable Proxy Protocol |
+| apisix.proxyProtocol.listenHttpPort | int | `9181` | The port with proxy protocol for http, it differs from node_listen and admin_listen. |
+| apisix.proxyProtocol.listenHttpsPort | int | `9182` | The port with proxy protocol for https |
+| apisix.proxyProtocol.tcp | bool | `true` | Enable the proxy protocol for tcp proxy, it works for stream_proxy.tcp option |
+| apisix.proxyProtocol.upstream | bool | `true` | Enable the proxy protocol to the upstream server |
 | apisix.router.http | string | `"radixtree_host_uri"` | Defines how apisix handles routing: - radixtree_uri: match route by uri(base on radixtree) - radixtree_host_uri: match route by host + uri(base on radixtree) - radixtree_uri_with_parameter: match route by uri with parameters |
 | apisix.setIDFromPodUID | bool | `false` | Use Pod metadata.uid as the APISIX id. |
 | apisix.ssl.additionalContainerPorts | list | `[]` | Support multiple https ports, See [Configuration](https://github.com/apache/apisix/blob/0bc65ea9acd726f79f80ae0abd8f50b7eb172e3d/conf/config-default.yaml#L99) |
@@ -203,6 +208,9 @@ The command removes all the Kubernetes components associated with the chart and 
 | service.http | object | `{"additionalContainerPorts":[],"containerPort":9080,"enabled":true,"servicePort":80}` | Apache APISIX service settings for http |
 | service.http.additionalContainerPorts | list | `[]` | Support multiple http ports, See [Configuration](https://github.com/apache/apisix/blob/0bc65ea9acd726f79f80ae0abd8f50b7eb172e3d/conf/config-default.yaml#L24) |
 | service.labelsOverride | object | `{}` | Override default labels assigned to Apache APISIX gateway resources |
+| service.proxyProtocol | object | `{"http":{"containerPort":9181,"enabled":false,"servicePort":9181},"https":{"containerPort":9182,"enabled":false,"servicePort":9182}}` | Proxy Protocol Configuration |
+| service.proxyProtocol.http | object | `{"containerPort":9181,"enabled":false,"servicePort":9181}` | If you enable proxy protocol, you must use this port to receive http request with proxy protocol |
+| service.proxyProtocol.https | object | `{"containerPort":9182,"enabled":false,"servicePort":9182}` | The port with proxy protocol for https |
 | service.stream | object | `{"enabled":false,"tcp":[],"udp":[]}` | Apache APISIX service settings for stream. L4 proxy (TCP/UDP) |
 | service.tls | object | `{"servicePort":443}` | Apache APISIX service settings for tls |
 | service.type | string | `"NodePort"` | Apache APISIX service type for user access itself |

--- a/charts/apisix/templates/configmap.yaml
+++ b/charts/apisix/templates/configmap.yaml
@@ -69,14 +69,16 @@ data:
       enable_http2: {{ .Values.apisix.enableHTTP2 }}
       enable_server_tokens: {{ .Values.apisix.enableServerTokens }} # Whether the APISIX version number should be shown in Server header
 
-      # proxy_protocol:                   # Proxy Protocol configuration
-      #   listen_http_port: 9181          # The port with proxy protocol for http, it differs from node_listen and admin_listen.
-      #                                   # This port can only receive http request with proxy protocol, but node_listen & admin_listen
-      #                                   # can only receive http request. If you enable proxy protocol, you must use this port to
-      #                                   # receive http request with proxy protocol
-      #   listen_https_port: 9182         # The port with proxy protocol for https
-      #   enable_tcp_pp: true             # Enable the proxy protocol for tcp proxy, it works for stream_proxy.tcp option
-      #   enable_tcp_pp_to_upstream: true # Enables the proxy protocol to the upstream server
+      {{- if .Values.apisix.proxyProtocol.enabled }}
+      proxy_protocol:                                                          # Proxy Protocol configuration
+        listen_http_port: {{ .Values.apisix.proxyProtocol.listenHttpPort }}    # The port with proxy protocol for http, it differs from node_listen and port_admin.
+                                                                               # This port can only receive http request with proxy protocol, but node_listen & port_admin
+                                                                               # can only receive http request. If you enable proxy protocol, you must use this port to
+                                                                               # receive http request with proxy protocol
+        listen_https_port: {{ .Values.apisix.proxyProtocol.listenHttpsPort }}  # The port with proxy protocol for https
+        enable_tcp_pp: {{ .Values.apisix.proxyProtocol.tcp }}                  # Enable the proxy protocol for tcp proxy, it works for stream_proxy.tcp option
+        enable_tcp_pp_to_upstream: {{ .Values.apisix.proxyProtocol.upstream }} # Enable the proxy protocol to the upstream server
+      {{- end }}
 
       proxy_cache:                         # Proxy Caching configuration
         cache_ttl: 10s                     # The default caching time if the upstream does not specify the cache time

--- a/charts/apisix/templates/deployment.yaml
+++ b/charts/apisix/templates/deployment.yaml
@@ -126,6 +126,16 @@ spec:
               containerPort: {{ .Values.apisix.prometheus.containerPort }}
               protocol: TCP
             {{- end }}
+            {{- if .Values.service.proxyProtocol.http.enabled }}
+            - name: pp-http
+              containerPort: {{ .Values.service.proxyProtocol.http.containerPort }}
+              protocol: TCP
+            {{- end }}
+            {{- if .Values.service.proxyProtocol.https.enabled }}
+            - name: pp-https
+              containerPort: {{ .Values.service.proxyProtocol.https.containerPort }}
+              protocol: TCP
+            {{- end }}
             {{- if and .Values.service.stream.enabled (or (gt (len .Values.service.stream.tcp) 0) (gt (len .Values.service.stream.udp) 0)) }}
             {{- with .Values.service.stream }}
             {{- if (gt (len .tcp) 0) }}

--- a/charts/apisix/templates/service-gateway.yaml
+++ b/charts/apisix/templates/service-gateway.yaml
@@ -76,6 +76,24 @@ spec:
     port: {{ .port }}
     targetPort: {{ .port }}
   {{- end }}
+  {{- if or .Values.service.proxyProtocol.http.enabled }}
+  - name: apisix-gateway-pp-http
+    port: {{ .Values.service.proxyProtocol.http.servicePort }}
+    targetPort: {{ .Values.service.proxyProtocol.http.containerPort }}
+  {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.proxyProtocol.http.nodePort))) }}
+    nodePort: {{ .Values.service.proxyProtocol.http.nodePort }}
+  {{- end }}
+    protocol: TCP
+  {{- end }}
+  {{- if or .Values.service.proxyProtocol.https.enabled }}
+  - name: apisix-gateway-pp-https
+    port: {{ .Values.service.proxyProtocol.https.servicePort }}
+    targetPort: {{ .Values.service.proxyProtocol.https.containerPort }}
+  {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.proxyProtocol.https.nodePort))) }}
+    nodePort: {{ .Values.service.proxyProtocol.https.nodePort }}
+  {{- end }}
+    protocol: TCP
+  {{- end }}  
   {{- if and .Values.service.stream.enabled (or (gt (len .Values.service.stream.tcp) 0) (gt (len .Values.service.stream.udp) 0)) }}
   {{- with .Values.service.stream }}
   {{- if (gt (len .tcp) 0) }}

--- a/charts/apisix/values.yaml
+++ b/charts/apisix/values.yaml
@@ -189,6 +189,27 @@ service:
     servicePort: 443
     # nodePort: 4443
 
+  # -- Proxy Protocol Configuration
+  proxyProtocol:
+    # -- If you enable proxy protocol, you must use this port to receive http request with proxy protocol
+    http:
+      enabled: false
+      # - Specify NodePort (only if gateway.type is NodePort)
+      # nodePort:
+      # - Define a Service Port on which the gateway is listening
+      servicePort: 9181
+      # - Gateway Service Port to use as target
+      containerPort: 9181
+    # -- The port with proxy protocol for https
+    https:
+      enabled: false
+      # - Specify NodePort (only if gateway.type is NodePort)
+      # nodePort:
+      # - Define a Service Port on which the gateway is listening
+      servicePort: 9182
+      # - Gateway Service Port to use as target
+      containerPort: 9182
+
   # -- Apache APISIX service settings for stream. L4 proxy (TCP/UDP)
   stream:
     enabled: false
@@ -243,6 +264,18 @@ apisix:
 
   # -- Use Pod metadata.uid as the APISIX id.
   setIDFromPodUID: false
+
+  # -- Enable Proxy Protocol
+  proxyProtocol:
+    enabled: false
+    # -- The port with proxy protocol for http, it differs from node_listen and admin_listen.
+    listenHttpPort: 9181
+    # -- The port with proxy protocol for https
+    listenHttpsPort: 9182
+    # -- Enable the proxy protocol for tcp proxy, it works for stream_proxy.tcp option
+    tcp: true
+    # -- Enable the proxy protocol to the upstream server
+    upstream: true
 
   # -- Whether to add a custom lua module
   luaModuleHook:


### PR DESCRIPTION
Hello everybody 👋🏻 

I contributed in june 2023 to this project by adding configuration nodes in helm chart allowing clean proxy-protocol configuration (https://github.com/apache/apisix-helm-chart/pull/528).

Recently we wanted to upgrade our current APISIX release because of [CVE-2024-32638](https://www.cvedetails.com/cve/CVE-2024-32638/) but during upgrade we noticed that all proxy-protocol configuration nodes have disapeared since this PR : https://github.com/apache/apisix-helm-chart/pull/738

Currently, we are unable to upgrade APISIX without manually editing ConfigMaps to re-enable proxy-protocol, and that's a big problem because we cannot automatize our deployments. I think we are not alone in this case (for example @adussarps in https://github.com/apache/apisix-helm-chart/issues/748).

Can you consider my PR that re-introduce needed changes ?

Here are example values for testing purpose : 

```yaml
global:
  enableIPv6: false
  storageClass: <my-storage-class>

apisix:
  kind: DaemonSet
  ssl:
    enabled: true
  proxyProtocol:
    enabled: true
    listenHttpPort: 9181
    listenHttpsPort: 9182

service:
  type: NodePort
  http:
    enabled: true
  proxyProtocol:
    http:
      enabled: true
      nodePort: 30080
      containerPort: 9181
    https:
      enabled: true
      nodePort: 30443
      containerPort: 9182
```

This PR also bumps Chart Version to the next minor : 2.9.1.

All comments are welcome.
