### PR TITLE
charts/apisix: Add support for setting encryption configs

### DIFF
--- a/charts/apisix/templates/configmap.yaml
+++ b/charts/apisix/templates/configmap.yaml
@@ -44,6 +44,16 @@ data:
     {{- end }}
     {{- else }}
     apisix:    # universal configurations
+      {{- if .Values.apisix.encryption }}
+      data_encryption:         # Data encryption settings
+        enable_encrypt_fields: {{ .Values.apisix.encryption.enabled }}
+        {{- if and .Values.apisix.encryption.keyring (gt (len .Values.apisix.encryption.keyring) 0) }}
+        keyring:
+          {{- range $key := .Values.apisix.encryption.keyring }}
+          - {{ $key | quote }}
+          {{- end }}
+        {{- end }}
+      {{- end }}
       {{- if not (eq .Values.apisix.deployment.role "control_plane") }}
       node_listen:    # APISIX listening port
         - {{ .Values.service.http.containerPort }}

--- a/charts/apisix/values.yaml
+++ b/charts/apisix/values.yaml
@@ -603,6 +603,13 @@ apisix:
     ip: "0.0.0.0"
     port: 7085
 
+  # -- Data encryption settings.
+  encryption:
+    # -- Enable or disable the encryption feature.
+    enabled: true
+    # -- The keyring used for encryption and decryption of sensitive data, e.g. "0123456789abcdef" or "${{MY_ENV_VAR}}". Leave empty to use the default keyring.
+    keyring: []
+
   # -- When configured, APISIX will trust the `X-Forwarded-*` Headers passed in requests from the IP/CIDR in the list.
   trustedAddresses:
     - 127.0.0.1


### PR DESCRIPTION
Example usage in helm values:

```yaml
apisix:
  encryption:
    enabled: true
    keyring:
      - "${{ENCRYPTION_KEYRING_1}}"
      - "${{ENCRYPTION_KEYRING_2}}"

extraEnvVars:
  - name: ENCRYPTION_KEYRING_1
    valueFrom:
      secretKeyRef:
        name: encryption-keyring
        key: ENCRYPTION_KEYRING_1
  - name: ENCRYPTION_KEYRING_2
    valueFrom:
      secretKeyRef:
        name: encryption-keyring
        key: ENCRYPTION_KEYRING_2
```