### PR TITLE
Add missing imagePullSecrets

### DIFF
--- a/charts/apisix-ingress-controller/templates/deployment.yaml
+++ b/charts/apisix-ingress-controller/templates/deployment.yaml
@@ -42,6 +42,12 @@ spec:
       labels:
         {{- include "apisix-ingress-controller-manager.selectorLabels" . | nindent 8 }}
     spec:
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- range $.Values.global.imagePullSecrets }}
+        - name: {{ . }}
+        {{- end }}
+      {{- end }}
       containers:
       - env:
         - name: POD_NAMESPACE


### PR DESCRIPTION
The deployment for the ingress controller is missing functionality to set `imagePullSecrets`. I copied the functionality from [the apisix deployment](https://github.com/apache/apisix-helm-chart/blob/master/charts/apisix/templates/deployment.yaml#L47)