### PR TITLE
Fix Control Ingress Creation

### DIFF
--- a/charts/apisix/templates/ingress-control.yaml
+++ b/charts/apisix/templates/ingress-control.yaml
@@ -16,7 +16,7 @@
 
 {{- if (and .Values.control.enabled .Values.control.ingress.enabled) -}}
 {{- $fullName := include "apisix.fullname" . -}}
-{{- $svcPort := .Values.control.servicePort -}}
+{{- $svcPort := .Values.control.service.servicePort -}}
 {{- if and .Values.control.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
   {{- if not (hasKey .Values.control.ingress.annotations "kubernetes.io/ingress.class") }}
   {{- $_ := set .Values.control.ingress.annotations "kubernetes.io/ingress.class" .Values.control.ingress.className}}

--- a/charts/apisix/templates/service-control.yaml
+++ b/charts/apisix/templates/service-control.yaml
@@ -13,7 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-{{ if (and .Values.apisix.enabled .Values.control.enabled) }}
+{{ if .Values.control.enabled }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/apisix/tests/ingress-control_test.yaml
+++ b/charts/apisix/tests/ingress-control_test.yaml
@@ -1,0 +1,20 @@
+suite: Control Ingress Configuation
+templates:
+  - ingress-control.yaml
+tests:
+  - it: should be disabled by default
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: should provide a working Ingress when enabled
+    set:
+      control:
+        ingress:
+          enabled: true
+    asserts:
+      - containsDocument:
+          kind: Ingress
+          apiVersion: networking.k8s.io/v1
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.port.number
+          value: 9090


### PR DESCRIPTION
By default if you enable ingress for the control api the chart breaks, its checking bad place for the servicePort.

This fixes that, and add tests with [helm- unittest](https://github.com/helm-unittest/helm-unittest), it currently only tests this exact situation, since i dont know if its something that the maintainers want. I can add more unitttest if you want.

Regards,
Alfredo Palhares