### PR TITLE
feat: bump apisix-ingress-controller's adc to 0.22.1

### DIFF
--- a/charts/apisix-ingress-controller/Chart.yaml
+++ b/charts/apisix-ingress-controller/Chart.yaml
@@ -24,7 +24,7 @@ keywords:
   - nginx
   - crd
 type: application
-version: 1.0.6
+version: 1.0.7
 appVersion: 2.0.0-rc5
 sources:
   - https://github.com/apache/apisix-helm-chart

--- a/charts/apisix-ingress-controller/README.md
+++ b/charts/apisix-ingress-controller/README.md
@@ -127,7 +127,7 @@ The same for container level, you need to set:
 | config.provider.syncPeriod | string | `"1m"` |  |
 | config.provider.type | string | `"apisix"` |  |
 | config.secureMetrics | bool | `false` |  |
-| deployment.adcContainer | object | `{"config":{"logLevel":"info"},"image":{"repository":"ghcr.io/api7/adc","tag":"0.21.2"}}` | Set adc sidecar container configuration |
+| deployment.adcContainer | object | `{"config":{"logLevel":"info"},"image":{"repository":"ghcr.io/api7/adc","tag":"0.22.1"}}` | Set adc sidecar container configuration |
 | deployment.affinity | object | `{}` |  |
 | deployment.annotations | object | `{}` | Add annotations to Apache APISIX ingress controller resource |
 | deployment.image.pullPolicy | string | `"IfNotPresent"` |  |

--- a/charts/apisix-ingress-controller/values.yaml
+++ b/charts/apisix-ingress-controller/values.yaml
@@ -72,7 +72,7 @@ deployment:
   adcContainer:
     image:
       repository: ghcr.io/api7/adc
-      tag: "0.21.2"
+      tag: "0.22.1"
     config:
       logLevel: "info"
 


### PR DESCRIPTION
In the currently used ADC 0.21.x, the ADC running in server mode suffers from a connection leak issue. This manifests as the ADC establishing an increasing number of connections over time, which can only be terminated by the server actively closing them.

ADC 0.22.x has addressed this issue by limiting the connection cap per host to 256 and proactively releasing connections after 60 seconds of inactivity. This significantly improves the previous connection leak problem.

This PR upgrades the ADC version for AIC.