### PR TITLE
Update service port reference in ingress-control.yaml

### DIFF
--- a/charts/apisix/templates/ingress-control.yaml
+++ b/charts/apisix/templates/ingress-control.yaml
@@ -16,7 +16,7 @@
 
 {{- if (and .Values.control.enabled .Values.control.ingress.enabled) -}}
 {{- $fullName := include "apisix.fullname" . -}}
-{{- $svcPort := .Values.control.servicePort -}}
+{{- $svcPort := .Values.control.ingress.servicePort -}}
 {{- if and .Values.control.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
   {{- if not (hasKey .Values.control.ingress.annotations "kubernetes.io/ingress.class") }}
   {{- $_ := set .Values.control.ingress.annotations "kubernetes.io/ingress.class" .Values.control.ingress.className}}


### PR DESCRIPTION
I’m not sure whether this is a config issue from the docs or from the code, but either way the docs and the current chart settings don’t work as-is. Should we be using:
* `control.service.servicePort`
* `control.ingress.servicePort`
* `controle.servicePort`

I’ll let you decide :)