### PR TITLE
fix(apisix): quote IP values in configmap so IPv6 addresses do not break YAML

### DIFF
--- a/charts/apisix/templates/configmap.yaml
+++ b/charts/apisix/templates/configmap.yaml
@@ -62,7 +62,7 @@ data:
       enable_control: {{ .Values.control.enabled }}
       {{- if .Values.control.enabled }}
       control:
-        ip: {{ default "127.0.0.1" .Values.control.service.ip }}
+        ip: {{ default "127.0.0.1" .Values.control.service.ip | quote }}
         port: {{ default 9090 .Values.control.service.port }}
       {{- end }}
 
@@ -172,7 +172,7 @@ data:
       {{- $useTraditionalYaml := and (eq .Values.apisix.deployment.role "traditional") (eq .Values.apisix.deployment.role_traditional.config_provider "yaml") }}
       {{- if $useTraditionalYaml }}
       status:
-        ip: {{ default "127.0.0.1" .Values.apisix.status.ip }}
+        ip: {{ default "127.0.0.1" .Values.apisix.status.ip | quote }}
         port: {{ default "7085" (.Values.apisix.status.port | toString) }}
       {{- end}}
 
@@ -338,7 +338,7 @@ data:
         allow_admin:    # http://nginx.org/en/docs/http/ngx_http_access_module.html#allow
         {{- if .Values.apisix.admin.allow.ipList }}
         {{- range $ips := .Values.apisix.admin.allow.ipList }}
-          - {{ $ips }}
+          - {{ $ips | quote }}
         {{- end }}
         {{- else }}
           - 0.0.0.0/0
@@ -349,7 +349,7 @@ data:
         #   - "::/64"
         {{- if .Values.apisix.admin.enabled }}
         admin_listen:
-          ip: {{ .Values.apisix.admin.ip }}
+          ip: {{ .Values.apisix.admin.ip | quote }}
           port: {{ .Values.apisix.admin.port }}
         {{- end }}
         # Default token when use API to call for Admin API.


### PR DESCRIPTION
### Problem

`charts/apisix/templates/configmap.yaml` renders `ip:` values and `allow_admin`
list items without quoting. For IPv4 this is fine, but when the value contains
YAML-flow characters the rendered file becomes invalid YAML:

```yaml
# e.g. apisix.admin.ip = "[::]"
admin_listen:
  ip: [::]                     # parses as an empty flow sequence, not a string

# e.g. allow_admin contains "::/0"
allow_admin:
  - ::/0                       # treated as a mapping-style token, not a string
```

apisix then fails to start, or picks up a different value than the operator
supplied. This is the failure mode reported in #920.

### Fix

Pipe the affected templated values through the `quote` filter so IPv6 values
render as regular YAML strings regardless of format (`::`, `[::]`, `::/0`,
`fe80::/10`, etc). Four locations in `charts/apisix/templates/configmap.yaml`:

- `admin.admin_listen.ip`  from `.Values.apisix.admin.ip` (called out in the issue)
- `admin.allow_admin` list items  from `.Values.apisix.admin.allow.ipList` (called out in the issue)
- `control.ip`  from `.Values.control.service.ip` (same bug, same chart)
- `status.ip`  from `.Values.apisix.status.ip` (same bug, same chart)

IPv4 values are unaffected because YAML treats a quoted `"127.0.0.1"` identically
to the bare form, and each affected key is already documented as a string on the
apisix side.

Fixes #920
