### PR TITLE
support exposing proxy protocol enabled listeners

### DIFF
--- a/charts/apisix/README.md
+++ b/charts/apisix/README.md
@@ -101,6 +101,8 @@ The command removes all the Kubernetes components associated with the chart and 
 | apisix.nginx.enableCPUAffinity | bool | `true` |  |
 | apisix.nginx.envs | list | `[]` |  |
 | apisix.nginx.keepaliveTimeout | string | `"60s"` | Timeout during which a keep-alive client connection will stay open on the server side. |
+| apisix.nginx.real_ip_from | list | `["127.0.0.1","unix:"]` | Trusted addresses used by nginx realip module when resolving the client IP. |
+| apisix.nginx.real_ip_header | string | `"X-Real-IP"` | Header field used to identify the originating client IP address. |
 | apisix.nginx.logs.accessLog | string | `"/dev/stdout"` | Access log path |
 | apisix.nginx.logs.accessLogFormat | string | `"$remote_addr - $remote_user [$time_local] $http_host \\\"$request\\\" $status $body_bytes_sent $request_time \\\"$http_referer\\\" \\\"$http_user_agent\\\" $upstream_addr $upstream_status $upstream_response_time \\\"$upstream_scheme://$upstream_host$upstream_uri\\\""` | Access log format |
 | apisix.nginx.logs.accessLogFormatEscape | string | `"default"` | Allows setting json or default characters escaping in variables |
@@ -118,6 +120,12 @@ The command removes all the Kubernetes components associated with the chart and 
 | apisix.prometheus.enabled | bool | `false` |  |
 | apisix.prometheus.metricPrefix | string | `"apisix_"` | prefix of the metrics |
 | apisix.prometheus.path | string | `"/apisix/prometheus/metrics"` | path of the metrics endpoint |
+| apisix.proxyProtocol | object | `{}` | Proxy Protocol configuration. |
+| apisix.proxyProtocol.exposed | bool | `false` | Expose the proxy protocol HTTP and HTTPS listener ports through the main gateway service target ports. |
+| apisix.proxyProtocol.enableTcpPP | bool | `false` | Enable the proxy protocol for TCP proxy traffic. |
+| apisix.proxyProtocol.enableTcpPPToUpstream | bool | `false` | Enables sending proxy protocol information to the upstream server. |
+| apisix.proxyProtocol.listenHttpPort | int | `9081` | Port that receives HTTP requests with proxy protocol enabled. |
+| apisix.proxyProtocol.listenHttpsPort | int | `9082` | Port that receives HTTPS requests with proxy protocol enabled. |
 | apisix.router.http | string | `"radixtree_host_uri"` | Defines how apisix handles routing: - radixtree_uri: match route by uri(base on radixtree) - radixtree_host_uri: match route by host + uri(base on radixtree) - radixtree_uri_with_parameter: match route by uri with parameters |
 | apisix.setIDFromPodUID | bool | `false` | Use Pod metadata.uid as the APISIX id. |
 | apisix.ssl.additionalContainerPorts | list | `[]` | Support multiple https ports, See [Configuration](https://github.com/apache/apisix/blob/0bc65ea9acd726f79f80ae0abd8f50b7eb172e3d/conf/config-default.yaml#L99) |

--- a/charts/apisix/templates/configmap.yaml
+++ b/charts/apisix/templates/configmap.yaml
@@ -84,6 +84,13 @@ data:
       #   listen_https_port: 9182         # The port with proxy protocol for https
       #   enable_tcp_pp: true             # Enable the proxy protocol for tcp proxy, it works for stream_proxy.tcp option
       #   enable_tcp_pp_to_upstream: true # Enables the proxy protocol to the upstream server
+      {{- with .Values.apisix.proxyProtocol }}
+      proxy_protocol:
+        listen_http_port: {{ .listenHttpPort }}
+        listen_https_port: {{ .listenHttpsPort }}
+        enable_tcp_pp: {{ default false .enableTcpPP }}
+        enable_tcp_pp_to_upstream: {{ default false .enableTcpPPToUpstream }}
+      {{- end }}
 
       proxy_cache:                         # Proxy Caching configuration
         cache_ttl: 10s                     # The default caching time if the upstream does not specify the cache time
@@ -214,10 +221,9 @@ data:
         client_body_timeout: 60s       # timeout for reading client request body, then 408 (Request Time-out) error is returned to the client
         send_timeout: 10s              # timeout for transmitting a response to the client.then the connection is closed
         underscores_in_headers: "on"   # default enables the use of underscores in client request header fields
-        real_ip_header: "X-Real-IP"    # http://nginx.org/en/docs/http/ngx_http_realip_module.html#real_ip_header
+        real_ip_header: {{ .Values.apisix.nginx.real_ip_header }}   # http://nginx.org/en/docs/http/ngx_http_realip_module.html#real_ip_header
         real_ip_from:                  # http://nginx.org/en/docs/http/ngx_http_realip_module.html#set_real_ip_from
-          - 127.0.0.1
-          - 'unix:'
+        {{- toYaml .Values.apisix.nginx.real_ip_from | nindent 10 }}
         {{- if .Values.apisix.nginx.customLuaSharedDicts }}
         custom_lua_shared_dict:        # add custom shared cache to nginx.conf
         {{- range $dict := .Values.apisix.nginx.customLuaSharedDicts }}

--- a/charts/apisix/templates/service-gateway.yaml
+++ b/charts/apisix/templates/service-gateway.yaml
@@ -50,7 +50,11 @@ spec:
   {{- if .Values.service.http.enabled }}
   - name: apisix-gateway
     port: {{ .Values.service.http.servicePort }}
+  {{- if .Values.apisix.proxyProtocol.exposed }}
+    targetPort: {{ .Values.apisix.proxyProtocol.listenHttpPort }}
+  {{- else }}
     targetPort: {{ .Values.service.http.containerPort }}
+  {{- end }}
   {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.http.nodePort))) }}
     nodePort: {{ .Values.service.http.nodePort }}
   {{- end }}
