### PR TITLE
Don't render any etcd resources if etcd is not being used

### DIFF
--- a/charts/apisix/templates/deployment.yaml
+++ b/charts/apisix/templates/deployment.yaml
@@ -92,7 +92,7 @@ spec:
                   key: {{ include "apisix.admin.credentials.secretViewerKey" . }}
           {{- end }}
 
-          {{- if or (and .Values.etcd.enabled .Values.etcd.auth.rbac.create) (and (not .Values.etcd.enabled) .Values.externalEtcd.user) }}
+          {{- if and (or (and .Values.etcd.enabled .Values.etcd.auth.rbac.create) (and (not .Values.etcd.enabled) .Values.externalEtcd.user)) (or (and .Values.apisix.deployment.role_traditional (eq .Values.apisix.deployment.role_traditional.config_provider "etcd")) (and (not .Values.apisix.deployment.role_traditional) (or (and .Values.apisix.deployment.role_data_plane (eq .Values.apisix.deployment.role_data_plane.config_provider "etcd")) (and .Values.apisix.deployment.role_control_plane (eq .Values.apisix.deployment.role_control_plane.config_provider "etcd"))))) }}
             - name: APISIX_ETCD_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/charts/apisix/templates/etcd-secret.yaml
+++ b/charts/apisix/templates/etcd-secret.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.externalEtcd.user (and (not .Values.etcd.enabled) (not .Values.externalEtcd.existingSecret)) }}
+{{- if and (or (and .Values.etcd.enabled .Values.etcd.auth.rbac.create) (and (not .Values.etcd.enabled) .Values.externalEtcd.user)) (or (and .Values.apisix.deployment.role_traditional (eq .Values.apisix.deployment.role_traditional.config_provider "etcd")) (and .Values.apisix.deployment.role_data_plane (eq .Values.apisix.deployment.role_data_plane.config_provider "etcd")) (and .Values.apisix.deployment.role_control_plane (eq .Values.apisix.deployment.role_control_plane.config_provider "etcd"))) }}
 apiVersion: v1
 kind: Secret
 metadata:


### PR DESCRIPTION
The chart was rendering etcd secret and setting APISIX_ETCD_PASSWORD env var from secret in the deployment even if etcd was not being used.