### PR TITLE
fix: fix template names in ingress controller pdb

### DIFF
--- a/charts/apisix-ingress-controller/templates/pdb.yaml
+++ b/charts/apisix-ingress-controller/templates/pdb.yaml
@@ -22,10 +22,10 @@ apiVersion: policy/v1
 {{- end }}
 kind: PodDisruptionBudget
 metadata:
-  name: {{ include "apisix-ingress-controller.fullname" . }}
+  name: {{ include "apisix-ingress-controller-manager.name.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "apisix-ingress-controller.labels" . | nindent 4 }}
+    {{- include "apisix-ingress-controller-manager.labels" . | nindent 4 }}
 spec:
 {{- if .Values.podDisruptionBudget.minAvailable }}
   minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
@@ -34,5 +34,5 @@ spec:
 {{- end }}
   selector:
     matchLabels:
-{{- include "apisix-ingress-controller.selectorLabels" . | nindent 6 }}
+{{- include "apisix-ingress-controller-manager.selectorLabels" . | nindent 6 }}
 {{- end }}


### PR DESCRIPTION
The PodDisruptionBudget refers to template that don't exist.

Test:
```
$ helm template test --set podDisruptionBudget.enabled=true --set deployment.replicas=3 charts/apisix-ingress-controller/  > /dev/null
Error: template: apisix-ingress-controller/templates/pdb.yaml:25:11: executing "apisix-ingress-controller/templates/pdb.yaml" at <include "apisix-ingress-controller.fullname" .>: error calling include: template: no template "apisix-ingress-controller.fullname" associated with template "gotpl"

Use --debug flag to render out invalid YAML
```