### PR TITLE
Added gateway service port value

### DIFF
--- a/charts/apisix/templates/service-gateway.yaml
+++ b/charts/apisix/templates/service-gateway.yaml
@@ -65,7 +65,7 @@ spec:
   {{- if or .Values.apisix.ssl.enabled }}
   - name: apisix-gateway-tls
     port: {{ .Values.service.tls.servicePort }}
-    targetPort: {{ .Values.apisix.ssl.containerPort }}
+    targetPort: {{ .Values.apisix.ssl.serviceTargetPort }}
   {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.tls.nodePort))) }}
     nodePort: {{ .Values.service.tls.nodePort }}
   {{- end }}

--- a/charts/apisix/values.yaml
+++ b/charts/apisix/values.yaml
@@ -308,6 +308,13 @@ apisix:
   ssl:
     enabled: false
     containerPort: 9443
+    # -- We need to change the Kubernetes Service target port independently from:
+    # --  - Nginx configuration
+    # --  - Container port
+    # -- This is useful while creating load-balancers in cloud providers, where the TLS is off-loaded
+    # -- and we need to send the requests from the external TLS port to the pod HTTP port, due to the node ports
+    # -- being automatically created based on the Kubernetes Service
+    serviceTargetPort: 9443
     # -- Support multiple https ports, See [Configuration](https://github.com/apache/apisix/blob/0bc65ea9acd726f79f80ae0abd8f50b7eb172e3d/conf/config-default.yaml#L99)
     additionalContainerPorts: []
       # - ip: 127.0.0.3           # Specific IP, If not set, the default value is `0.0.0.0`.


### PR DESCRIPTION
Adding the ability to change the Apisix gateway's service pod target port. While working with cloud providers like AWS, the node ports are automatically configured based on the Kubernetes 
Service ports. When we want to offload the TLS to the load-balancer, we need to send the HTTP traffic sent to the Service's TLS port to the Pod HTTP port and, with the current configuration, we 
cannot do it because the same value `ssl.containerPort` is used for: 
- Gateway service's tls port target port to the Pod 
- Pod's TLS container port
- Internal Nginx configuration, defined in the ConfigMap
