### PR TITLE
feat: add namespace to standalone configmap

### DIFF
--- a/charts/apisix/templates/apisix-config-cm.yml
+++ b/charts/apisix/templates/apisix-config-cm.yml
@@ -19,6 +19,7 @@ kind: ConfigMap
 apiVersion: v1
 metadata:
   name: apisix.yaml
+  namespace: {{ .Release.Namespace }}
 data:
   apisix.yaml: |
     routes:


### PR DESCRIPTION
This pattern is used with other resources in the chart and is useful when using `helm template` 