### PR TITLE
chore: update reusability of some parameters, update versions of ingr…

### DIFF
--- a/charts/apisix-dashboard/Chart.yaml
+++ b/charts/apisix-dashboard/Chart.yaml
@@ -31,12 +31,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.2
+version: 0.8.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 3.0.0
+appVersion: 3.0.1
 
 maintainers:
   - name: tao12345666333

--- a/charts/apisix-dashboard/README.md
+++ b/charts/apisix-dashboard/README.md
@@ -78,7 +78,7 @@ _See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command documen
 | fullnameOverride | string | `""` | String to fully override apisix-dashboard.fullname template |
 | image.pullPolicy | string | `"IfNotPresent"` | Apache APISIX Dashboard image pull policy |
 | image.repository | string | `"apache/apisix-dashboard"` | Apache APISIX Dashboard image repository |
-| image.tag | string | `"3.0.0-alpine"` |  |
+| image.tag | string | `"3.0.1-alpine"` |  |
 | imagePullSecrets | list | `[]` | Docker registry secret names as an array |
 | ingress.annotations | object | `{}` | Ingress annotations |
 | ingress.className | string | `""` | Kubernetes 1.18+ support ingressClassName attribute |

--- a/charts/apisix-dashboard/templates/_helpers.tpl
+++ b/charts/apisix-dashboard/templates/_helpers.tpl
@@ -18,7 +18,8 @@
 Expand the name of the chart.
 */}}
 {{- define "apisix-dashboard.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- $nameOverride := tpl .Values.nameOverride $ }}
+{{- default .Chart.Name $nameOverride | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*
@@ -27,10 +28,12 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 If release name contains chart name it will be used as a full name.
 */}}
 {{- define "apisix-dashboard.fullname" -}}
-{{- if .Values.fullnameOverride }}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- $nameOverride := tpl .Values.nameOverride $ }}
+{{- $fullnameOverride := tpl .Values.fullnameOverride $ }}
+{{- if $fullnameOverride }}
+{{- $fullnameOverride | trunc 63 | trimSuffix "-" }}
 {{- else }}
-{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- $name := default .Chart.Name $nameOverride }}
 {{- if contains $name .Release.Name }}
 {{- .Release.Name | trunc 63 | trimSuffix "-" }}
 {{- else }}

--- a/charts/apisix-dashboard/templates/configmap.yaml
+++ b/charts/apisix-dashboard/templates/configmap.yaml
@@ -33,7 +33,7 @@ data:
         prefix: {{ .prefix | quote }}
         endpoints:
           {{- range .endpoints }}
-          - {{ . }}
+          - {{ tpl . $ }}
           {{- end }}
         {{- if .username }}
         username: {{ .username }}

--- a/charts/apisix-dashboard/templates/ingress.yaml
+++ b/charts/apisix-dashboard/templates/ingress.yaml
@@ -43,14 +43,14 @@ spec:
     {{- range .Values.ingress.tls }}
     - hosts:
         {{- range .hosts }}
-        - {{ . | quote }}
+        - {{ tpl . $ | quote }}
         {{- end }}
-      secretName: {{ .secretName }}
+      secretName: {{ tpl .secretName $ }}
     {{- end }}
   {{- end }}
   rules:
     {{- range .Values.ingress.hosts }}
-    - host: {{ .host | quote }}
+    - host: {{ tpl .host $ | quote }}
       http:
         paths:
           {{- range .paths }}

--- a/charts/apisix-dashboard/values.yaml
+++ b/charts/apisix-dashboard/values.yaml
@@ -28,7 +28,7 @@ image:
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   # Apache APISIX Dashboard image tag (immutable tags are recommended)
-  tag: 3.0.0-alpine
+  tag: 3.0.1-alpine
 
 # -- Docker registry secret names as an array
 imagePullSecrets: []

