### PR TITLE
fix: apisix control service&ingress fix.

### DIFF
--- a/charts/apisix/templates/ingress-control.yaml
+++ b/charts/apisix/templates/ingress-control.yaml
@@ -16,7 +16,7 @@
 
 {{- if (and .Values.control.enabled .Values.control.ingress.enabled) -}}
 {{- $fullName := include "apisix.fullname" . -}}
-{{- $svcPort := .Values.control.servicePort -}}
+{{- $svcPort := .Values.control.service.servicePort -}}
 {{- if and .Values.control.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
   {{- if not (hasKey .Values.control.ingress.annotations "kubernetes.io/ingress.class") }}
   {{- $_ := set .Values.control.ingress.annotations "kubernetes.io/ingress.class" .Values.control.ingress.className}}

--- a/charts/apisix/templates/service-control.yaml
+++ b/charts/apisix/templates/service-control.yaml
@@ -13,7 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-{{ if (and .Values.apisix.enabled .Values.control.enabled) }}
+{{ if .Values.control.enabled }}
 apiVersion: v1
 kind: Service
 metadata:


### PR DESCRIPTION
1. The apisix.enabled option is not present in the apisix chart values.yaml file, so need remove tempaltes service-control.yaml apisix.enabled
2. tempaltes  ingress-control.yaml  .Values.control.servicePort -> .Values.control.service.servicePort