### PR TITLE
Remove externalTrafficPolicy from template for service type ClusterIP

### DIFF
--- a/charts/apisix/templates/service-gateway.yaml
+++ b/charts/apisix/templates/service-gateway.yaml
@@ -28,7 +28,9 @@ metadata:
     app.kubernetes.io/service: apisix-gateway
 spec:
   type: {{ .Values.service.type }}
+  {{- if or (eq .Values.service.type "LoadBalancer") (eq .Values.service.type "NodePort") }}
   externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy }}
+  {{- end }}
   {{- if eq .Values.service.type "LoadBalancer" }}
   {{- if .Values.service.loadBalancerIP }}
   loadBalancerIP: {{ .Values.service.loadBalancerIP }}


### PR DESCRIPTION
Add a condition to specify `externalTrafficPolicy` in the apisix-gateway service spec only for service types LoadBalancer and NodePort. Adding the field for service type ClusterIP leads to configuration errors in Kubernetes.