### PR TITLE
fix: ConfigMap rendering to use YAML block format instead of JSON encoding

### DIFF
--- a/charts/apisix/templates/configmap.yaml
+++ b/charts/apisix/templates/configmap.yaml
@@ -176,10 +176,10 @@ data:
         port: {{ default "7085" (.Values.apisix.status.port | toString) }}
       {{- end}}
 
-      {{ if .Values.apisix.trustedAddresses }}
+      {{- if .Values.apisix.trustedAddresses }}
       trusted_addresses:
       {{- toYaml .Values.apisix.trustedAddresses | nindent 8 }}
-      {{ end }}
+      {{- end }}
 
     nginx_config:    # config for render the template to genarate nginx.conf
       error_log: "{{ .Values.apisix.nginx.logs.errorLog }}"


### PR DESCRIPTION
# Fix ConfigMap rendering to use YAML block format instead of JSON encoding

## Problem
When running `kustomize build --enable-helm`, the APISIX ConfigMap was being rendered with JSON-encoded strings (containing `\n` escape sequences) instead of clean YAML block format with the pipe (`|`) operator. This made the rendered output extremely difficult to read and debug.

**Before:**
```yaml
data:
  config.yaml: "#\n# Licensed to the Apache Software Foundation...\n  enable_admin: true\n  enable_admin_cors: true\n..."
```

**After:**
```yaml
data:
  config.yaml: |
    #
    # Licensed to the Apache Software Foundation...
    enable_admin: true
    enable_admin_cors: true
    ...
```

## Root Cause
The issue was caused by inconsistent Helm template whitespace control in the `trustedAddresses` conditional block. The template used `{{ if` and `{{ end }}` without the dash (`-`) modifier, which preserved extra whitespace and newlines in the output.

When these extra characters were present, the YAML serializer switched to JSON encoding mode to preserve the literal whitespace, resulting in the unreadable escaped format.

## Solution
Changed the conditional block from:
```helm
{{ if .Values.apisix.trustedAddresses }}
trusted_addresses:
{{- toYaml .Values.apisix.trustedAddresses | nindent 8 }}
{{ end }}
```

To:
```helm
{{- if .Values.apisix.trustedAddresses }}
trusted_addresses:
{{- toYaml .Values.apisix.trustedAddresses | nindent 8 }}
{{- end }}
```

The `{{-` syntax tells Helm to trim leading whitespace, preventing extra newlines from being added to the rendered output. This keeps the YAML formatting consistent with the rest of the template.

## Impact
- ✅ ConfigMap output is now human-readable when using `kustomize build`
- ✅ Easier to debug and review configuration changes in CI/CD pipelines
- ✅ No functional changes - the deployed ConfigMap works identically
- ✅ Consistent with Helm best practices for whitespace control

## Testing
```
# kustomization.yaml
apiVersion: kustomize.config.k8s.io/v1beta1
kind: Kustomization
helmCharts:
- name: apisix
  repo: https://apache.github.io/apisix-helm-chart
  version: 2.12.4
```
Verified that `kustomize build --enable-helm .` now produces properly formatted YAML output with clean line breaks instead of JSON-encoded strings.

