### PR TITLE
fix: missing trusted_addresses

### DIFF
--- a/charts/apisix/templates/configmap.yaml
+++ b/charts/apisix/templates/configmap.yaml
@@ -58,7 +58,9 @@ data:
       {{- if or .Values.apisix.customPlugins.enabled .Values.apisix.luaModuleHook.enabled }}
       extra_lua_path: {{ .Values.apisix.customPlugins.luaPath }};{{ .Values.apisix.luaModuleHook.luaPath }}
       {{- end }}
-
+      
+      trusted_addresses: {{ toYaml .Values.apisix.trusted_addresses | nindent 8 }}
+      
       enable_control: {{ .Values.control.enabled }}
       {{- if .Values.control.enabled }}
       control:


### PR DESCRIPTION
https://github.com/apache/apisix/pull/12551/files. The breaking change is introduced here, but it's not addressed in the helm chart