### PR TITLE
charts/apisix: Remove .Values.apisix.enabled check from service-control

### DIFF
--- a/charts/apisix/templates/service-control.yaml
+++ b/charts/apisix/templates/service-control.yaml
@@ -13,7 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-{{ if (and .Values.apisix.enabled .Values.control.enabled) }}
+{{ if (.Values.control.enabled) }}
 apiVersion: v1
 kind: Service
 metadata:


### PR DESCRIPTION
The field `.Values.apisix.enabled` does not exist in helm values and causes the control API's service to not be created even when `.Values.control.enabled` is set.