### PR TITLE
feat: add apisix.standaloneConfig.config

### DIFF
--- a/charts/apisix/README.md
+++ b/charts/apisix/README.md
@@ -121,6 +121,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | apisix.ssl.existingCASecret | string | `""` | Specifies the name of Secret contains trusted CA certificates in the PEM format used to verify the certificate when APISIX needs to do SSL/TLS handshaking with external services (e.g. etcd) |
 | apisix.ssl.fallbackSNI | string | `""` | Define SNI to fallback if none is presented by client |
 | apisix.ssl.sslProtocols | string | `"TLSv1.2 TLSv1.3"` | TLS protocols allowed to use. |
+| apisix.standaloneConfig.config | string | `""` | If apisix.deployment.mode is "standalone": custom apisix.yaml as string. |
 | apisix.stream_plugins | list | `[]` | Customize the list of APISIX stream_plugins to enable. By default, APISIX's default stream_plugins are automatically used. See [config-default.yaml](https://github.com/apache/apisix/blob/master/conf/config-default.yaml) |
 | apisix.vault.enabled | bool | `false` | Enable or disable the vault integration |
 | apisix.vault.host | string | `""` | The host address where the vault server is running. |

--- a/charts/apisix/README.md
+++ b/charts/apisix/README.md
@@ -121,7 +121,8 @@ The command removes all the Kubernetes components associated with the chart and 
 | apisix.ssl.existingCASecret | string | `""` | Specifies the name of Secret contains trusted CA certificates in the PEM format used to verify the certificate when APISIX needs to do SSL/TLS handshaking with external services (e.g. etcd) |
 | apisix.ssl.fallbackSNI | string | `""` | Define SNI to fallback if none is presented by client |
 | apisix.ssl.sslProtocols | string | `"TLSv1.2 TLSv1.3"` | TLS protocols allowed to use. |
-| apisix.standaloneConfig.config | string | `""` | If apisix.deployment.mode is "standalone": custom apisix.yaml as string. |
+| apisix.standaloneConfig.config | string | `""` | If apisix.deployment.mode is "standalone": custom apisix.yaml as string. Takes precedence over configMapRef. |
+| apisix.standaloneConfig.configMapName | string | `""` | If apisix.deployment.mode is "standalone": reference to an existing config map. It must contain the key "apisix.yaml". |
 | apisix.stream_plugins | list | `[]` | Customize the list of APISIX stream_plugins to enable. By default, APISIX's default stream_plugins are automatically used. See [config-default.yaml](https://github.com/apache/apisix/blob/master/conf/config-default.yaml) |
 | apisix.vault.enabled | bool | `false` | Enable or disable the vault integration |
 | apisix.vault.host | string | `""` | The host address where the vault server is running. |

--- a/charts/apisix/templates/_helpers.tpl
+++ b/charts/apisix/templates/_helpers.tpl
@@ -157,3 +157,25 @@ Key to use to fetch viewer token from secret
 {{- "viewer" }}
 {{- end }}
 {{- end }}
+
+{{/*
+Return true if we should render the standalone config.
+*/}}
+{{- define "apisix.shouldRenderStandaloneConfig" -}}
+{{- $isStandalone := eq .Values.apisix.deployment.mode "standalone" -}}
+{{- $configEmpty := empty .Values.apisix.standaloneConfig.config -}}
+{{- $configMapNameEmpty := empty .Values.apisix.standaloneConfig.configMapName -}}
+{{- $dontRender := and $configEmpty (not $configMapNameEmpty) -}}
+{{- ternary true false (and $isStandalone (not $dontRender)) -}}
+{{- end }}
+
+{{/*
+Return the name of the standalone config.
+*/}}
+{{- define "apisix.standaloneConfigName" -}}
+{{- if (eq (include "apisix.shouldRenderStandaloneConfig" .) "true") -}}
+"apisix.yaml"
+{{- else -}}
+{{ .Values.apisix.standaloneConfig.configMapName | quote }}
+{{- end -}}
+{{- end }}

--- a/charts/apisix/templates/apisix-config-cm.yml
+++ b/charts/apisix/templates/apisix-config-cm.yml
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- if eq .Values.apisix.deployment.mode "standalone" }}
+{{- if (eq (include "apisix.shouldRenderStandaloneConfig" .) "true") }}
 kind: ConfigMap
 apiVersion: v1
 metadata:
@@ -35,4 +35,3 @@ data:
     #END
 {{- end }}
 {{- end }}
-

--- a/charts/apisix/templates/apisix-config-cm.yml
+++ b/charts/apisix/templates/apisix-config-cm.yml
@@ -21,6 +21,10 @@ metadata:
   name: apisix.yaml
 data:
   apisix.yaml: |
+{{- with .Values.apisix.standaloneConfig.config }}
+{{ . | indent 4 }}
+{{- else }}
+    # Use apisix.standaloneConfig.config to customize this
     routes:
     -
       uri: /hi
@@ -30,3 +34,5 @@ data:
         type: roundrobin
     #END
 {{- end }}
+{{- end }}
+

--- a/charts/apisix/templates/deployment.yaml
+++ b/charts/apisix/templates/deployment.yaml
@@ -241,7 +241,7 @@ spec:
       volumes:
         {{- if eq .Values.apisix.deployment.mode "standalone" }}
         - configMap:
-            name: apisix.yaml
+            name: {{ include "apisix.standaloneConfigName" . }}
           name: apisix-admin
         {{- end }}
         - configMap:

--- a/charts/apisix/values.yaml
+++ b/charts/apisix/values.yaml
@@ -351,8 +351,11 @@ apisix:
     role: "traditional"
 
   standaloneConfig:
-    # -- If apisix.deployment.mode is "standalone": custom apisix.yaml as string.
+    # -- If apisix.deployment.mode is "standalone": custom apisix.yaml as string. Takes precedence over configMapRef.
     config: ""
+    # -- If apisix.deployment.mode is "standalone": reference to an existing config map. It must contain the key "apisix.yaml".
+    configMapName: ""
+
 
   admin:
     # -- Enable Admin API

--- a/charts/apisix/values.yaml
+++ b/charts/apisix/values.yaml
@@ -350,6 +350,10 @@ apisix:
     # ref: https://apisix.apache.org/docs/apisix/deployment-modes/
     role: "traditional"
 
+  standaloneConfig:
+    # -- If apisix.deployment.mode is "standalone": custom apisix.yaml as string.
+    config: ""
+
   admin:
     # -- Enable Admin API
     enabled: true


### PR DESCRIPTION
Previously, a static `apisix.yaml` config map was created in standalone mode, with no way of updating it in the chart. now there is.