### PR TITLE
fix: add support for configuring etcd watch timeout

### DIFF
--- a/charts/apisix/README.md
+++ b/charts/apisix/README.md
@@ -155,7 +155,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | control.service.port | int | `9090` | which port to use for Apache APISIX Control API |
 | control.service.servicePort | int | `9090` | Service port to use for Apache APISIX Control API |
 | control.service.type | string | `"ClusterIP"` | Control service type |
-| etcd | object | `{"auth":{"rbac":{"create":false,"rootPassword":""},"tls":{"certFilename":"","certKeyFilename":"","enabled":false,"existingSecret":"","sni":"","verify":true}},"autoCompactionMode":"periodic","autoCompactionRetention":"1h","containerSecurityContext":{"enabled":false},"enabled":true,"image":{"registry":"docker.io","repository":"bitnamilegacy/etcd","tag":"latest"},"prefix":"/apisix","replicaCount":3,"service":{"port":2379},"timeout":30}` | etcd configuration use the FQDN address or the IP of the etcd |
+| etcd | object | `{"auth":{"rbac":{"create":false,"rootPassword":""},"tls":{"certFilename":"","certKeyFilename":"","enabled":false,"existingSecret":"","sni":"","verify":true}},"autoCompactionMode":"periodic","autoCompactionRetention":"1h","containerSecurityContext":{"enabled":false},"enabled":true,"image":{"registry":"docker.io","repository":"bitnamilegacy/etcd","tag":"latest"},"prefix":"/apisix","replicaCount":3,"service":{"port":2379},"timeout":30,"watch_timeout":50}` | etcd configuration use the FQDN address or the IP of the etcd |
 | etcd.auth | object | `{"rbac":{"create":false,"rootPassword":""},"tls":{"certFilename":"","certKeyFilename":"","enabled":false,"existingSecret":"","sni":"","verify":true}}` | if etcd.enabled is true, set more values of bitnamilegacy/etcd helm chart |
 | etcd.auth.rbac.create | bool | `false` | No authentication by default. Switch to enable RBAC authentication |
 | etcd.auth.rbac.rootPassword | string | `""` | root password for etcd. Requires etcd.auth.rbac.create to be true. |
@@ -171,6 +171,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | etcd.image.tag | string | `"latest"` | `bitnamilegacy/etcd` only provide `latest` tag now, ref: https://github.com/bitnami/containers/issues/83267, you can switch `etcd.image.repository` to `bitnamilegacy/etcd` to use old versioned tags. |
 | etcd.prefix | string | `"/apisix"` | apisix configurations prefix |
 | etcd.timeout | int | `30` | Set the timeout value in seconds for subsequent socket operations from apisix to etcd cluster |
+| etcd.watch_timeout | int | `50` | Set the timeout value in seconds for apisix to wait for a response from etcd cluster when watching etcd changes |
 | externalEtcd | object | `{"existingSecret":"","host":["http://etcd.host:2379"],"password":"","secretPasswordKey":"etcd-root-password","user":"root"}` | external etcd configuration. If etcd.enabled is false, these configuration will be used. |
 | externalEtcd.existingSecret | string | `""` | if externalEtcd.existingSecret is the name of secret containing the external etcd password |
 | externalEtcd.host | list | `["http://etcd.host:2379"]` | if etcd.enabled is false, use external etcd, support multiple address, if your etcd cluster enables TLS, please use https scheme, e.g. https://127.0.0.1:2379. |

--- a/charts/apisix/templates/configmap.yaml
+++ b/charts/apisix/templates/configmap.yaml
@@ -384,6 +384,7 @@ data:
       {{- end }}
         prefix: {{ .Values.etcd.prefix | quote }}    # configuration prefix in etcd
         timeout: {{ .Values.etcd.timeout }}    # 30 seconds
+        watch_timeout: {{ .Values.etcd.watch_timeout }}    # 50 seconds, default value from apisix
         {{- if and (not .Values.etcd.enabled) .Values.externalEtcd.user }}
         user: {{ .Values.externalEtcd.user | quote }}
         password: "{{ print "${{ APISIX_ETCD_PASSWORD }}" }}"

--- a/charts/apisix/values.yaml
+++ b/charts/apisix/values.yaml
@@ -643,6 +643,8 @@ etcd:
   prefix: "/apisix"
   # -- Set the timeout value in seconds for subsequent socket operations from apisix to etcd cluster
   timeout: 30
+  # -- Set the timeout value in seconds for apisix to wait for a response from etcd cluster when watching etcd changes
+  watch_timeout: 50
 
   # -- if etcd.enabled is true, set more values of bitnamilegacy/etcd helm chart
   auth:


### PR DESCRIPTION
It seems like [`etcd.watch_timeout`](https://github.com/apache/apisix/blob/master/apisix/core/config_etcd.lua#L141) is not currently configurable through the Helm chart, based on the current ConfigMap template here: https://github.com/apache/apisix-helm-chart/blob/master/charts/apisix/templates/configmap.yaml#L371-L400

At the moment, APISIX appears to read the etcd config from config.yaml, as shown from:
- https://github.com/apache/apisix/blob/master/apisix/cli/file.lua#L276-L287
- https://github.com/apache/apisix/blob/master/apisix/core/config_local.lua#L61

And the default value 50 is derived from here: https://github.com/apache/apisix/blob/master/apisix/core/config_etcd.lua#L184

btw, is `deployment.etcd.timeout` used elsewhere as i cannot find it yet..