### PR TITLE
feat: support setting resources for the ingress pod

### DIFF
--- a/charts/apisix-ingress-controller/Chart.yaml
+++ b/charts/apisix-ingress-controller/Chart.yaml
@@ -24,7 +24,7 @@ keywords:
   - nginx
   - crd
 type: application
-version: 1.0.2
+version: 1.0.3
 appVersion: 2.0.0-rc2
 sources:
   - https://github.com/apache/apisix-helm-chart

--- a/charts/apisix-ingress-controller/README.md
+++ b/charts/apisix-ingress-controller/README.md
@@ -136,6 +136,7 @@ The same for container level, you need to set:
 | deployment.podAnnotations | object | `{}` |  |
 | deployment.podSecurityContext | object | `{}` |  |
 | deployment.replicas | int | `1` |  |
+| deployment.resources | object | `{}` | Set pod resource requests & limits |
 | deployment.tolerations | list | `[]` |  |
 | deployment.topologySpreadConstraints | list | `[]` | Topology Spread Constraints for pod assignment spread across your cluster among failure-domains ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/#spread-constraints-for-pods |
 | fullnameOverride | string | `""` |  |

--- a/charts/apisix-ingress-controller/templates/deployment.yaml
+++ b/charts/apisix-ingress-controller/templates/deployment.yaml
@@ -71,12 +71,7 @@ spec:
           initialDelaySeconds: 5
           periodSeconds: 10
         resources:
-          limits:
-            cpu: 500m
-            memory: 128Mi
-          requests:
-            cpu: 10m
-            memory: 64Mi
+          {{- toYaml .Values.deployment.resources | nindent 10 }}
         securityContext:
           {{- toYaml .Values.deployment.podSecurityContext | nindent 10 }}
       {{- with .Values.deployment.nodeSelector }}

--- a/charts/apisix-ingress-controller/values.yaml
+++ b/charts/apisix-ingress-controller/values.yaml
@@ -61,6 +61,8 @@ deployment:
     repository: apache/apisix-ingress-controller
     pullPolicy: IfNotPresent
     tag: "2.0.0-rc2"
+  # -- Set pod resource requests & limits
+  resources: {}
 
 config:
   logLevel: "info"


### PR DESCRIPTION
It should use the default resource configuration of the k8s cluster and allow configuration.

Prevent the application from being unusable due to limit.