### PR TITLE
feat: support adding sessionAffinity on admin service

### DIFF
--- a/charts/apisix/templates/service-gateway.yaml
+++ b/charts/apisix/templates/service-gateway.yaml
@@ -28,6 +28,7 @@ metadata:
     app.kubernetes.io/service: apisix-gateway
 spec:
   type: {{ .Values.service.type }}
+  sessionAffinity: {{ .Values.service.sessionAffinity | default "None" }}
   externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy }}
   {{- if eq .Values.service.type "LoadBalancer" }}
   {{- if .Values.service.loadBalancerIP }}


### PR DESCRIPTION
As of now, We cannot change the sessionAffinity on the Apisix Helm chart. I want to add an option to help us change it