### PR TITLE
feat: add configurable real_ip_header option for nginx

### DIFF
--- a/charts/apisix/README.md
+++ b/charts/apisix/README.md
@@ -105,6 +105,8 @@ The command removes all the Kubernetes components associated with the chart and 
 | apisix.nginx.logs.errorLog | string | `"/dev/stderr"` | Error log path |
 | apisix.nginx.logs.errorLogLevel | string | `"warn"` | Error log level |
 | apisix.nginx.luaSharedDicts | list | `[]` | Override default [lua_shared_dict](https://github.com/apache/apisix/blob/master/conf/config.yaml.example#L250-L276) settings, click [here](https://github.com/apache/apisix-helm-chart/blob/master/charts/apisix/values.yaml#L27-L30) to learn the format of a shared dict |
+| apisix.nginx.realIpFrom | list | `["127.0.0.1","unix:"]` | Defines trusted addresses that are known to send correct replacement addresses. http://nginx.org/en/docs/http/ngx_http_realip_module.html#set_real_ip_from |
+| apisix.nginx.realIpHeader | string | `"X-Real-IP"` | The name of the header from which to extract the real client IP address http://nginx.org/en/docs/http/ngx_http_realip_module.html#real_ip_header |
 | apisix.nginx.workerConnections | string | `"10620"` |  |
 | apisix.nginx.workerProcesses | string | `"auto"` |  |
 | apisix.nginx.workerRlimitNofile | string | `"20480"` |  |

--- a/charts/apisix/templates/configmap.yaml
+++ b/charts/apisix/templates/configmap.yaml
@@ -209,8 +209,12 @@ data:
         underscores_in_headers: "on"   # default enables the use of underscores in client request header fields
         real_ip_header: {{ .Values.apisix.nginx.realIpHeader | quote }}    # http://nginx.org/en/docs/http/ngx_http_realip_module.html#real_ip_header
         real_ip_from:                  # http://nginx.org/en/docs/http/ngx_http_realip_module.html#set_real_ip_from
+        {{- if .Values.apisix.nginx.realIpFrom }}
+          {{- toYaml .Values.apisix.nginx.realIpFrom | nindent 10 }}
+        {{- else }}
           - 127.0.0.1
           - 'unix:'
+        {{- end }}
         {{- if .Values.apisix.nginx.customLuaSharedDicts }}
         custom_lua_shared_dict:        # add custom shared cache to nginx.conf
         {{- range $dict := .Values.apisix.nginx.customLuaSharedDicts }}

--- a/charts/apisix/templates/configmap.yaml
+++ b/charts/apisix/templates/configmap.yaml
@@ -202,7 +202,7 @@ data:
         client_body_timeout: 60s       # timeout for reading client request body, then 408 (Request Time-out) error is returned to the client
         send_timeout: 10s              # timeout for transmitting a response to the client.then the connection is closed
         underscores_in_headers: "on"   # default enables the use of underscores in client request header fields
-        real_ip_header: "X-Real-IP"    # http://nginx.org/en/docs/http/ngx_http_realip_module.html#real_ip_header
+        real_ip_header: {{ .Values.apisix.nginx.realIpHeader | quote }}    # http://nginx.org/en/docs/http/ngx_http_realip_module.html#real_ip_header
         real_ip_from:                  # http://nginx.org/en/docs/http/ngx_http_realip_module.html#set_real_ip_from
           - 127.0.0.1
           - 'unix:'

--- a/charts/apisix/values.yaml
+++ b/charts/apisix/values.yaml
@@ -421,6 +421,11 @@ apisix:
     # -- The name of the header from which to extract the real client IP address
     # http://nginx.org/en/docs/http/ngx_http_realip_module.html#real_ip_header
     realIpHeader: "X-Real-IP"
+    # -- Defines trusted addresses that are known to send correct replacement addresses.
+    # http://nginx.org/en/docs/http/ngx_http_realip_module.html#set_real_ip_from
+    realIpFrom:
+      - 127.0.0.1
+      - 'unix:'
     envs: []
     # access log and error log configuration
     logs:

--- a/charts/apisix/values.yaml
+++ b/charts/apisix/values.yaml
@@ -418,6 +418,9 @@ apisix:
     enableCPUAffinity: true
     # -- Timeout during which a keep-alive client connection will stay open on the server side.
     keepaliveTimeout: 60s
+    # -- The name of the header from which to extract the real client IP address
+    # http://nginx.org/en/docs/http/ngx_http_realip_module.html#real_ip_header
+    realIpHeader: "X-Real-IP"
     envs: []
     # access log and error log configuration
     logs:


### PR DESCRIPTION
## Add configurable `real_ip_header` option for nginx configuration

### Summary
This PR makes the nginx `real_ip_header` directive configurable via `values.yaml`, allowing users to customize which header is used to extract the real client IP address.

### Changes
- Added `apisix.nginx.realIpHeader` configuration option in `values.yaml` with a default value of `"X-Real-IP"`
- Updated `configmap.yaml` template to use the configurable value instead of hardcoded `"X-Real-IP"`
- Maintains backward compatibility with existing deployments (default remains `"X-Real-IP"`)

### Why This Change is Necessary

Different deployment environments and proxy setups use different headers to pass the original client IP address:

1. **Load Balancer Variations**: Different cloud providers and load balancers use different headers:
   - AWS ALB/ELB often uses `X-Forwarded-For`
   - Cloudflare uses `CF-Connecting-IP`
   - Google Cloud Load Balancer may use `X-Forwarded-For`
   - Some proxies use `X-Real-IP` (current default)

2. **Multi-Layer Proxy Environments**: In complex deployments with multiple proxy layers (e.g., CDN → Load Balancer → Ingress → APISIX), the appropriate header may differ based on architecture.

3. **Security and Rate Limiting**: Correctly identifying client IPs is crucial for:
   - Accurate rate limiting based on client IP
   - Security plugins that rely on IP-based access control
   - Logging and analytics
   - Compliance requirements

4. **Flexibility**: Without this configuration option, users would need to either:
   - Fork the chart and modify it
   - Use post-deployment patches
   - Accept incorrect IP detection in their environment

This change provides the flexibility needed for various deployment scenarios while maintaining sensible defaults.

### Usage Example

```yaml
apisix:
  nginx:
    realIpHeader: "X-Forwarded-For"  # For AWS ALB/ELB environments
```

Or via Helm CLI:
```bash
helm install apisix . --set apisix.nginx.realIpHeader="CF-Connecting-IP"
```
