### PR TITLE
chore: release apisix-ingress-controller charts to 1.1.3

### DIFF
--- a/charts/apisix-ingress-controller/Chart.yaml
+++ b/charts/apisix-ingress-controller/Chart.yaml
@@ -24,8 +24,8 @@ keywords:
   - nginx
   - crd
 type: application
-version: 1.1.2
-appVersion: 2.0.1
+version: 1.1.3
+appVersion: 2.0.2
 sources:
   - https://github.com/apache/apisix-helm-chart
 

--- a/charts/apisix-ingress-controller/README.md
+++ b/charts/apisix-ingress-controller/README.md
@@ -133,7 +133,7 @@ The same for container level, you need to set:
 | deployment.annotations | object | `{}` | Add annotations to Apache APISIX ingress controller resource |
 | deployment.image.pullPolicy | string | `"IfNotPresent"` |  |
 | deployment.image.repository | string | `"apache/apisix-ingress-controller"` |  |
-| deployment.image.tag | string | `"2.0.1"` |  |
+| deployment.image.tag | string | `"2.0.2"` |  |
 | deployment.imagePullSecrets | list | `[]` |  |
 | deployment.nodeSelector | object | `{}` |  |
 | deployment.podAnnotations | object | `{}` |  |

--- a/charts/apisix-ingress-controller/values.yaml
+++ b/charts/apisix-ingress-controller/values.yaml
@@ -65,7 +65,7 @@ deployment:
   image:
     repository: apache/apisix-ingress-controller
     pullPolicy: IfNotPresent
-    tag: "2.0.1"
+    tag: "2.0.2"
   # -- Set pod resource requests & limits
   resources: {}
 


### PR DESCRIPTION
This PR updates the apisix-ingress-controller to the latest version following the addition of imagePullSecrets support.

This change ensures compatibility with the new feature, allowing the use of private images within the cluster.

The update to the Apisix chart to support this new controller version is being handled in PR #962 