### PR TITLE
Make it optional to check sni for etcd endpoints

### DIFF
--- a/charts/apisix/README.md
+++ b/charts/apisix/README.md
@@ -158,6 +158,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | etcd.auth.tls.certKeyFilename | string | `""` | etcd client cert key filename using in etcd.auth.tls.existingSecret |
 | etcd.auth.tls.enabled | bool | `false` | enable etcd client certificate |
 | etcd.auth.tls.existingSecret | string | `""` | name of the secret contains etcd client cert |
+| etcd.auth.tls.sni_enabled | bool | `true` | check TLS Server Name Indication extension. |
 | etcd.auth.tls.sni | string | `""` | specify the TLS Server Name Indication extension, the ETCD endpoint hostname will be used when this setting is unset. |
 | etcd.auth.tls.verify | bool | `true` | whether to verify the etcd endpoint certificate when setup a TLS connection to etcd |
 | etcd.containerSecurityContext | object | `{"enabled":false}` | added for backward compatibility with old kubernetes versions, as seccompProfile is not supported in kubernetes < 1.19 |

--- a/charts/apisix/templates/configmap.yaml
+++ b/charts/apisix/templates/configmap.yaml
@@ -376,7 +376,9 @@ data:
           cert: "/etcd-ssl/{{ .Values.etcd.auth.tls.certFilename }}"
           key: "/etcd-ssl/{{ .Values.etcd.auth.tls.certKeyFilename }}"
           verify: {{ .Values.etcd.auth.tls.verify }}
+          {{- if .Values.etcd.auth.tls.sni_enabled }}
           sni: "{{ .Values.etcd.auth.tls.sni }}"
+          {{- end }}
         {{- end }}
       {{- end }}
       {{- end }}

--- a/charts/apisix/values.yaml
+++ b/charts/apisix/values.yaml
@@ -612,6 +612,8 @@ etcd:
       certKeyFilename: ""
       # -- whether to verify the etcd endpoint certificate when setup a TLS connection to etcd
       verify: true
+      # -- check TLS Server Name Indication extension.
+      sni_enabled: true
       # -- specify the TLS Server Name Indication extension, the ETCD endpoint hostname will be used when this setting is unset.
       sni: ""
 


### PR DESCRIPTION
If TLS is enabled for an external etcd, APISIX will check the SNI. In this PR, I've added an option to make the SNI check optional for etcd TLS.