### PR TITLE
fix: revert PDB support to latest kubernetes versions

### DIFF
--- a/charts/apisix/templates/pdb.yaml
+++ b/charts/apisix/templates/pdb.yaml
@@ -15,7 +15,11 @@
 # limitations under the License.
 
 {{- if (.Values.podDisruptionBudget.enabled) }}
+{{ if semverCompare "<1.21-0" .Capabilities.KubeVersion.Version -}}
 apiVersion: policy/v1beta1
+{{- else -}}
+apiVersion: policy/v1
+{{- end }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "apisix.fullname" . }}


### PR DESCRIPTION
This PR adds a conditional to use the apiVersion according to the kubernetes version being used.

Similar to [this](https://github.com/apache/apisix-helm-chart/blob/97c26c0e802debaf0b5552763e19591a6ac25427/charts/apisix-ingress-controller/templates/pdb.yaml#L18)

It was ok until this [PR](https://github.com/apache/apisix-helm-chart/pull/738/files) deleted the configuration
