### PR TITLE
add support to override the container name

### DIFF
--- a/charts/apisix/templates/deployment.yaml
+++ b/charts/apisix/templates/deployment.yaml
@@ -60,7 +60,7 @@ spec:
       {{- end }}
       containers:
         {{- $useTraditionalYaml := and (eq .Values.apisix.deployment.role "traditional") (eq .Values.apisix.deployment.role_traditional.config_provider "yaml") }}
-        - name: {{ .Chart.Name }}
+        - name: {{ include "apisix.name" . }}
           {{- with .Values.securityContext }}
           securityContext:
             {{- . | toYaml | nindent 12 }}


### PR DESCRIPTION
## Summary

Use `apisix.name` for the APISIX container name in `deployment.yaml`.

## Why

The container name was using `.Chart.Name` directly, while other chart-generated names already rely on the shared `apisix.name` helper. This caused inconsistent naming behavior when chart naming is customized.

Using the shared helper keeps the Deployment aligned with the rest of the chart and ensures the container name follows the same naming path as other generated resources, especially when `nameOverride` is used.

This is also useful when the APISIX chart is consumed as a dependency from another chart and chart naming is customized through overrides or aliases, e.g. `apisixControlPlane`, `apisixDataPlane`. However, the rendered container name still needs to remain a valid lowercase RFC 1123 label.

## Impact

- fixes naming inconsistency in rendered manifests
- keeps default behavior unchanged for default installs
- aligns container naming with the chart's shared naming helper
