### PR TITLE
fix(ingress-controller): use webhook secret name from values when provided

### DIFF
--- a/charts/apisix-ingress-controller/templates/_helpers.tpl
+++ b/charts/apisix-ingress-controller/templates/_helpers.tpl
@@ -79,11 +79,15 @@ Webhook service name - ensure it stays within 63 character limit
 {{- end }}
 
 {{/*
-Webhook secret name - ensure it stays within 63 character limit
+Webhook secret name - use value from values.yaml if provided, otherwise generate one
 */}}
 {{- define "apisix-ingress-controller-manager.webhook.secretName" -}}
+{{- if and .Values.webhook.certificate.provided .Values.webhook.certificate.secretName -}}
+{{- .Values.webhook.certificate.secretName -}}
+{{- else -}}
 {{- $suffix := "-webhook-cert" -}}
 {{- $maxLen := sub 63 (len $suffix) | int -}}
 {{- $baseName := include "apisix-ingress-controller-manager.name.fullname" . | trunc $maxLen | trimSuffix "-" -}}
 {{- printf "%s%s" $baseName $suffix -}}
+{{- end -}}
 {{- end }}


### PR DESCRIPTION
This PR fixes #954 by modifying the webhook.secretName helper to use the user-provided secret name from values.yaml when webhook.certificate.provided is true and webhook.certificate.secretName is set.