### PR TITLE
fix: Resolve duplicate volume mounts for custom plugins sharing same ConfigMap

### DIFF
--- a/charts/apisix/templates/_helpers.tpl
+++ b/charts/apisix/templates/_helpers.tpl
@@ -157,3 +157,18 @@ Key to use to fetch viewer token from secret
 {{- "viewer" }}
 {{- end }}
 {{- end }}
+
+{{/*
+Get unique ConfigMap names from custom plugins
+*/}}
+{{- define "apisix.uniqueConfigMaps" -}}
+{{- $configMaps := dict }}
+{{- if .Values.apisix.customPlugins.enabled }}
+{{- range $plugin := .Values.apisix.customPlugins.plugins }}
+{{- if ne $plugin.configMap.name "" }}
+{{- $_ := set $configMaps $plugin.configMap.name true }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- keys $configMaps | join "," }}
+{{- end }}

--- a/charts/apisix/templates/deployment.yaml
+++ b/charts/apisix/templates/deployment.yaml
@@ -279,11 +279,14 @@ spec:
           name: id
         {{- end }}
         {{- if .Values.apisix.customPlugins.enabled }}
-        {{- range $plugin := .Values.apisix.customPlugins.plugins }}
-        {{- if ne $plugin.configMap.name "" }}
-        - name: plugin-{{ $plugin.configMap.name }}
+        {{- $uniqueConfigMaps := include "apisix.uniqueConfigMaps" . }}
+        {{- if ne $uniqueConfigMaps "" }}
+        {{- range $configMapName := splitList "," $uniqueConfigMaps }}
+        {{- if ne $configMapName "" }}
+        - name: plugin-{{ $configMapName }}
           configMap:
-            name: {{ $plugin.configMap.name }}
+            name: {{ $configMapName }}
+        {{- end }}
         {{- end }}
         {{- end }}
         {{- end }}


### PR DESCRIPTION
# Fix: Resolve duplicate volume mounts for custom plugins sharing same ConfigMap

## Problem

When multiple APISIX custom plugins reference the same ConfigMap, the Helm chart creates duplicate volume mounts, causing deployment failures. This occurs because the chart template generates a volume for each plugin individually, without checking if multiple plugins share the same ConfigMap.

**Example:**
```yaml
customPlugins:
  plugins:
  - name: "custom-forward-auth"
    attrs: {}
    configMap:
      name: "apisix-custom-plugins"
      mounts:
      - key: "custom-forward-auth.lua"
        path: "/opt/apisix/plugins/custom-forward-auth.lua"
  - name: "header-to-cookie"
    attrs: {}
    configMap:
      name: "apisix-custom-plugins"
      mounts:
      - key: "header-to-cookie.lua"
        path: "/opt/apisix/plugins/header-to-cookie.lua"
```

## Solution

This PR introduces a helper function that deduplicates ConfigMap references across custom plugins, ensuring only one volume is created per unique ConfigMap while preserving all individual plugin file mounts.

### Changes Made

1. **Added helper function** in `templates/_helpers.tpl`:
   - `apisix.uniqueConfigMaps`: Collects and returns unique ConfigMap names from all custom plugins

2. **Modified deployment template** in `templates/deployment.yaml`:
   - Updated volumes section to use the helper function
   - Creates volumes based on unique ConfigMap names instead of per-plugin

### Before vs After

**Before (Broken):**
```yaml
volumes:
- name: plugin-apisix-custom-plugins
  configMap:
    name: apisix-custom-plugins
volumes:
- name: plugin-apisix-custom-plugins
  configMap:
    name: apisix-custom-plugins  # Duplicate!
```
Result: Duplicate volume mount error

**After (Fixed):**
- Same configuration works correctly
- Single volume created for shared ConfigMap
- All plugin files properly mounted

```yaml
volumes:
- name: plugin-apisix-custom-plugins
  configMap:
    name: apisix-custom-plugins
```

## Benefits

- ✅ Eliminates duplicate volume mount errors
- ✅ Maintains backward compatibility
- ✅ Preserves all existing functionality
- ✅ Supports multiple plugins sharing ConfigMaps
- ✅ No breaking changes to values.yaml format

## Testing

- [x] helm build succeeds without errors
- [x] Single volume created for shared ConfigMap
- [x] All plugin files correctly mounted
- [x] Both custom plugins properly configured

This fix resolves the deployment issue while maintaining the clean, intuitive configuration format for custom plugins.