### PR TITLE
add security context and explicit resource definition to wait-etcd

### DIFF
--- a/charts/apisix/templates/deployment.yaml
+++ b/charts/apisix/templates/deployment.yaml
@@ -229,6 +229,12 @@ spec:
         {{- if .Values.etcd.enabled }}
         - name: wait-etcd
           image: {{ .Values.initContainer.image }}:{{ .Values.initContainer.tag }}
+          {{- with .Values.initContainer.securityContext }}
+          securityContext:
+            {{- . | toYaml | nindent 12 }}
+          {{- end }}
+          resources:
+          {{- toYaml .Values.initContainer.resources | nindent 12 }}
           {{- if .Values.etcd.fullnameOverride }}
           command: ['sh', '-c', "until nc -z {{ .Values.etcd.fullnameOverride }} {{ .Values.etcd.service.port }}; do echo waiting for etcd `date`; sleep 2; done;"]
           {{ else }}


### PR DESCRIPTION
In the current Helm charts, the wait-etcd init container lacks a security context and therefore cannot run in non-root environments.
Additionally, adding explicit resource definitions for the container would be beneficial for effective resource management.
