### PR TITLE
feat: expose apisix config for standalone mode support

### DIFF
--- a/charts/apisix-ingress-controller/templates/configmap.yaml
+++ b/charts/apisix-ingress-controller/templates/configmap.yaml
@@ -39,6 +39,11 @@ data:
       type: {{ .Values.config.provider.type | default "apisix" }}
       sync_period: {{ .Values.config.provider.syncPeriod | default "1s" }}
       init_sync_delay: {{ .Values.config.provider.initSyncDelay | default "20m" }}
+
+    {{- if .Values.config.apisix }}
+    apisix:
+{{ toYaml .Values.config.apisix | indent 6 }}
+    {{- end }}
     {{- if .Values.webhook.enabled }}
     webhook:
       enable: true

--- a/charts/apisix-ingress-controller/templates/deployment.yaml
+++ b/charts/apisix-ingress-controller/templates/deployment.yaml
@@ -109,6 +109,10 @@ spec:
           value: "remote-state-file,parallel-backend-request"
         - name: ADC_INGRESS_LOG_LEVEL
           value: "{{ .Values.deployment.adcContainer.config.logLevel }}"
+
+        {{- if .Values.deployment.adcContainer.env }}
+        {{- toYaml .Values.deployment.adcContainer.env | nindent 8 }}
+        {{- end }}
         ports:
         - name: http-status
           containerPort: 3001


### PR DESCRIPTION
This PR adds configuration options to support the API-driven standalone deployment mode for the APISIX Ingress Controller.

### Motivation
When deploying APISIX and the Ingress Controller in separate pods (but without etcd), the Ingress Controller needs to know the address and credentials of the APISIX Admin API to push configurations. The current chart does not expose a way to configure the `apisix` block in the controller's config.yaml or inject environment variables into the `adc` sidecar container (which handles the communication in standalone mode).

### Changes
1. **ConfigMap**: Added support for rendering an `apisix` block in `config.yaml` from `.Values.config.apisix`. This allows setting `base_url` and `admin_key`.
2. **Deployment**: Added support for iterating over `.Values.deployment.adcContainer.env` to inject custom environment variables (like `APISIX_BASE_URL` and `APISIX_API_KEY`) into the `adc-server` container.

### Example Usage (values.yaml)
```yaml
config:
  provider:
    type: apisix-standalone
  apisix:
    base_url: http://apisix-admin:9180/apisix/admin
    admin_key: edd1c9f034335f136f87ad84b625c8f1

deployment:
  adcContainer:
    env:
      - name: APISIX_BASE_URL
        value: http://apisix-admin:9180/apisix/admin
      - name: APISIX_API_KEY
        value: edd1c9f034335f136f87ad84b625c8f1
```