### PR TITLE
docs: add missing wasm parameters

### DIFF
--- a/charts/apisix/README.md
+++ b/charts/apisix/README.md
@@ -133,8 +133,11 @@ The command removes all the Kubernetes components associated with the chart and 
 | apisix.vault.prefix | string | `""` | Prefix allows you to better enforcement of policies. |
 | apisix.vault.timeout | int | `10` | HTTP timeout for each request. |
 | apisix.vault.token | string | `""` | The generated token from vault instance that can grant access to read data from the vault. |
-| apisix.wasm.enabled | bool | `false` | Enable Wasm Plugins. See [wasm plugin](https://apisix.apache.org/docs/apisix/next/wasm/) |
-| apisix.wasm.plugins | list | `[]` |  |
+| apisix.wasm.enabled | bool | `false` | Enable Wasm Plugins. See [wasm plugin](https://apisix.apache.org/docs/apisix/next/wasm/). |
+| apisix.wasm.file | string | `""` | Set path to Wasm plugin. |
+| apisix.wasm.http_request_phase | string | `"rewrite"` | Set the HTTP request phase in which the plugin should run. |
+| apisix.wasm.plugins | list | `[]` | Set Wasm plugin name. |
+| apisix.wasm.priority | int | `7999` | Set wasm plugin priority. |
 | autoscaling.enabled | bool | `false` |  |
 | autoscaling.maxReplicas | int | `100` |  |
 | autoscaling.minReplicas | int | `1` |  |

--- a/charts/apisix/README.md
+++ b/charts/apisix/README.md
@@ -134,10 +134,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | apisix.vault.timeout | int | `10` | HTTP timeout for each request. |
 | apisix.vault.token | string | `""` | The generated token from vault instance that can grant access to read data from the vault. |
 | apisix.wasm.enabled | bool | `false` | Enable Wasm Plugins. See [wasm plugin](https://apisix.apache.org/docs/apisix/next/wasm/). |
-| apisix.wasm.file | string | `""` | Set path to Wasm plugin. |
-| apisix.wasm.http_request_phase | string | `"rewrite"` | Set the HTTP request phase in which the plugin should run. |
-| apisix.wasm.plugins | list | `[]` | Set Wasm plugin name. |
-| apisix.wasm.priority | int | `7999` | Set wasm plugin priority. |
+| apisix.wasm.plugins | list | `[]` | Set Wasm plugins. Each item supports fields such as name, priority, file, and http_request_phase. |
 | autoscaling.enabled | bool | `false` |  |
 | autoscaling.maxReplicas | int | `100` |  |
 | autoscaling.minReplicas | int | `1` |  |

--- a/charts/apisix/values.yaml
+++ b/charts/apisix/values.yaml
@@ -554,9 +554,16 @@ apisix:
     cmd: ["/path/to/apisix-plugin-runner/runner", "run"]
 
   wasm:
-    # -- Enable Wasm Plugins. See [wasm plugin](https://apisix.apache.org/docs/apisix/next/wasm/)
+    # -- Enable Wasm Plugins. See [wasm plugin](https://apisix.apache.org/docs/apisix/next/wasm/).
     enabled: false
+    # -- Set Wasm plugin name.
     plugins: []
+    # -- Set wasm plugin priority.
+    priority: 7999
+    # -- Set path to Wasm plugin.
+    file: ""
+    # -- Set the HTTP request phase in which the plugin should run.
+    http_request_phase: rewrite
 
   # -- customPlugins allows you to mount your own HTTP plugins.
   customPlugins:

--- a/charts/apisix/values.yaml
+++ b/charts/apisix/values.yaml
@@ -556,14 +556,13 @@ apisix:
   wasm:
     # -- Enable Wasm Plugins. See [wasm plugin](https://apisix.apache.org/docs/apisix/next/wasm/).
     enabled: false
-    # -- Set Wasm plugin name.
+    # -- Set Wasm plugins. Each item supports fields such as name, priority, file, and http_request_phase.
+    # plugins:
+    #   - name: "example-plugin"
+    #     priority: 7999
+    #     file: "/path/to/plugin.wasm"
+    #     http_request_phase: "rewrite"
     plugins: []
-    # -- Set wasm plugin priority.
-    priority: 7999
-    # -- Set path to Wasm plugin.
-    file: ""
-    # -- Set the HTTP request phase in which the plugin should run.
-    http_request_phase: rewrite
 
   # -- customPlugins allows you to mount your own HTTP plugins.
   customPlugins:


### PR DESCRIPTION
Wasm's `priority`, `file`, and `http_request_phase` were previously documented but got removed in https://github.com/apache/apisix-helm-chart/pull/415 which switched to using `helm-docs` to generate the docs.

The missed configuration could lead to:

<img width="826" height="97" alt="image" src="https://github.com/user-attachments/assets/9e03628a-aed5-4354-b04f-3bb96547b587" />

This PR adds these parameters back.