### PR TITLE
feat(apisix): add configurable livenessProbe support

### DIFF
--- a/charts/apisix/templates/deployment.yaml
+++ b/charts/apisix/templates/deployment.yaml
@@ -175,6 +175,16 @@ spec:
               port: {{ .Values.service.http.containerPort }}
             {{- end}}
             timeoutSeconds: 1
+            {{- if .Values.apisix.deployment.livenessProbe.enabled }}
+          livenessProbe:
+            tcpSocket:
+              port: {{ .Values.service.http.containerPort }}
+            initialDelaySeconds: {{ .Values.apisix.deployment.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.apisix.deployment.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.apisix.deployment.livenessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.apisix.deployment.livenessProbe.failureThreshold }}
+            successThreshold: {{ .Values.apisix.deployment.livenessProbe.successThreshold }}
+            {{- end}}
           {{- end }}
           lifecycle:
             preStop:

--- a/charts/apisix/values.yaml
+++ b/charts/apisix/values.yaml
@@ -346,6 +346,13 @@ apisix:
     # ref: https://apisix.apache.org/docs/apisix/deployment-modes/
     mode: traditional
 
+    livenessProbe:
+      enabled: false
+      initialDelaySeconds: 30
+      periodSeconds: 10
+      timeoutSeconds: 1
+      failureThreshold: 6
+      successThreshold: 1
     # -- Deployment role
     # Optional: traditional, data_plane, control_plane
     #


### PR DESCRIPTION
## What this PR does

Adds an optional `livenessProbe` configuration to the APISIX chart.

Currently, only a `readinessProbe` (TCP on :9080) is configured. Without a
`livenessProbe`, a frozen APISIX process (no crash, but unresponsive) will
cause the pod to stay in `Not Ready` state indefinitely without ever being
restarted by Kubernetes.

## Changes

- `values.yaml`: add `livenessProbe` block with `enabled: false` by default
- `templates/deployment.yaml`: inject the probe when enabled

## How to test
```yaml
# values.yaml
livenessProbe:
  enabled: true
```

The pod should now be restarted automatically if APISIX stops responding on :9080.

Closes #951