### PR TITLE
fix: switch to dict instead of list for nginx lua_shared_dict

### DIFF
--- a/charts/apisix/templates/configmap.yaml
+++ b/charts/apisix/templates/configmap.yaml
@@ -209,7 +209,7 @@ data:
         {{- if .Values.apisix.nginx.luaSharedDicts }}
         lua_shared_dict:
         {{- range $dict := .Values.apisix.nginx.luaSharedDicts }}
-          - {{ $dict.name }}: {{ $dict.size }}
+          {{ $dict.name }}: {{ $dict.size }}
         {{- end }}
         {{- end }}
       {{- if .Values.apisix.nginx.configurationSnippet.main }}


### PR DESCRIPTION
Fixes issue from https://github.com/apache/apisix-helm-chart/pull/822