### PR TITLE
Respect fullnameOverride

### DIFF
--- a/charts/apisix-ingress-controller/templates/cluster_role.yaml
+++ b/charts/apisix-ingress-controller/templates/cluster_role.yaml
@@ -17,7 +17,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ .Release.Name }}-apisix-ingress-manager-role
+  name: {{ include "apisix-ingress-controller-manager.name.fullname" . }}-manager-role
 rules:
 - apiGroups:
   - ""
@@ -155,7 +155,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ .Release.Name }}-apisix-ingress-metrics-auth-role
+  name: {{ include "apisix-ingress-controller-manager.name.fullname" . }}-metrics-auth-role
 rules:
 - apiGroups:
   - authentication.k8s.io
@@ -173,7 +173,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ .Release.Name }}-apisix-ingress-metrics-reader
+  name: {{ include "apisix-ingress-controller-manager.name.fullname" . }}-metrics-reader
 rules:
 - nonResourceURLs:
   - /metrics

--- a/charts/apisix-ingress-controller/templates/cluster_role_binding.yaml
+++ b/charts/apisix-ingress-controller/templates/cluster_role_binding.yaml
@@ -19,25 +19,25 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     {{- include "apisix-ingress-controller-manager.labels" . | nindent 4 }}
-  name: {{ .Release.Name }}-apisix-ingress-manager-rolebinding
+  name: {{ include "apisix-ingress-controller-manager.name.fullname" . }}-manager-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ .Release.Name }}-apisix-ingress-manager-role
+  name: {{ include "apisix-ingress-controller-manager.name.fullname" . }}-manager-role
 subjects:
 - kind: ServiceAccount
-  name: {{ .Release.Name }}
+  name: {{ include "apisix-ingress-controller-manager.name.fullname" . }}
   namespace: {{ .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ .Release.Name }}-apisix-ingress-metrics-auth-rolebinding
+  name: {{ include "apisix-ingress-controller-manager.name.fullname" . }}-metrics-auth-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ .Release.Name }}-apisix-ingress-metrics-auth-role
+  name: {{ include "apisix-ingress-controller-manager.name.fullname" . }}-metrics-auth-role
 subjects:
 - kind: ServiceAccount
-  name: {{ .Release.Name }}
+  name: {{ include "apisix-ingress-controller-manager.name.fullname" . }}
   namespace: {{ .Release.Namespace }}

--- a/charts/apisix-ingress-controller/templates/configmap.yaml
+++ b/charts/apisix-ingress-controller/templates/configmap.yaml
@@ -17,7 +17,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Release.Name }}-ingress-config
+  name: {{ include "apisix-ingress-controller-manager.name.fullname" . }}-ingress-config
   namespace: {{ .Release.Namespace }}
 data:
   config.yaml: |

--- a/charts/apisix-ingress-controller/templates/deployment.yaml
+++ b/charts/apisix-ingress-controller/templates/deployment.yaml
@@ -97,8 +97,8 @@ spec:
       volumes:
       - name: {{ .Release.Name }}-ingress-config
         configMap:
-          name: {{ .Release.Name }}-ingress-config
+          name: {{ include "apisix-ingress-controller-manager.name.fullname" . }}-ingress-config
       securityContext:
         runAsNonRoot: false
-      serviceAccountName: {{ .Release.Name }}
+      serviceAccountName: {{ include "apisix-ingress-controller-manager.name.fullname" . }}
       terminationGracePeriodSeconds: 10

--- a/charts/apisix-ingress-controller/templates/deployment.yaml
+++ b/charts/apisix-ingress-controller/templates/deployment.yaml
@@ -58,7 +58,7 @@ spec:
           name: metrics
           protocol: TCP
         volumeMounts:
-        - name: {{ .Release.Name }}-ingress-config
+        - name: config
           mountPath: /app/conf/config.yaml
           subPath: config.yaml
         livenessProbe:
@@ -95,7 +95,7 @@ spec:
         {{- tpl (. | toYaml) $ | nindent 8 }}
       {{- end }}
       volumes:
-      - name: {{ .Release.Name }}-ingress-config
+      - name: config
         configMap:
           name: {{ include "apisix-ingress-controller-manager.name.fullname" . }}-ingress-config
       securityContext:

--- a/charts/apisix-ingress-controller/templates/gatewayproxy.yaml
+++ b/charts/apisix-ingress-controller/templates/gatewayproxy.yaml
@@ -19,7 +19,7 @@ apiVersion: apisix.apache.org/v1alpha1
 kind: GatewayProxy
 metadata:
   namespace: {{ .Release.Namespace }}
