### PR TITLE
fix: allow webhook calls to fail

### DIFF
--- a/charts/apisix-ingress-controller/README.md
+++ b/charts/apisix-ingress-controller/README.md
@@ -168,6 +168,6 @@ The same for container level, you need to set:
 | serviceMonitor.namespace | string | `"monitoring"` | @param serviceMonitor.namespace Namespace in which to create the ServiceMonitor |
 | webhook.certificate.provided | bool | `false` | Set to true if you want to provide your own certificate |
 | webhook.enabled | bool | `true` | Enable or disable admission webhook |
-| webhook.failurePolicy | string | `"Fail"` | Failure policy for the webhook (Fail or Ignore) |
+| webhook.failurePolicy | string | `"Ignore"` | Failure policy for the webhook (Fail or Ignore) |
 | webhook.port | int | `9443` | The port for the webhook server to listen on |
 | webhook.timeoutSeconds | int | `10` | Timeout in seconds for the webhook |

--- a/charts/apisix-ingress-controller/values.yaml
+++ b/charts/apisix-ingress-controller/values.yaml
@@ -105,7 +105,7 @@ webhook:
   # -- The port for the webhook server to listen on
   port: 9443
   # -- Failure policy for the webhook (Fail or Ignore)
-  failurePolicy: Fail
+  failurePolicy: Ignore
   # -- Timeout in seconds for the webhook
   timeoutSeconds: 10
   certificate:


### PR DESCRIPTION
fix: https://github.com/apache/apisix-ingress-controller/issues/2658