### PR TITLE
Eanble daemonset for ingress-controller-chart

### DIFF
--- a/charts/apisix-ingress-controller/README.md
+++ b/charts/apisix-ingress-controller/README.md
@@ -195,3 +195,4 @@ The same for container level, you need to set:
 | tolerations | list | `[]` |  |
 | topologySpreadConstraints | list | `[]` | Topology Spread Constraints for pod assignment spread across your cluster among failure-domains ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/#spread-constraints-for-pods |
 | updateStrategy | object | `{}` | Update strategy for apisix ingress controller deployment |
+| useDaemonSet | bool | `false` | set false to use `Deployment`, set true to use `DaemonSet` |

--- a/charts/apisix-ingress-controller/templates/deployment.yaml
+++ b/charts/apisix-ingress-controller/templates/deployment.yaml
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 apiVersion: apps/v1
-kind: Deployment
+kind: {{ ternary "DaemonSet" "Deployment" .Values.useDaemonSet }}
 metadata:
   name: {{ include "apisix-ingress-controller.fullname" . }}
   namespace: {{ .Release.Namespace }}
@@ -26,14 +26,18 @@ metadata:
   labels:
     {{- include "apisix-ingress-controller.labels" . | nindent 4 }}
 spec:
+  {{- if and (not .Values.useDaemonSet) (not .Values.autoscaling.enabled) }}
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
+  {{- end }}
   {{- end }}
   selector:
     matchLabels:
       {{- include "apisix-ingress-controller.selectorLabels" . | nindent 6 }}
-  {{- with .Values.updateStrategy }}
-  strategy: {{ toYaml . | nindent 4 }}
+  {{- if (not .Values.useDaemonSet) }}
+  strategy: {{ toYaml .Values.updateStrategy | nindent 4 }}
+  {{- else }}
+  updateStrategy: {{ toYaml .Values.updateStrategy | nindent 4 }}
   {{- end }}
   template:
     metadata:

--- a/charts/apisix-ingress-controller/values.yaml
+++ b/charts/apisix-ingress-controller/values.yaml
@@ -45,6 +45,8 @@ serviceAccount:
   # -- Whether automounting API credentials for a service account
   automountServiceAccountToken: true
 
+# -- set false to use `Deployment`, set true to use `DaemonSet`
+useDaemonSet: false
 
 replicaCount: 1
 


### PR DESCRIPTION
When using a [composite architecture](https://apisix.apache.org/docs/ingress-controller/composite/) without etcd, it is feasible to deploy Apache APISIX with a DaemonSet. In this PR, I've added useDaemonSet to the APISIX Ingress Controller chart.