### PR TITLE
bugfix: hostnetwork is defined twice when it is set to true which blocks the installation

### DIFF
--- a/charts/apisix/templates/deployment.yaml
+++ b/charts/apisix/templates/deployment.yaml
@@ -221,7 +221,6 @@ spec:
         {{- toYaml .Values.extraContainers | nindent 8 }}
         {{- end }}
       {{- if .Values.hostNetwork }}
-      hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
       {{- end }}
       hostNetwork: {{ .Values.hostNetwork }}


### PR DESCRIPTION
Just removed the reduntant check