### PR TITLE
fix: default listenerPortMatchMode to off in apisix and ingress-controller charts

### DIFF
--- a/charts/apisix-ingress-controller/Chart.yaml
+++ b/charts/apisix-ingress-controller/Chart.yaml
@@ -24,7 +24,7 @@ keywords:
   - nginx
   - crd
 type: application
-version: 1.2.0
+version: 1.2.1
 appVersion: 2.1.0
 sources:
   - https://github.com/apache/apisix-helm-chart

--- a/charts/apisix-ingress-controller/README.md
+++ b/charts/apisix-ingress-controller/README.md
@@ -121,7 +121,7 @@ The same for container level, you need to set:
 | config.leaderElection.leaseDuration | string | `"15s"` |  |
 | config.leaderElection.renewDeadline | string | `"10s"` |  |
 | config.leaderElection.retryPeriod | string | `"2s"` |  |
-| config.listenerPortMatchMode | string | `"auto"` |  |
+| config.listenerPortMatchMode | string | `"off"` |  |
 | config.logLevel | string | `"info"` |  |
 | config.metricsAddr | string | `":8080"` |  |
 | config.probeAddr | string | `":8081"` |  |

--- a/charts/apisix-ingress-controller/templates/configmap.yaml
+++ b/charts/apisix-ingress-controller/templates/configmap.yaml
@@ -35,7 +35,7 @@ data:
     secure_metrics: {{ .Values.config.secureMetrics | default false }}
     exec_adc_timeout: {{ .Values.config.execADCTimeout | default "15s" }}
     disable_gateway_api: {{ .Values.config.disableGatewayAPI | default false }}
-    listener_port_match_mode: {{ .Values.config.listenerPortMatchMode | default "auto" }}
+    listener_port_match_mode: {{ .Values.config.listenerPortMatchMode | default "off" }}
     provider:
       type: {{ .Values.config.provider.type | default "apisix" }}
       sync_period: {{ .Values.config.provider.syncPeriod | default "1s" }}

--- a/charts/apisix-ingress-controller/values.yaml
+++ b/charts/apisix-ingress-controller/values.yaml
@@ -92,7 +92,11 @@ config:
   secureMetrics: false
   execADCTimeout: "15s"
   disableGatewayAPI: false
-  listenerPortMatchMode: "auto"
+  # server_port matches the port APISIX actually listens on (e.g. 9080/9443),
+  # not the Gateway listener port. Defaults to "off" so port-var injection is
+  # opt-in; set to "auto"/"explicit" only when APISIX listens on the same ports
+  # declared in the Gateway listeners.
+  listenerPortMatchMode: "off"
   provider:
     type: "apisix"
     syncPeriod: "1m"

--- a/charts/apisix/Chart.yaml
+++ b/charts/apisix/Chart.yaml
@@ -31,7 +31,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.14.1
+version: 2.14.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/apisix/values.yaml
+++ b/charts/apisix/values.yaml
@@ -688,6 +688,11 @@ etcd:
 # -- Ingress controller configuration
 ingress-controller:
   enabled: false
+  config:
+    # server_port matches the port APISIX actually listens on (e.g. 9080/9443),
+    # not the Gateway listener port. Default to "off" so port-var injection is
+    # opt-in.
+    listenerPortMatchMode: "off"
   webhook:
     # Specifies whether to enable the validation webhook.
     # Note: This feature relies on the '/apisix/admin/configs/validate' endpoint.


### PR DESCRIPTION
### What this PR does

Changes the default of `listenerPortMatchMode` from `auto` to `off` for both the `apisix-ingress-controller` chart and the umbrella `apisix` chart.

### Why

`auto` mode (introduced in apache/apisix-ingress-controller#2703, shipped in 2.1.0) injects a `server_port` route var into any route matching multiple listener ports. The injected value is the **Gateway listener port** (e.g. `80`/`443`), but the APISIX `server_port` variable reflects the port the **data plane actually listens on** (e.g. `9080`/`9443` — the Service maps `80/443 → 9080/9443`). The two never match, so every multi-listener route returns `404` after upgrading.

See apache/apisix-ingress-controller#2782 for the full analysis.

### Changes

**`charts/apisix-ingress-controller`**
- `values.yaml`: `config.listenerPortMatchMode` now defaults to `"off"` (with an explanatory comment).
- `templates/configmap.yaml`: template default updated to `off`.
- `README.md`: regenerated default value.
- `Chart.yaml`: version `1.2.0` → `1.2.1`.

**`charts/apisix`** (umbrella)
- `values.yaml`: pins `ingress-controller.config.listenerPortMatchMode: "off"` so bundled deployments inherit the safe default.
- `Chart.yaml`: version `2.14.1` → `2.14.2`.

Rendered output verified (`listener_port_match_mode: off`) and `helm lint` passes. Users who run APISIX with `node_listen` aligned to their Gateway listener ports can still opt back in via `config.listenerPortMatchMode: auto`/`explicit`.

> Note: the upstream controller default is also being changed to `off` in apache/apisix-ingress-controller#2784. This chart change protects existing chart users immediately, independent of the controller release cycle.