@@ -65,7 +69,11 @@ spec:
   {{- if or .Values.apisix.ssl.enabled }}
   - name: apisix-gateway-tls
     port: {{ .Values.service.tls.servicePort }}
+  {{- if .Values.apisix.proxyProtocol.exposed }}
+    targetPort: {{ .Values.apisix.proxyProtocol.listenHttpsPort }}
+  {{- else }}
     targetPort: {{ .Values.apisix.ssl.containerPort }}
+  {{- end }}
   {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.tls.nodePort))) }}
     nodePort: {{ .Values.service.tls.nodePort }}
   {{- end }}

--- a/charts/apisix/values.schema.json
+++ b/charts/apisix/values.schema.json
@@ -87,6 +87,45 @@
         "luaPath",
         "plugins"
       ]
+    },
+    "apisix": {
+      "type": "object",
+      "properties": {
+        "nginx": {
+          "type": "object",
+          "properties": {
+            "real_ip_header": {
+              "type": "string"
+            },
+            "real_ip_from": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "proxyProtocol": {
+          "type": "object",
+          "properties": {
+            "listenHttpPort": {
+              "type": "integer"
+            },
+            "listenHttpsPort": {
+              "type": "integer"
+            },
+            "enableTcpPP": {
+              "type": "boolean"
+            },
+            "enableTcpPPToUpstream": {
+              "type": "boolean"
+            },
+            "exposed": {
+              "type": "boolean"
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/charts/apisix/values.yaml
+++ b/charts/apisix/values.yaml
@@ -276,6 +276,8 @@ metrics:
     annotations: {}
 
 apisix:
+
+
   # -- Enable nginx IPv6 resolver
   enableIPv6: true
   enableHTTP2: true
@@ -438,6 +440,12 @@ apisix:
     keepaliveTimeout: 60s
     envs: []
     # access log and error log configuration
+    # -- Header field used to identify the originating client IP address.
+    real_ip_header: "X-Real-IP"
+    # -- Trusted addresses used by nginx realip module when resolving the client IP.
+    real_ip_from:
+      - 127.0.0.1
+      - 'unix:'
     logs:
       # -- Enable access log or not, default true
       enableAccessLog: true
@@ -565,6 +573,7 @@ apisix:
     # -- container port where the metrics are exposed
     containerPort: 9091
 
+
   # -- Customize the list of APISIX plugins to enable. By default, APISIX's [default plugins](https://github.com/apache/apisix/blob/master/apisix/cli/config.lua#L196) are automatically used.
   plugins: []
   # -- Customize the list of APISIX stream_plugins to enable. By default, APISIX's [default stream_plugins](https://github.com/apache/apisix/blob/master/apisix/cli/config.lua#L294) are automatically used.
@@ -606,6 +615,14 @@ apisix:
           mounts:
             - key: "the-file-name"
               path: "mount-path"
+
+  # -- Proxy Protocol configuration.
+  proxyProtocol: {}
+  #  listenHttpPort: 9081
+  #  listenHttpsPort: 9082
+  #  enableTcpPP: false
+  #  enableTcpPPToUpstream: false
+  #  exposed: false
 
   status:
     ip: "0.0.0.0"


### PR DESCRIPTION
Co-authored-by: GPT-5.4

These changes add configurable nginx realip settings and proxy protocol listener support for APISIX. This enables deployments behind L4/L7 proxies to preserve the original client IP end to end, including cases where the proxy sends PROXY protocol metadata.

The change introduces:

- apisix.nginx.real_ip_header and apisix.nginx.real_ip_from
- apisix.proxyProtocol.listenHttpPort and listenHttpsPort- 
- apisix.proxyProtocol.enableTcpPP and enableTcpPPToUpstream
- apisix.proxyProtocol.exposed to route the main gateway service to the proxy-protocol listeners
- 
Backwards compatibility is preserved: all new settings are optional, and existing rendered templates are unchanged unless these values are set.

Operational note: when using proxy protocol, operators should set real_ip_header to proxy_protocol, configure trusted proxy CIDRs in real_ip_from, and ensure the external load balancer actually sends PROXY protocol to the exposed listener ports.