-  name: {{ .Release.Name }}-config
+  name: {{ include "apisix-ingress-controller-manager.name.fullname" . }}-config
 spec:
   provider:
     type: {{ .Values.gatewayProxy.provider.type }}

--- a/charts/apisix-ingress-controller/templates/ingress-class.yaml
+++ b/charts/apisix-ingress-controller/templates/ingress-class.yaml
@@ -28,7 +28,7 @@ spec:
   parameters:
     apiGroup: apisix.apache.org
     kind: GatewayProxy
-    name: {{ .Release.Name }}-config
+    name: {{ include "apisix-ingress-controller-manager.name.fullname" . }}-config
     namespace: {{ .Release.Namespace }}
     scope: Namespace
   {{- end}}

--- a/charts/apisix-ingress-controller/templates/role.yaml
+++ b/charts/apisix-ingress-controller/templates/role.yaml
@@ -19,7 +19,7 @@ kind: Role
 metadata:
   labels:
     {{- include "apisix-ingress-controller-manager.labels" . | nindent 4 }}
-  name: {{ .Release.Name }}-apisix-ingress-leader-election-role
+  name: {{ include "apisix-ingress-controller-manager.name.fullname" . }}-leader-election-role
   namespace: {{ .Release.Namespace }}
 rules:
 - apiGroups:

--- a/charts/apisix-ingress-controller/templates/role_binding.yaml
+++ b/charts/apisix-ingress-controller/templates/role_binding.yaml
@@ -19,13 +19,13 @@ kind: RoleBinding
 metadata:
   labels:
     {{- include "apisix-ingress-controller-manager.labels" . | nindent 4 }}
-  name: {{ .Release.Name }}-apisix-ingress-leader-election-rolebinding
+  name: {{ include "apisix-ingress-controller-manager.name.fullname" . }}-leader-election-rolebinding
   namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: {{ .Release.Name }}-apisix-ingress-leader-election-role
+  name: {{ include "apisix-ingress-controller-manager.name.fullname" . }}-leader-election-role
 subjects:
 - kind: ServiceAccount
-  name: {{ .Release.Name }}
+  name: {{ include "apisix-ingress-controller-manager.name.fullname" . }}
   namespace: {{ .Release.Namespace }}

--- a/charts/apisix-ingress-controller/templates/service-account.yaml
+++ b/charts/apisix-ingress-controller/templates/service-account.yaml
@@ -19,5 +19,5 @@ kind: ServiceAccount
 metadata:
   labels:
     {{- include "apisix-ingress-controller-manager.labels" . | nindent 4 }}
-  name: {{ .Release.Name }}
+  name: {{ include "apisix-ingress-controller-manager.name.fullname" . }}
   namespace: {{ .Release.Namespace }}


### PR DESCRIPTION
Not all the resources handle `fullnameOverride` consistently. Most of them just use the release name.

In the following example, `whatever` should appear in no resource name:

```
$ helm template whatever --set fullnameOverride=foo ./charts/apisix-ingress-controller | yq --no-doc '.metadata.name + "/" + .kind'
whatever/ServiceAccount
whatever-ingress-config/ConfigMap
whatever-apisix-ingress-manager-role/ClusterRole
whatever-apisix-ingress-metrics-auth-role/ClusterRole
whatever-apisix-ingress-metrics-reader/ClusterRole
whatever-apisix-ingress-manager-rolebinding/ClusterRoleBinding
whatever-apisix-ingress-metrics-auth-rolebinding/ClusterRoleBinding
whatever-apisix-ingress-leader-election-role/Role
whatever-apisix-ingress-leader-election-rolebinding/RoleBinding
foo/Service
foo/Deployment
apisix/IngressClass
```

after the fix:

```
$ helm template whatever --set fullnameOverride=foo ./charts/apisix-ingress-controller | yq --no-doc '.metadata.name + "/" + .kind'
foo/ServiceAccount
foo-ingress-config/ConfigMap
foo-manager-role/ClusterRole
foo-metrics-auth-role/ClusterRole
foo-metrics-reader/ClusterRole
foo-manager-rolebinding/ClusterRoleBinding
foo-metrics-auth-rolebinding/ClusterRoleBinding
foo-leader-election-role/Role
foo-leader-election-rolebinding/RoleBinding
foo/Service
foo/Deployment
apisix/IngressClass
```

The MR also remove the redundant `apisix-ingress` part from the roles and bindings (previous names would have been like `apisix-ingress-controller-apisix-ingress-manager-role`) and fixes the volume names in the deployment.
