### PR TITLE
chore: upgrade apisix to 3.16.0

### DIFF
--- a/charts/apisix/Chart.yaml
+++ b/charts/apisix/Chart.yaml
@@ -31,12 +31,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.13.0
+version: 2.14.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 3.15.0
+appVersion: 3.16.0
 sources:
   - https://github.com/apache/apisix-helm-chart
 

--- a/charts/apisix/README.md
+++ b/charts/apisix/README.md
@@ -108,6 +108,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | apisix.nginx.logs.errorLog | string | `"/dev/stderr"` | Error log path |
 | apisix.nginx.logs.errorLogLevel | string | `"warn"` | Error log level |
 | apisix.nginx.luaSharedDicts | list | `[]` | Override default [lua_shared_dict](https://github.com/apache/apisix/blob/master/conf/config.yaml.example#L250-L276) settings, click [here](https://github.com/apache/apisix-helm-chart/blob/master/charts/apisix/values.yaml#L27-L30) to learn the format of a shared dict |
+| apisix.nginx.metaLuaSharedDicts | list | `[]` | Override default meta-level [lua_shared_dict](https://github.com/apache/apisix/blob/master/conf/config.yaml.example) settings, meta-level shared dicts are shared across both HTTP and stream subsystems. Since APISIX 3.16.0, `upstream-healthcheck` is a meta-level shared dict. |
 | apisix.nginx.workerConnections | string | `"10620"` |  |
 | apisix.nginx.workerProcesses | string | `"auto"` |  |
 | apisix.nginx.workerRlimitNofile | string | `"20480"` |  |
@@ -188,7 +189,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | hostNetwork | bool | `false` |  |
 | image.pullPolicy | string | `"IfNotPresent"` | Apache APISIX image pull policy |
 | image.repository | string | `"apache/apisix"` | Apache APISIX image repository |
-| image.tag | string | `"3.15.0-ubuntu"` | Apache APISIX image tag Overrides the image tag whose default is the chart appVersion. |
+| image.tag | string | `"3.16.0-ubuntu"` | Apache APISIX image tag Overrides the image tag whose default is the chart appVersion. |
 | ingress | object | `{"annotations":{},"enabled":false,"hosts":[{"host":"apisix.local","paths":[]}],"servicePort":null,"tls":[]}` | Using ingress access Apache APISIX service |
 | ingress-controller | object | `{"enabled":false}` | Ingress controller configuration |
 | ingress.annotations | object | `{}` | Ingress annotations |

--- a/charts/apisix/README.md
+++ b/charts/apisix/README.md
@@ -108,7 +108,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | apisix.nginx.logs.errorLog | string | `"/dev/stderr"` | Error log path |
 | apisix.nginx.logs.errorLogLevel | string | `"warn"` | Error log level |
 | apisix.nginx.luaSharedDicts | list | `[]` | Override default [lua_shared_dict](https://github.com/apache/apisix/blob/master/conf/config.yaml.example#L250-L276) settings, click [here](https://github.com/apache/apisix-helm-chart/blob/master/charts/apisix/values.yaml#L27-L30) to learn the format of a shared dict |
-| apisix.nginx.metaLuaSharedDicts | list | `[]` | Override default meta-level [lua_shared_dict](https://github.com/apache/apisix/blob/master/conf/config.yaml.example) settings, meta-level shared dicts are shared across both HTTP and stream subsystems. Since APISIX 3.16.0, `upstream-healthcheck` is a meta-level shared dict. |
+| apisix.nginx.metaLuaSharedDicts | list | `[]` | Override default meta-level [lua_shared_dict](https://github.com/apache/apisix/blob/master/conf/config.yaml.example) settings, meta-level shared dicts are shared across both HTTP and stream subsystems. Since APISIX 3.16.0, `upstream-healthcheck` is a meta-level shared dict. click [here](https://github.com/apache/apisix-helm-chart/blob/master/charts/apisix/values.yaml#L27-L30) to learn the format of a shared dict |
 | apisix.nginx.workerConnections | string | `"10620"` |  |
 | apisix.nginx.workerProcesses | string | `"auto"` |  |
 | apisix.nginx.workerRlimitNofile | string | `"20480"` |  |

--- a/charts/apisix/templates/configmap.yaml
+++ b/charts/apisix/templates/configmap.yaml
@@ -195,6 +195,13 @@ data:
         - {{ $env }}
       {{- end }}
       {{- end }}
+      {{- if .Values.apisix.nginx.metaLuaSharedDicts }}
+      meta:
+        lua_shared_dict:
+        {{- range $dict := .Values.apisix.nginx.metaLuaSharedDicts }}
+          {{ $dict.name }}: {{ $dict.size }}
+        {{- end }}
+      {{- end }}
       http:
         enable_access_log: {{ .Values.apisix.nginx.logs.enableAccessLog }}
         {{- if .Values.apisix.nginx.logs.enableAccessLog }}

--- a/charts/apisix/values.yaml
+++ b/charts/apisix/values.yaml
@@ -29,7 +29,7 @@ image:
   pullPolicy: IfNotPresent
   # -- Apache APISIX image tag
   # Overrides the image tag whose default is the chart appVersion.
-  tag: 3.15.0-ubuntu
+  tag: 3.16.0-ubuntu
 
 # -- set false to use `Deployment`, set true to use `DaemonSet`
 useDaemonSet: false
@@ -478,6 +478,14 @@ apisix:
     luaSharedDicts: []
       # - name: prometheus-metrics
       #   size: 20m
+
+    # -- Override default meta-level [lua_shared_dict](https://github.com/apache/apisix/blob/master/conf/config.yaml.example) settings,
+    # meta-level shared dicts are shared across both HTTP and stream subsystems.
+    # Since APISIX 3.16.0, `upstream-healthcheck` is a meta-level shared dict.
+    # click [here](https://github.com/apache/apisix-helm-chart/blob/master/charts/apisix/values.yaml#L27-L30) to learn the format of a shared dict
+    metaLuaSharedDicts: []
+      # - name: upstream-healthcheck
+      #   size: 10m
 
   discovery:
     # -- Enable or disable Apache APISIX integration service discovery


### PR DESCRIPTION
## Summary

- Upgrades Apache APISIX from 3.15.0 to 3.16.0 (chart version 2.13.0 → 2.14.0)
- Adds support for `apisix.nginx.metaLuaSharedDicts` to override meta-level `lua_shared_dict` settings in the generated `nginx_config`

## Why meta-level shared dict support?

APISIX 3.16.0 ([PR #12996](https://github.com/apache/apisix/pull/12996)) moved the `upstream-healthcheck` shared memory dict from `nginx_config.http.lua_shared_dict` to `nginx_config.meta.lua_shared_dict`, making it shared across both the HTTP and stream subsystems. Previously, users who needed to customize the `upstream-healthcheck` dict size could do so via `apisix.nginx.luaSharedDicts`. After this APISIX change, that override would silently stop working. The new `metaLuaSharedDicts` value allows users to override meta-level shared dicts.

## Notable APISIX 3.16.0 changes

**Breaking changes (plugin-level defaults, no helm chart config needed):**
- `ssl_verify` default in `openid-connect` plugin changed to `true` ([#13010](https://github.com/apache/apisix/pull/13010))
- `tencent-cloud-cls` scheme default changed to `https` ([#13009](https://github.com/apache/apisix/pull/13009))

**Full changelog:** https://github.com/apache/apisix/blob/master/CHANGELOG.md#3160

## Test plan
- [ ] `helm template` renders correctly with default values (no `meta` section when `metaLuaSharedDicts` is empty)
- [ ] `helm template` renders `meta.lua_shared_dict` when `metaLuaSharedDicts` is set
- [ ] Verify APISIX 3.16.0 container image `apache/apisix:3.16.0-ubuntu` exists
- [ ] Deploy and confirm APISIX starts correctly with the new chart