### PR TITLE
feat: add gatewayProxy publishService and statusAddress

### DIFF
--- a/charts/apisix-ingress-controller/README.md
+++ b/charts/apisix-ingress-controller/README.md
@@ -146,6 +146,8 @@ The same for container level, you need to set:
 | gatewayProxy.provider.controlPlane.auth.type | string | `"AdminKey"` |  |
 | gatewayProxy.provider.controlPlane.endpoints | list | `[]` |  |
 | gatewayProxy.provider.type | string | `"ControlPlane"` |  |
+| gatewayProxy.publishService | string | `""` | publishService specifies the LoadBalancer-type Service whose external address the controller uses to update the status of Ingress resources. Example: [Namespace]/[APISIX_LoadBalancer_Service]. Applicable to ingress resources. |
+| gatewayProxy.statusAddress | string | `""` | statusAddress specifies the external IP addresses that the controller uses to populate the status field of GatewayProxy or Ingress resources for developers to access. statusAddress has higher priority than publishService. |
 | labelsOverride | object | `{}` | Override default labels assigned to Apache APISIX ingress controller resource |
 | nameOverride | string | `""` | Default values for apisix-ingress-controller. This is a YAML-formatted file. Declare variables to be passed into your templates.  |
 | podDisruptionBudget | object | `{"enabled":false,"maxUnavailable":1,"minAvailable":"90%"}` | See https://kubernetes.io/docs/tasks/run-application/configure-pdb/ for more details |

--- a/charts/apisix-ingress-controller/templates/gatewayproxy.yaml
+++ b/charts/apisix-ingress-controller/templates/gatewayproxy.yaml
@@ -31,4 +31,8 @@ spec:
       auth:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+  publishService: {{ .Values.gatewayProxy.publishService }}
+  {{- if .Values.gatewayProxy.statusAddress }}
+  statusAddress: {{ .Values.gatewayProxy.statusAddress }}
+  {{- end }}
 {{- end }}

--- a/charts/apisix-ingress-controller/templates/gatewayproxy.yaml
+++ b/charts/apisix-ingress-controller/templates/gatewayproxy.yaml
@@ -31,7 +31,9 @@ spec:
       auth:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+  {{- if .Values.gatewayProxy.publishService }}
   publishService: {{ .Values.gatewayProxy.publishService }}
+  {{- end }}
   {{- if .Values.gatewayProxy.statusAddress }}
   statusAddress: {{ .Values.gatewayProxy.statusAddress }}
   {{- end }}

--- a/charts/apisix-ingress-controller/values.yaml
+++ b/charts/apisix-ingress-controller/values.yaml
@@ -105,6 +105,13 @@ gatewayProxy:
         adminKey:
           value: "edd1c9f034335f136f87ad84b625c8f1"
 
+  # -- publishService specifies the LoadBalancer-type Service whose external address the controller uses to update the
+  # status of Ingress resources.
+  publishService: apisix-ingress/apisix-gateway
+  # -- statusAddress specifies the external IP addresses that the controller uses to populate the status field
+  # of GatewayProxy or Ingress resources for developers to access. statusAddress has higher priority than publishService.
+  # statusAddress:
+
 apisix:
   adminService:
     namespace: apisix-ingress

--- a/charts/apisix-ingress-controller/values.yaml
+++ b/charts/apisix-ingress-controller/values.yaml
@@ -106,7 +106,7 @@ gatewayProxy:
           value: "edd1c9f034335f136f87ad84b625c8f1"
 
   # -- publishService specifies the LoadBalancer-type Service whose external address the controller uses to update the
-  # status of Ingress resources.
+  # status of Ingress resources. Example: [Namespace]/[APISIX_LoadBalancer_Service]
   publishService: apisix-ingress/apisix-gateway
   # -- statusAddress specifies the external IP addresses that the controller uses to populate the status field
   # of GatewayProxy or Ingress resources for developers to access. statusAddress has higher priority than publishService.

--- a/charts/apisix-ingress-controller/values.yaml
+++ b/charts/apisix-ingress-controller/values.yaml
@@ -104,7 +104,6 @@ gatewayProxy:
         type: AdminKey
         adminKey:
           value: "edd1c9f034335f136f87ad84b625c8f1"
-
   # -- publishService specifies the LoadBalancer-type Service whose external address the controller uses to update the
   # status of Ingress resources. Example: [Namespace]/[APISIX_LoadBalancer_Service]
   publishService: apisix-ingress/apisix-gateway

--- a/charts/apisix-ingress-controller/values.yaml
+++ b/charts/apisix-ingress-controller/values.yaml
@@ -105,11 +105,13 @@ gatewayProxy:
         adminKey:
           value: "edd1c9f034335f136f87ad84b625c8f1"
   # -- publishService specifies the LoadBalancer-type Service whose external address the controller uses to update the
-  # status of Ingress resources. Example: [Namespace]/[APISIX_LoadBalancer_Service]
-  publishService: apisix-ingress/apisix-gateway
+  # status of Ingress resources. Example: [Namespace]/[APISIX_LoadBalancer_Service]. Applicable to ingress resources.
+  publishService: ""
+  # publishService: apisix-ingress/apisix-gateway
+
   # -- statusAddress specifies the external IP addresses that the controller uses to populate the status field
   # of GatewayProxy or Ingress resources for developers to access. statusAddress has higher priority than publishService.
-  # statusAddress:
+  statusAddress: ""
 
 apisix:
   adminService:


### PR DESCRIPTION
gatewayProxy add publishService and statusAddress， To support ingress status updates and display LoadBalancer addresses. 

issue: #876 