### PR TITLE
chore: deprecate apisix dashboard chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,14 +22,14 @@
 Apache APISIX Helm Charts provide the installation of [Apache APISIX](https://github.com/apache/apisix#apache-apisix) components for kubernetes.
 
 - [Apache APISIX Helm Chart](./docs/en/latest/apisix.md)
-- [Apache APISIX Dashboard Helm Chart](./docs/en/latest/apisix-dashboard.md)
+- [[DEPRECATED] Apache APISIX Dashboard Helm Chart](./docs/en/latest/apisix-dashboard.md)
 - [Apache APISIX Ingress Controller Helm Chart](./docs/en/latest/apisix-ingress-controller.md)
 
 Currently, APISIX Ingress Controller automatically manipulates some APISIX resources, which is not very compatible with APISIX Dashboard. In addition, users should not modify resources labeled `managed-by: apisix-ingress-controllers` via APISIX Dashboard.
 
 ## Compatibility matrix
 
-|            | APISIX | APISIX Ingress | APISIX Dashboard |
+|            | APISIX | APISIX Ingress | [DEPRECATED] APISIX Dashboard |
 | :--------: | :----: | :------------: | :--------------: |
 | Chart v2.x |  v3.x  |      v1.x      |       v3.x       |
 | Chart v1.x |  v3.x  |      v1.x      |       v3.x       |

--- a/charts/apisix-dashboard/Chart.yaml
+++ b/charts/apisix-dashboard/Chart.yaml
@@ -19,7 +19,7 @@
 #
 # In short:
 # The old version of the APISIX Dashboard lacks maintenance from community members,
-# while the new version of the Dashboard will be directly integrated into APISIX,
+# while the brand new Dashboard will be directly integrated into APISIX,
 # eliminating the need for the current chart.
 #
 # For details, please see https://github.com/apache/apisix-dashboard/issues/2981.

--- a/charts/apisix-dashboard/Chart.yaml
+++ b/charts/apisix-dashboard/Chart.yaml
@@ -14,9 +14,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+# This chart is deprecated and no longer maintained.
+#
+# In short:
+# The old version of the APISIX Dashboard lacks maintenance from community members,
+# while the new version of the Dashboard will be directly integrated into APISIX,
+# eliminating the need for the current chart.
+#
+# For details, please see https://github.com/apache/apisix-dashboard/issues/2981.
+#
+# If you are still using the old version of the APISIX Dashboard,
+# you can continue to use the chart.
+deprecated: true
+
 apiVersion: v2
 name: apisix-dashboard
-description: A Helm chart for Apache APISIX Dashboard
+description: DEPRECATED A Helm chart for Apache APISIX Dashboard
 icon: https://apache.org/logos/res/apisix/apisix.png
 # A chart can be either an 'application' or a 'library' chart.
 #
@@ -31,12 +45,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.2
+version: 0.8.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 appVersion: 3.0.0
-
-maintainers:
-  - name: tao12345666333

--- a/charts/apisix-dashboard/README.md
+++ b/charts/apisix-dashboard/README.md
@@ -1,4 +1,17 @@
-# Apache APISIX Dashboard
+# [DEPRECATED] Apache APISIX Dashboard
+
+> [!WARNING]
+> This chart is deprecated and no longer maintained.
+>
+> In short:
+> The old version of the APISIX Dashboard lacks maintenance from community members,
+> while the new version of the Dashboard will be directly integrated into APISIX,
+> eliminating the need for the current chart.
+>
+> For details, please see <https://github.com/apache/apisix-dashboard/issues/2981>.
+>
+> If you are still using the old version of the APISIX Dashboard,
+> you can continue to use the chart.
 
 [APISIX Dashboard](https://github.com/apache/apisix-dashboard/) is designed to make it as easy as possible for users to operate Apache APISIX through a frontend interface.
 
@@ -100,5 +113,5 @@ _See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command documen
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
 | serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |
 | tolerations | list | `[]` | Tolerations for pod assignment |
-| topologySpreadConstraints | list | `[]` | Topology Spread Constraints for pod assignment spread across your cluster among failure-domains ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/#spread-constraints-for-pods |
+| topologySpreadConstraints | list | `[]` | Topology Spread Constraints for pod assignment spread across your cluster among failure-domains ref: <https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/#spread-constraints-for-pods> |
 | updateStrategy | object | `{}` | Update strategy for apisix dashboard deployment |

--- a/charts/apisix-dashboard/README.md
+++ b/charts/apisix-dashboard/README.md
@@ -113,5 +113,5 @@ _See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command documen
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
 | serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |
 | tolerations | list | `[]` | Tolerations for pod assignment |
-| topologySpreadConstraints | list | `[]` | Topology Spread Constraints for pod assignment spread across your cluster among failure-domains ref: <https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/#spread-constraints-for-pods> |
+| topologySpreadConstraints | list | `[]` | Topology Spread Constraints for pod assignment spread across your cluster among failure-domains ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/#spread-constraints-for-pods |
 | updateStrategy | object | `{}` | Update strategy for apisix dashboard deployment |

--- a/charts/apisix-dashboard/README.md
+++ b/charts/apisix-dashboard/README.md
@@ -5,7 +5,7 @@
 >
 > In short:
 > The old version of the APISIX Dashboard lacks maintenance from community members,
-> while the new version of the Dashboard will be directly integrated into APISIX,
+> while the brand new Dashboard will be directly integrated into APISIX,
 > eliminating the need for the current chart.
 >
 > For details, please see <https://github.com/apache/apisix-dashboard/issues/2981>.

--- a/docs/en/latest/apisix-dashboard.md
+++ b/docs/en/latest/apisix-dashboard.md
@@ -26,7 +26,7 @@ title: Apache APISIX Dashboard Helm Chart
 >
 > In short:
 > The old version of the APISIX Dashboard lacks maintenance from community members,
-> while the new version of the Dashboard will be directly integrated into APISIX,
+> while the brand new Dashboard will be directly integrated into APISIX,
 > eliminating the need for the current chart.
 >
 > For details, please see <https://github.com/apache/apisix-dashboard/issues/2981>.

--- a/docs/en/latest/apisix-dashboard.md
+++ b/docs/en/latest/apisix-dashboard.md
@@ -21,6 +21,19 @@ title: Apache APISIX Dashboard Helm Chart
 #
 -->
 
+> [!WARNING]
+> This chart is deprecated and no longer maintained.
+>
+> In short:
+> The old version of the APISIX Dashboard lacks maintenance from community members,
+> while the new version of the Dashboard will be directly integrated into APISIX,
+> eliminating the need for the current chart.
+>
+> For details, please see <https://github.com/apache/apisix-dashboard/issues/2981>.
+>
+> If you are still using the old version of the APISIX Dashboard,
+> you can continue to use the chart.
+
 ## Prerequisites
 
 - [Kubernetes 1.12+](https://kubernetes.io/docs/setup/)


### PR DESCRIPTION
This PR references the DEPRECATED process described in https://github.com/helm/charts/blob/master/PROCESSES.md.

### Why

The old version of the APISIX Dashboard lacks maintenance from community members,
while the brand new Dashboard will be directly integrated into APISIX,
eliminating the need for the current chart. 

So, the helm chart for apisix-dashboard can be marked as DEPRECATED.

Details:

* https://github.com/apache/apisix-dashboard/issues/2981
* https://github.com/apache/apisix-dashboard/issues/2984

close: https://github.com/apache/apisix-dashboard/issues/2984