### PR TITLE
feat: allow custom labels via Values.podLabels

### DIFF
--- a/charts/apisix/README.md
+++ b/charts/apisix/README.md
@@ -206,6 +206,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` | Node labels for Apache APISIX pod assignment |
 | podAnnotations | object | `{}` | Annotations to add to each pod |
+| podLabels | object | `{}` | Labels to add to each pod |
 | podDisruptionBudget | object | `{"enabled":false,"maxUnavailable":1,"minAvailable":"90%"}` | See https://kubernetes.io/docs/tasks/run-application/configure-pdb/ for more details |
 | podDisruptionBudget.enabled | bool | `false` | Enable or disable podDisruptionBudget |
 | podDisruptionBudget.maxUnavailable | int | `1` | Set the maxUnavailable of podDisruptionBudget |

--- a/charts/apisix/templates/deployment.yaml
+++ b/charts/apisix/templates/deployment.yaml
@@ -43,6 +43,9 @@ spec:
         {{- end }}
       labels:
         {{- include "apisix.selectorLabels" . | nindent 8 }}
+        {{- if .Values.podLabels }}
+        {{- toYaml .Values.podLabels | nindent 8 }}
+        {{- end }}
     spec:
       {{- with .Values.global.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/apisix/values.yaml
+++ b/charts/apisix/values.yaml
@@ -40,6 +40,8 @@ replicaCount: 1
 priorityClassName: ""
 # -- Annotations to add to each pod
 podAnnotations: {}
+# -- Labels to add to each pod
+podLabels: {}
 # -- Set the securityContext for Apache APISIX pods
 podSecurityContext: {}
   # fsGroup: 2000


### PR DESCRIPTION
Adds the ability to inject custom labels into the pod template via the podLabels value. This is useful for users who need to add metadata for monitoring, cost allocation, or third-party integrations (e.g., Grafana, Datadog) specifically at the pod level