### PR TITLE
feat: add PROXY protocol support 

### DIFF
--- a/charts/apisix/README.md
+++ b/charts/apisix/README.md
@@ -204,6 +204,11 @@ The command removes all the Kubernetes components associated with the chart and 
 | podDisruptionBudget.minAvailable | string | `"90%"` | Set the `minAvailable` of podDisruptionBudget. You can specify only one of `maxUnavailable` and `minAvailable` in a single PodDisruptionBudget. See [Specifying a Disruption Budget for your Application](https://kubernetes.io/docs/tasks/run-application/configure-pdb/#specifying-a-poddisruptionbudget) for more details |
 | podSecurityContext | object | `{}` | Set the securityContext for Apache APISIX pods |
 | priorityClassName | string | `""` | Set [priorityClassName](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#pod-priority) for Apache APISIX pods |
+| proxyProtocol.enabled | bool | `false` | Enable or disable PROXY protocol |
+| proxyProtocol.listenHTTPPort | int | `9181` | The port with proxy protocol for HTTP |
+| proxyProtocol.listenHTTPSPort | int | `9182` | The port with proxy protocol for HTTPS |
+| proxyProtocol.enableTCPPP | bool | `false` | Enable the proxy protocol for TCP proxy, works for stream_proxy.tcp option |
+| proxyProtocol.enableTCPPPToUpstream | bool | `false` | Enable the proxy protocol to the upstream server |
 | rbac.create | bool | `false` |  |
 | replicaCount | int | `1` | if useDaemonSet is true or autoscaling.enabled is true, replicaCount not become effective |
 | resources | object | `{}` | Set pod resource requests & limits |

--- a/charts/apisix/README.md
+++ b/charts/apisix/README.md
@@ -111,6 +111,12 @@ The command removes all the Kubernetes components associated with the chart and 
 | apisix.prometheus.enabled | bool | `false` |  |
 | apisix.prometheus.metricPrefix | string | `"apisix_"` | prefix of the metrics |
 | apisix.prometheus.path | string | `"/apisix/prometheus/metrics"` | path of the metrics endpoint |
+| apisix.proxyProtocol | object | `{"enableTCPPP":false,"enableTCPPPToUpstream":false,"enabled":false,"listenHTTPPort":9181,"listenHTTPSPort":9182}` | Configuration for PROXY protocol |
+| apisix.proxyProtocol.enableTCPPP | bool | `false` | Enable the proxy protocol for TCP proxy, works for stream_proxy.tcp option |
+| apisix.proxyProtocol.enableTCPPPToUpstream | bool | `false` | Enable the proxy protocol to the upstream server |
+| apisix.proxyProtocol.enabled | bool | `false` | Enable or disable PROXY protocol |
+| apisix.proxyProtocol.listenHTTPPort | int | `9181` | The port with proxy protocol for HTTP |
+| apisix.proxyProtocol.listenHTTPSPort | int | `9182` | The port with proxy protocol for HTTPS |
 | apisix.router.http | string | `"radixtree_host_uri"` | Defines how apisix handles routing: - radixtree_uri: match route by uri(base on radixtree) - radixtree_host_uri: match route by host + uri(base on radixtree) - radixtree_uri_with_parameter: match route by uri with parameters |
 | apisix.setIDFromPodUID | bool | `false` | Use Pod metadata.uid as the APISIX id. |
 | apisix.ssl.additionalContainerPorts | list | `[]` | Support multiple https ports, See [Configuration](https://github.com/apache/apisix/blob/0bc65ea9acd726f79f80ae0abd8f50b7eb172e3d/conf/config-default.yaml#L99) |
@@ -204,11 +210,6 @@ The command removes all the Kubernetes components associated with the chart and 
 | podDisruptionBudget.minAvailable | string | `"90%"` | Set the `minAvailable` of podDisruptionBudget. You can specify only one of `maxUnavailable` and `minAvailable` in a single PodDisruptionBudget. See [Specifying a Disruption Budget for your Application](https://kubernetes.io/docs/tasks/run-application/configure-pdb/#specifying-a-poddisruptionbudget) for more details |
 | podSecurityContext | object | `{}` | Set the securityContext for Apache APISIX pods |
 | priorityClassName | string | `""` | Set [priorityClassName](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#pod-priority) for Apache APISIX pods |
-| apisix.proxyProtocol.enabled | bool | `false` | Enable or disable PROXY protocol |
-| apisix.proxyProtocol.listenHTTPPort | int | `9181` | The port with proxy protocol for HTTP |
-| apisix.proxyProtocol.listenHTTPSPort | int | `9182` | The port with proxy protocol for HTTPS |
-| apisix.proxyProtocol.enableTCPPP | bool | `false` | Enable the proxy protocol for TCP proxy, works for stream_proxy.tcp option |
-| apisix.proxyProtocol.enableTCPPPToUpstream | bool | `false` | Enable the proxy protocol to the upstream server |
 | rbac.create | bool | `false` |  |
 | replicaCount | int | `1` | if useDaemonSet is true or autoscaling.enabled is true, replicaCount not become effective |
 | resources | object | `{}` | Set pod resource requests & limits |

--- a/charts/apisix/README.md
+++ b/charts/apisix/README.md
@@ -204,11 +204,11 @@ The command removes all the Kubernetes components associated with the chart and 
 | podDisruptionBudget.minAvailable | string | `"90%"` | Set the `minAvailable` of podDisruptionBudget. You can specify only one of `maxUnavailable` and `minAvailable` in a single PodDisruptionBudget. See [Specifying a Disruption Budget for your Application](https://kubernetes.io/docs/tasks/run-application/configure-pdb/#specifying-a-poddisruptionbudget) for more details |
 | podSecurityContext | object | `{}` | Set the securityContext for Apache APISIX pods |
 | priorityClassName | string | `""` | Set [priorityClassName](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#pod-priority) for Apache APISIX pods |
-| proxyProtocol.enabled | bool | `false` | Enable or disable PROXY protocol |
-| proxyProtocol.listenHTTPPort | int | `9181` | The port with proxy protocol for HTTP |
-| proxyProtocol.listenHTTPSPort | int | `9182` | The port with proxy protocol for HTTPS |
-| proxyProtocol.enableTCPPP | bool | `false` | Enable the proxy protocol for TCP proxy, works for stream_proxy.tcp option |
-| proxyProtocol.enableTCPPPToUpstream | bool | `false` | Enable the proxy protocol to the upstream server |
+| apisix.proxyProtocol.enabled | bool | `false` | Enable or disable PROXY protocol |
+| apisix.proxyProtocol.listenHTTPPort | int | `9181` | The port with proxy protocol for HTTP |
+| apisix.proxyProtocol.listenHTTPSPort | int | `9182` | The port with proxy protocol for HTTPS |
+| apisix.proxyProtocol.enableTCPPP | bool | `false` | Enable the proxy protocol for TCP proxy, works for stream_proxy.tcp option |
+| apisix.proxyProtocol.enableTCPPPToUpstream | bool | `false` | Enable the proxy protocol to the upstream server |
 | rbac.create | bool | `false` |  |
 | replicaCount | int | `1` | if useDaemonSet is true or autoscaling.enabled is true, replicaCount not become effective |
 | resources | object | `{}` | Set pod resource requests & limits |

--- a/charts/apisix/templates/configmap.yaml
+++ b/charts/apisix/templates/configmap.yaml
@@ -76,15 +76,15 @@ data:
       enable_http2: {{ .Values.apisix.enableHTTP2 }}
       enable_server_tokens: {{ .Values.apisix.enableServerTokens }} # Whether the APISIX version number should be shown in Server header
 
-      {{- if .Values.proxyProtocol.enabled }}
+      {{- if .Values.apisix.proxyProtocol.enabled }}
       proxy_protocol:                     # Proxy Protocol configuration
-        listen_http_port: {{ .Values.proxyProtocol.listenHTTPPort }}          # The port with proxy protocol for http, it differs from node_listen and admin_listen.
+        listen_http_port: {{ .Values.apisix.proxyProtocol.listenHTTPPort }}          # The port with proxy protocol for http, it differs from node_listen and admin_listen.
                                         # This port can only receive http request with proxy protocol, but node_listen & admin_listen
                                         # can only receive http request. If you enable proxy protocol, you must use this port to
                                         # receive http request with proxy protocol
-        listen_https_port: {{ .Values.proxyProtocol.listenHTTPSPort }}        # The port with proxy protocol for https
-        enable_tcp_pp: {{ .Values.proxyProtocol.enableTCPPP }}             # Enable the proxy protocol for tcp proxy, it works for stream_proxy.tcp option
-        enable_tcp_pp_to_upstream: {{ .Values.proxyProtocol.enableTCPPPToUpstream }} # Enables the proxy protocol to the upstream server
+        listen_https_port: {{ .Values.apisix.proxyProtocol.listenHTTPSPort }}        # The port with proxy protocol for https
+        enable_tcp_pp: {{ .Values.apisix.proxyProtocol.enableTCPPP }}             # Enable the proxy protocol for tcp proxy, it works for stream_proxy.tcp option
+        enable_tcp_pp_to_upstream: {{ .Values.apisix.proxyProtocol.enableTCPPPToUpstream }} # Enables the proxy protocol to the upstream server
       {{- end }}
 
       proxy_cache:                         # Proxy Caching configuration

--- a/charts/apisix/templates/configmap.yaml
+++ b/charts/apisix/templates/configmap.yaml
@@ -76,14 +76,16 @@ data:
       enable_http2: {{ .Values.apisix.enableHTTP2 }}
       enable_server_tokens: {{ .Values.apisix.enableServerTokens }} # Whether the APISIX version number should be shown in Server header
 
-      # proxy_protocol:                   # Proxy Protocol configuration
-      #   listen_http_port: 9181          # The port with proxy protocol for http, it differs from node_listen and admin_listen.
-      #                                   # This port can only receive http request with proxy protocol, but node_listen & admin_listen
-      #                                   # can only receive http request. If you enable proxy protocol, you must use this port to
-      #                                   # receive http request with proxy protocol
-      #   listen_https_port: 9182         # The port with proxy protocol for https
-      #   enable_tcp_pp: true             # Enable the proxy protocol for tcp proxy, it works for stream_proxy.tcp option
-      #   enable_tcp_pp_to_upstream: true # Enables the proxy protocol to the upstream server
+      {{- if .Values.proxyProtocol.enabled }}
+      proxy_protocol:                     # Proxy Protocol configuration
+        listen_http_port: {{ .Values.proxyProtocol.listenHTTPPort }}          # The port with proxy protocol for http, it differs from node_listen and admin_listen.
+                                        # This port can only receive http request with proxy protocol, but node_listen & admin_listen
+                                        # can only receive http request. If you enable proxy protocol, you must use this port to
+                                        # receive http request with proxy protocol
+        listen_https_port: {{ .Values.proxyProtocol.listenHTTPSPort }}        # The port with proxy protocol for https
+        enable_tcp_pp: {{ .Values.proxyProtocol.enableTCPPP }}             # Enable the proxy protocol for tcp proxy, it works for stream_proxy.tcp option
+        enable_tcp_pp_to_upstream: {{ .Values.proxyProtocol.enableTCPPPToUpstream }} # Enables the proxy protocol to the upstream server
+      {{- end }}
 
       proxy_cache:                         # Proxy Caching configuration
         cache_ttl: 10s                     # The default caching time if the upstream does not specify the cache time

--- a/charts/apisix/values.schema.json
+++ b/charts/apisix/values.schema.json
@@ -1,6 +1,28 @@
 {
   "$schema": "https://json-schema.org/draft-07/schema#",
   "properties": {
+    "proxyProtocol": {
+      "description": "Configuration for PROXY protocol",
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "listenHTTPPort": {
+          "type": "integer"
+        },
+        "listenHTTPSPort": {
+          "type": "integer"
+        },
+        "enableTCPPP": {
+          "type": "boolean"
+        },
+        "enableTCPPPToUpstream": {
+          "type": "boolean"
+        }
+      },
+      "required": ["enabled", "listenHTTPPort", "listenHTTPSPort", "enableTCPPP", "enableTCPPPToUpstream"]
+    },
     "plugins": {
       "description": "APISIX plugins to be enabled",
       "type": "array",

--- a/charts/apisix/values.schema.json
+++ b/charts/apisix/values.schema.json
@@ -1,27 +1,33 @@
 {
   "$schema": "https://json-schema.org/draft-07/schema#",
   "properties": {
-    "proxyProtocol": {
-      "description": "Configuration for PROXY protocol",
+    "apisix": {
+      "description": "Apache APISIX configuration",
       "type": "object",
       "properties": {
-        "enabled": {
-          "type": "boolean"
-        },
-        "listenHTTPPort": {
-          "type": "integer"
-        },
-        "listenHTTPSPort": {
-          "type": "integer"
-        },
-        "enableTCPPP": {
-          "type": "boolean"
-        },
-        "enableTCPPPToUpstream": {
-          "type": "boolean"
+        "proxyProtocol": {
+          "description": "Configuration for PROXY protocol",
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "listenHTTPPort": {
+              "type": "integer"
+            },
+            "listenHTTPSPort": {
+              "type": "integer"
+            },
+            "enableTCPPP": {
+              "type": "boolean"
+            },
+            "enableTCPPPToUpstream": {
+              "type": "boolean"
+            }
+          },
+          "required": ["enabled", "listenHTTPPort", "listenHTTPSPort", "enableTCPPP", "enableTCPPPToUpstream"]
         }
-      },
-      "required": ["enabled", "listenHTTPPort", "listenHTTPSPort", "enableTCPPP", "enableTCPPPToUpstream"]
+      }
     },
     "plugins": {
       "description": "APISIX plugins to be enabled",

--- a/charts/apisix/values.yaml
+++ b/charts/apisix/values.yaml
@@ -114,19 +114,6 @@ updateStrategy: {}
 # -- Additional Kubernetes resources to deploy with the release.
 extraDeploy: []
 
-# -- Configuration for PROXY protocol
-proxyProtocol:
-  # -- Enable or disable PROXY protocol
-  enabled: false
-  # -- The port with proxy protocol for HTTP
-  listenHTTPPort: 9181
-  # -- The port with proxy protocol for HTTPS
-  listenHTTPSPort: 9182
-  # -- Enable the proxy protocol for TCP proxy, works for stream_proxy.tcp option
-  enableTCPPP: false
-  # -- Enable the proxy protocol to the upstream server
-  enableTCPPPToUpstream: false
-
 # -- Additional `volume`, See [Kubernetes Volumes](https://kubernetes.io/docs/concepts/storage/volumes/) for the detail.
 extraVolumes: []
 # - name: extras
@@ -295,6 +282,19 @@ apisix:
 
   # -- Whether the APISIX version number should be shown in Server header
   enableServerTokens: true
+
+  # -- Configuration for PROXY protocol
+  proxyProtocol:
+    # -- Enable or disable PROXY protocol
+    enabled: false
+    # -- The port with proxy protocol for HTTP
+    listenHTTPPort: 9181
+    # -- The port with proxy protocol for HTTPS
+    listenHTTPSPort: 9182
+    # -- Enable the proxy protocol for TCP proxy, works for stream_proxy.tcp option
+    enableTCPPP: false
+    # -- Enable the proxy protocol to the upstream server
+    enableTCPPPToUpstream: false
 
   # -- Use Pod metadata.uid as the APISIX id.
   setIDFromPodUID: false

--- a/charts/apisix/values.yaml
+++ b/charts/apisix/values.yaml
@@ -114,6 +114,19 @@ updateStrategy: {}
 # -- Additional Kubernetes resources to deploy with the release.
 extraDeploy: []
 
+# -- Configuration for PROXY protocol
+proxyProtocol:
+  # -- Enable or disable PROXY protocol
+  enabled: false
+  # -- The port with proxy protocol for HTTP
+  listenHTTPPort: 9181
+  # -- The port with proxy protocol for HTTPS
+  listenHTTPSPort: 9182
+  # -- Enable the proxy protocol for TCP proxy, works for stream_proxy.tcp option
+  enableTCPPP: false
+  # -- Enable the proxy protocol to the upstream server
+  enableTCPPPToUpstream: false
+
 # -- Additional `volume`, See [Kubernetes Volumes](https://kubernetes.io/docs/concepts/storage/volumes/) for the detail.
 extraVolumes: []
 # - name: extras


### PR DESCRIPTION
I would like to add support for configuring the PROXY protocol in the APISIX helm chart. Currently, the PROXY protocol configuration exists in the template as commented code, but there's no way to enable or configure it via values.yaml.

**Motivation**

The PROXY protocol allows load balancers to pass client connection information to APISIX. This is especially useful in Kubernetes environments where APISIX is deployed behind a load balancer, and the original client IP needs to be preserved.

**Implementation**


- [x] Added proxy protocol configuration options to values.yaml with default values:


  proxyProtocol:
    enabled: false
    listenHTTPPort: 9181
    listenHTTPSPort: 9182
    enableTCPPP: false
    enableTCPPPToUpstream: false

- [x] Updated configmap.yaml to conditionally include proxy_protocol configuration when enabled

- [x] Added schema validation in values.schema.json for the new options

- [x] Updated README.md with documentation for the new configuration options

These changes allow users to easily enable and configure proxy protocol support through the helm chart values, rather than having to manually modify the configmap.

Fixes #812