### PR TITLE
Bugfix: service.annotations did not find expected key

### DIFF
--- a/charts/apisix/templates/service-gateway.yaml
+++ b/charts/apisix/templates/service-gateway.yaml
@@ -20,9 +20,9 @@ metadata:
   name: {{ include "apisix.fullname" . }}-gateway
   namespace: {{ .Release.Namespace }}
   annotations:
-    {{- range $key, $value := .Values.service.annotations }}
-      {{ $key }}: {{ $value | quote }}
-    {{- end }}
+  {{- with .Values.service.annotations }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "apisix.labels" . | nindent 4 }}
     app.kubernetes.io/service: apisix-gateway


### PR DESCRIPTION
Bugfix for a issue about setting annotations for Service Gateway, in the [Apisix Helm Chart ](https://github.com/apache/apisix-helm-chart/tree/master/charts/apisix)

How to reproduce:

1 - From master, in a local clone, update the block service: uncommenting the annotation block and including the following lines in the [values.yaml](https://github.com/apache/apisix-helm-chart/blob/master/charts/apisix/values.yaml)

```yaml
service:
  # -- Apache APISIX service type for user access itself
  type: NodePort
  # -- Setting how the Service route external traffic
  # If you want to keep the client source IP, you can set this to Local.

  # ref: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
  externalTrafficPolicy: Cluster
  # type: LoadBalancer
  annotations:
    cloud.google.com/neg: '{"exposed_ports": {"80":{"name":""}}}'
    controller.autoneg.dev/neg: |
      {"backend_services": {"80":[
        {"max_rate_per_endpoint":2000,"name":"apisix-backend-service"},
        {"max_rate_per_endpoint":2000,"name":"xlb-ng-apisix-backend-service"}
      ]}}

```

2 - Run `helm template apisix apisix-helm-chart/charts/apisix` from root folder

--- `helm template apisix apisix-helm-chart/charts/apisix` Output without the fix:
```yaml
# Source: apisix/templates/service-gateway.yaml
#
# Licensed to the Apache Software Foundation (ASF) under one or more
# contributor license agreements.  See the NOTICE file distributed with
# this work for additional information regarding copyright ownership.
# The ASF licenses this file to You under the Apache License, Version 2.0
# (the "License"); you may not use this file except in compliance with
# the License.  You may obtain a copy of the License at
#
#     http://www.apache.org/licenses/LICENSE-2.0
#
# Unless required by applicable law or agreed to in writing, software
# distributed under the License is distributed on an "AS IS" BASIS,
# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
# See the License for the specific language governing permissions and
# limitations under the License.

apiVersion: v1
kind: Service
metadata:
  name: apisix-gateway
  namespace: default
  annotations:
      cloud.google.com/neg: "{\"exposed_ports\": {\"80\":{\"name\":\"\"}}}"
      controller.autoneg.dev/neg: "{\"backend_services\": {\"80\":[\n  {\"max_rate_per_endpoint\":2000,\"name\":\"apisix-backend-service\"},\n  {\"max_rate_per_endpoint\":2000,\"name\":\"xlb-ng-apisix-backend-service\"}\n]}}\n"
  labels:
    helm.sh/chart: apisix-2.8.1
    
    app.kubernetes.io/name: apisix
    app.kubernetes.io/instance: apisix
    app.kubernetes.io/version: "3.9.1"
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/service: apisix-gateway
spec:
  type: NodePort
  externalTrafficPolicy: Cluster
  ports:
  - name: apisix-gateway
    port: 80
    targetPort: 9080
    protocol: TCP
  selector:
    
    app.kubernetes.io/name: apisix
    app.kubernetes.io/instance: apisix
---
```

--- `helm template apisix apisix-helm-chart/charts/apisix` Output with the fix:
```yaml
# Source: apisix/templates/service-gateway.yaml
#
# Licensed to the Apache Software Foundation (ASF) under one or more
# contributor license agreements.  See the NOTICE file distributed with
# this work for additional information regarding copyright ownership.
# The ASF licenses this file to You under the Apache License, Version 2.0
# (the "License"); you may not use this file except in compliance with
# the License.  You may obtain a copy of the License at
#
#     http://www.apache.org/licenses/LICENSE-2.0
#
# Unless required by applicable law or agreed to in writing, software
# distributed under the License is distributed on an "AS IS" BASIS,
# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
# See the License for the specific language governing permissions and
# limitations under the License.

apiVersion: v1
kind: Service
metadata:
  name: apisix-gateway
  namespace: default
  annotations:
    cloud.google.com/neg: '{"exposed_ports": {"80":{"name":""}}}'
    controller.autoneg.dev/neg: |
      {"backend_services": {"80":[
        {"max_rate_per_endpoint":2000,"name":"apisix-backend-service"},
        {"max_rate_per_endpoint":2000,"name":"xlb-ng-apisix-backend-service"}
      ]}}
  labels:
    helm.sh/chart: apisix-2.8.1
    
    app.kubernetes.io/name: apisix
    app.kubernetes.io/instance: apisix
    app.kubernetes.io/version: "3.9.1"
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/service: apisix-gateway
spec:
  type: NodePort
  externalTrafficPolicy: Cluster
  ports:
  - name: apisix-gateway
    port: 80
    targetPort: 9080
    protocol: TCP
  selector:
    
    app.kubernetes.io/name: apisix
    app.kubernetes.io/instance: apisix
---
```
#495 #591 cc @Gallardot @Revolyssup 