### PR TITLE
charts/ingress-controller: add global.imagePullSecrets support

### DIFF
--- a/charts/apisix-ingress-controller/README.md
+++ b/charts/apisix-ingress-controller/README.md
@@ -155,6 +155,7 @@ The same for container level, you need to set:
 | gatewayProxy.provider.pluginMetadata | object | `{}` | Global plugin metadata shared by all instances of the same plugin. |
 | gatewayProxy.provider.plugins | list | `[]` | List of global plugins to be enabled on the GatewayProxy. |
 | gatewayProxy.provider.type | string | `"ControlPlane"` | Specifies the provider type for the GatewayProxy. |
+| global.imagePullSecrets | list | `[]` | Global Docker registry secret names as an array |
 | labelsOverride | object | `{}` | Override default labels assigned to Apache APISIX ingress controller resource |
 | nameOverride | string | `""` | Default values for apisix-ingress-controller. This is a YAML-formatted file. Declare variables to be passed into your templates.  |
 | podDisruptionBudget | object | `{"enabled":false,"maxUnavailable":1,"minAvailable":"90%"}` | See https://kubernetes.io/docs/tasks/run-application/configure-pdb/ for more details |

--- a/charts/apisix-ingress-controller/templates/deployment.yaml
+++ b/charts/apisix-ingress-controller/templates/deployment.yaml
@@ -42,6 +42,12 @@ spec:
       labels:
         {{- include "apisix-ingress-controller-manager.selectorLabels" . | nindent 8 }}
     spec:
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- range $.Values.global.imagePullSecrets }}
+        - name: {{ . }}
+        {{- end }}
+      {{- end }}
       containers:
       - env:
         - name: POD_NAMESPACE


### PR DESCRIPTION
### Motivation

Pulling the ingress-controller from a registry with authentication is currently not possible. This makes working around the Dockerhub ratelimiting hard.

### Details

Since the ingress-controller is used as a subchart by apisix, which already defines `global.imagePullSecrets`, I decided to reuse them.