### PR TITLE
feat: make IngressClass creation optional

### DIFF
--- a/charts/apisix-ingress-controller/templates/ingress-class.yaml
+++ b/charts/apisix-ingress-controller/templates/ingress-class.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.config.kubernetes.createIngressClass }}
 {{ if or (eq .Values.config.kubernetes.ingressVersion "") (eq .Values.config.kubernetes.ingressVersion "networking/v1")}}
 apiVersion: networking.k8s.io/v1
 {{- else if (eq .Values.config.kubernetes.ingressVersion "networking/v1beta1")}}
@@ -10,3 +11,4 @@ metadata:
   name: {{ .Values.config.kubernetes.ingressClass | quote }}
 spec:
   controller: apisix.apache.org/apisix-ingress # fix: https://github.com/apache/apisix-ingress-controller/issues/1653
+{{- end }}

--- a/charts/apisix-ingress-controller/values.yaml
+++ b/charts/apisix-ingress-controller/values.yaml
@@ -119,6 +119,8 @@ config:
     # only the leader will watch and delivery resource changes,
     # other instances (as candidates) stand by.
     electionId: "ingress-apisix-leader"
+    # Set to false to disable IngressClass creation
+    createIngressClass: true
     # -- The class of an Ingress object is set using the field IngressClassName in
     # Kubernetes clusters version v1.18.0 or higher or the annotation
     # "kubernetes.io/ingress.class" (deprecated).


### PR DESCRIPTION
**Use Case:**
Our team does not have the necessary cluster-wide rights to create CRDs or other related resources. In our case, the ingress-class.yaml  is managed and deployed by another IT team. Therefore, having the option to disable the creation of the IngressClass resource in the charts deployment is essential for our workflow.