--- a/charts/apisix-ingress-controller/Chart.yaml
+++ b/charts/apisix-ingress-controller/Chart.yaml
@@ -24,8 +24,8 @@ keywords:
   - nginx
   - crd
 type: application
-version: 0.14.0
-appVersion: 1.8.0
+version: 0.14.1
+appVersion: 1.8.2
 sources:
   - https://github.com/apache/apisix-helm-chart
 

--- a/charts/apisix-ingress-controller/README.md
+++ b/charts/apisix-ingress-controller/README.md
@@ -166,7 +166,7 @@ The same for container level, you need to set:
 | gateway.type | string | `"NodePort"` | Apache APISIX service type for user access itself |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"apache/apisix-ingress-controller"` |  |
-| image.tag | string | `"1.8.0"` |  |
+| image.tag | string | `"1.8.2"` |  |
 | imagePullSecrets | list | `[]` |  |
 | initContainer.image | string | `"busybox"` |  |
 | initContainer.tag | float | `1.28` |  |

--- a/charts/apisix-ingress-controller/templates/_helpers.tpl
+++ b/charts/apisix-ingress-controller/templates/_helpers.tpl
@@ -19,7 +19,8 @@
 Expand the name of the chart.
 */}}
 {{- define "apisix-ingress-controller.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- $nameOverride := tpl .Values.nameOverride $ }}
+{{- default .Chart.Name $nameOverride | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*
@@ -28,10 +29,12 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 If release name contains chart name it will be used as a full name.
 */}}
 {{- define "apisix-ingress-controller.fullname" -}}
-{{- if .Values.fullnameOverride }}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- $nameOverride := tpl .Values.nameOverride $ }}
+{{- $fullnameOverride := tpl .Values.fullnameOverride $ }}
+{{- if $fullnameOverride }}
+{{- $fullnameOverride | trunc 63 | trimSuffix "-" }}
 {{- else }}
-{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- $name := default .Chart.Name $nameOverride }}
 {{- if contains $name .Release.Name }}
 {{- .Release.Name | trunc 63 | trimSuffix "-" }}
 {{- else }}

--- a/charts/apisix-ingress-controller/templates/configmap.yaml
+++ b/charts/apisix-ingress-controller/templates/configmap.yaml
@@ -45,11 +45,11 @@ data:
       {{- if gt (len .Values.config.kubernetes.namespaceSelector) 0 }}
       namespace_selector:
       {{- range .Values.config.kubernetes.namespaceSelector }}
-      - {{ . | quote }}
+      - {{ tpl . $ | quote }}
       {{- end }}
       {{- end }}
       election_id: {{ .Values.config.kubernetes.electionId | quote }}
-      ingress_class: {{ .Values.config.kubernetes.ingressClass | quote }}
+      ingress_class: {{ tpl .Values.config.kubernetes.ingressClass $ | quote }}
       ingress_version: {{ .Values.config.kubernetes.ingressVersion | quote }}
       watch_endpointslices: {{ .Values.config.kubernetes.watchEndpointSlices }}
       apisix_route_version: {{ .Values.config.kubernetes.apisixRouteVersion | quote }}
@@ -61,9 +61,9 @@ data:
       default_cluster_base_url: http://127.0.0.1:9180/apisix/admin
       {{ else }}
       {{- if .Values.config.apisix.serviceFullname }}
-      default_cluster_base_url: http://{{ .Values.config.apisix.serviceFullname }}:{{ .Values.config.apisix.servicePort }}/apisix/admin
+      default_cluster_base_url: http://{{ tpl .Values.config.apisix.serviceFullname $ }}:{{ .Values.config.apisix.servicePort }}/apisix/admin
       {{ else }}
-      default_cluster_base_url: http://{{ .Values.config.apisix.serviceName }}.{{ .Values.config.apisix.serviceNamespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.config.apisix.servicePort }}/apisix/admin
+      default_cluster_base_url: http://{{ tpl .Values.config.apisix.serviceName $ }}.{{ tpl .Values.config.apisix.serviceNamespace $ }}.svc.{{ .Values.clusterDomain }}:{{ .Values.config.apisix.servicePort }}/apisix/admin
       {{- end}}
       {{- end }}
       {{- if .Values.config.apisix.existingSecret }}

--- a/charts/apisix-ingress-controller/templates/deployment.yaml
+++ b/charts/apisix-ingress-controller/templates/deployment.yaml
@@ -76,7 +76,7 @@ spec:
           {{ if .Values.config.apisix.serviceFullname }}
           command: ['sh', '-c', "until nc -z {{ .Values.config.apisix.serviceFullname }} {{ .Values.config.apisix.servicePort }} ; do echo waiting for apisix-admin; sleep 2; done;"]
           {{ else }}
-          command: ['sh', '-c', "until nc -z {{ .Values.config.apisix.serviceName }}.{{ .Values.config.apisix.serviceNamespace }}.svc.{{ .Values.clusterDomain }} {{ .Values.config.apisix.servicePort }} ; do echo waiting for apisix-admin; sleep 2; done;"]
+          command: ['sh', '-c', "until nc -z {{ tpl .Values.config.apisix.serviceName $ }}.{{ tpl .Values.config.apisix.serviceNamespace $ }}.svc.{{ .Values.clusterDomain }} {{ .Values.config.apisix.servicePort }} ; do echo waiting for apisix-admin; sleep 2; done;"]
           {{ end}}
 
           securityContext:
@@ -129,7 +129,7 @@ spec:
           - name: DEFAULT_CLUSTER_ADMIN_KEY
             valueFrom:
               secretKeyRef:
-                name: {{ .Values.config.apisix.existingSecret | quote }}
+                name: {{ tpl .Values.config.apisix.existingSecret $ | quote }}
                 key: {{ include "apisix-ingress-controller.credentials.secretAdminKey" . }}
           {{- end }}
         {{ if .Values.config.etcdserver.enabled }}

--- a/charts/apisix-ingress-controller/templates/ingress-class.yaml
+++ b/charts/apisix-ingress-controller/templates/ingress-class.yaml
@@ -7,6 +7,6 @@ apiVersion: {{ .Values.config.kubernetes.ingressVersion }}
 {{- end }}
 kind: IngressClass
 metadata:
-  name: {{ .Values.config.kubernetes.ingressClass | quote }}
+  name: {{ tpl .Values.config.kubernetes.ingressClass $ | quote }}
 spec:
   controller: apisix.apache.org/apisix-ingress # fix: https://github.com/apache/apisix-ingress-controller/issues/1653

--- a/charts/apisix-ingress-controller/values.yaml
+++ b/charts/apisix-ingress-controller/values.yaml
@@ -51,7 +51,7 @@ replicaCount: 1
 image:
   repository: apache/apisix-ingress-controller
   pullPolicy: IfNotPresent
-  tag: "1.8.0"
+  tag: "1.8.2"
 
 podAnnotations: {}
 

--- a/charts/apisix/Chart.yaml
+++ b/charts/apisix/Chart.yaml
@@ -31,7 +31,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.8.1
+version: 2.8.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/apisix/templates/_helpers.tpl
+++ b/charts/apisix/templates/_helpers.tpl
@@ -3,7 +3,8 @@
 Expand the name of the chart.
 */}}
 {{- define "apisix.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- $nameOverride := tpl .Values.nameOverride $ }}
+{{- default .Chart.Name $nameOverride | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*
@@ -12,10 +13,12 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 If release name contains chart name it will be used as a full name.
 */}}
 {{- define "apisix.fullname" -}}
-{{- if .Values.fullnameOverride }}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- $nameOverride := tpl .Values.nameOverride $ }}
+{{- $fullnameOverride := tpl .Values.fullnameOverride $ }}
+{{- if $fullnameOverride }}
+{{- $fullnameOverride | trunc 63 | trimSuffix "-" }}
 {{- else }}
-{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- $name := default .Chart.Name $nameOverride }}
 {{- if contains $name .Release.Name }}
 {{- .Release.Name | trunc 63 | trimSuffix "-" }}
 {{- else }}

--- a/charts/apisix/templates/configmap.yaml
+++ b/charts/apisix/templates/configmap.yaml
@@ -352,7 +352,7 @@ data:
       {{- else }}
         host:                          # it's possible to define multiple etcd hosts addresses of the same etcd cluster.
           {{- range $value := .Values.externalEtcd.host }}
-          - "{{ $value }}"             # multiple etcd address
+          - "{{ tpl $value $ }}"             # multiple etcd address
           {{- end}}
       {{- end }}
         prefix: {{ .Values.etcd.prefix | quote }}    # configuration prefix in etcd

--- a/charts/apisix/templates/deployment.yaml
+++ b/charts/apisix/templates/deployment.yaml
@@ -82,12 +82,12 @@ spec:
             - name: APISIX_ADMIN_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.apisix.admin.credentials.secretName }}
+                  name: {{ tpl .Values.apisix.admin.credentials.secretName $ }}
                   key: {{ include "apisix.admin.credentials.secretAdminKey" . }}
             - name: APISIX_VIEWER_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.apisix.admin.credentials.secretName }}
+                  name: {{ tpl .Values.apisix.admin.credentials.secretName $ }}
                   key: {{ include "apisix.admin.credentials.secretViewerKey" . }}
           {{- end }}
 

--- a/charts/apisix/templates/ingress-admin.yaml
+++ b/charts/apisix/templates/ingress-admin.yaml
@@ -47,14 +47,14 @@ spec:
     {{- range .Values.apisix.admin.ingress.tls }}
     - hosts:
         {{- range .hosts }}
-        - {{ . | quote }}
+        - {{ tpl . $ | quote }}
         {{- end }}
-      secretName: {{ .secretName }}
+      secretName: {{ tpl .secretName $ }}
     {{- end }}
   {{- end }}
   rules:
     {{- range .Values.apisix.admin.ingress.hosts }}
-    - host: {{ .host | quote }}
+    - host: {{ tpl .host $ | quote }}
       http:
         paths:
           {{- range .paths }}

--- a/charts/apisix/templates/ingress.yaml
+++ b/charts/apisix/templates/ingress.yaml
@@ -47,14 +47,14 @@ spec:
     {{- range .Values.ingress.tls }}
     - hosts:
         {{- range .hosts }}
-        - {{ . | quote }}
+        - {{ tpl . $ | quote }}
         {{- end }}
-      secretName: {{ .secretName }}
+      secretName: {{ tpl .secretName $ }}
     {{- end }}
   {{- end }}
   rules:
     {{- range .Values.ingress.hosts }}
-    - host: {{ .host | quote }}
+    - host: {{ tpl .host $ | quote }}
       http:
         paths:
           {{- range .paths }}


### PR DESCRIPTION
This pull request addresses 2 cases:

1. Updating some of the configuration options to be rendered through the _tpl_ directive, which is needed to improve configurability and reusability of the parameters when the values file is composed. Ideally all parameters should be migrated to this approach to make it more consistent and predictable.
For example:

Ingress

```
  ingress:
    enabled: true
    annotations: 
      kubernetes.io/ingress.class: nginx 
    hosts:
      - host: "{{ tpl .Values.global.app.host . }}"
        paths:
          - "/"
    tls:
      - secretName: "{{ tpl .Values.global.config.secrets.tlsSecret . }}"
        hosts:
          - "{{ tpl .Values.global.app.host . }}"
```

External etcd

```
  externalEtcd:
    host:
      - "http://{{ tpl .Values.global.app.etcdHost . }}:2379"
    prefix: "/apisix"
    user: ""
```

2. Updating the version of the dashboard and ingress controller images to the latest versions