### PR TITLE
Allow nodePort & servicePort also to be configured in additionalContainerPorts

### DIFF
--- a/charts/apisix/templates/service-gateway.yaml
+++ b/charts/apisix/templates/service-gateway.yaml
@@ -58,8 +58,11 @@ spec:
   {{- end }}
   {{- range .Values.service.http.additionalContainerPorts }}
   - name: apisix-gateway-{{ .port | toString }}
-    port: {{ .port }}
+    port: {{ or .servicePort .port }}
     targetPort: {{ .port }}
+  {{- if not (empty .nodePort) }}
+    nodePort: {{ .nodePort }}
+  {{- end}}
     protocol: TCP
   {{- end }}
   {{- if or .Values.apisix.ssl.enabled }}

--- a/charts/apisix/values.yaml
+++ b/charts/apisix/values.yaml
@@ -180,7 +180,8 @@ service:
     # -- Support multiple http ports, See [Configuration](https://github.com/apache/apisix/blob/0bc65ea9acd726f79f80ae0abd8f50b7eb172e3d/conf/config-default.yaml#L24)
     additionalContainerPorts: []
       # - port: 9081
-      #   enable_http2: true          # If not set, the default value is `false`.
+      #   servicePort: 8080 # Optional, if not set, `.port` value will be used.
+      #   nodePort: 303030 # Optional
       # - ip: 127.0.0.2               # Specific IP, If not set, the default value is `0.0.0.0`.
       #   port: 9082
       #   enable_http2: true


### PR DESCRIPTION
currently for configuring gateway service only the port parameter is used to populate TargetPort and ServicePort. which is quite limiting in certain conditions
```
    additionalContainerPorts:
      - port: 9081
```

With added changes:
```
    additionalContainerPorts:
      - port: 8443
        servicePort: 80    # optional, if not set uses `.port` value, hence it does not cause breaking changes
        nodePort: 30303 # optional
```
