### PR TITLE
feat(apisix): add Proxy Protocol v2 support

### DIFF
--- a/charts/apisix/README.md
+++ b/charts/apisix/README.md
@@ -118,6 +118,13 @@ The command removes all the Kubernetes components associated with the chart and 
 | apisix.prometheus.enabled | bool | `false` |  |
 | apisix.prometheus.metricPrefix | string | `"apisix_"` | prefix of the metrics |
 | apisix.prometheus.path | string | `"/apisix/prometheus/metrics"` | path of the metrics endpoint |
+| apisix.proxyProtocol.enableTcpPP | bool | `false` | Enable Proxy Protocol for TCP stream proxy |
+| apisix.proxyProtocol.enableTcpPPToUpstream | bool | `false` | Enable Proxy Protocol to upstream servers |
+| apisix.proxyProtocol.enabled | bool | `false` | Enable Proxy Protocol. When enabled, dedicated listeners (listenHttpPort/listenHttpsPort) are added alongside the standard ports so internal cluster traffic continues to work. |
+| apisix.proxyProtocol.listenHttpNodePort | string | `""` | NodePort for HTTP Proxy Protocol listener (NodePort service type only) |
+| apisix.proxyProtocol.listenHttpPort | int | `9181` | Listening port for HTTP with Proxy Protocol |
+| apisix.proxyProtocol.listenHttpsNodePort | string | `""` | NodePort for HTTPS Proxy Protocol listener (NodePort service type only) |
+| apisix.proxyProtocol.listenHttpsPort | int | `9182` | Listening port for HTTPS with Proxy Protocol |
 | apisix.router.http | string | `"radixtree_host_uri"` | Defines how apisix handles routing: - radixtree_uri: match route by uri(base on radixtree) - radixtree_host_uri: match route by host + uri(base on radixtree) - radixtree_uri_with_parameter: match route by uri with parameters |
 | apisix.setIDFromPodUID | bool | `false` | Use Pod metadata.uid as the APISIX id. |
 | apisix.ssl.additionalContainerPorts | list | `[]` | Support multiple https ports, See [Configuration](https://github.com/apache/apisix/blob/0bc65ea9acd726f79f80ae0abd8f50b7eb172e3d/conf/config-default.yaml#L99) |

--- a/charts/apisix/templates/configmap.yaml
+++ b/charts/apisix/templates/configmap.yaml
@@ -76,14 +76,13 @@ data:
       enable_http2: {{ .Values.apisix.enableHTTP2 }}
       enable_server_tokens: {{ .Values.apisix.enableServerTokens }} # Whether the APISIX version number should be shown in Server header
 
-      # proxy_protocol:                   # Proxy Protocol configuration
-      #   listen_http_port: 9181          # The port with proxy protocol for http, it differs from node_listen and admin_listen.
-      #                                   # This port can only receive http request with proxy protocol, but node_listen & admin_listen
-      #                                   # can only receive http request. If you enable proxy protocol, you must use this port to
-      #                                   # receive http request with proxy protocol
-      #   listen_https_port: 9182         # The port with proxy protocol for https
-      #   enable_tcp_pp: true             # Enable the proxy protocol for tcp proxy, it works for stream_proxy.tcp option
-      #   enable_tcp_pp_to_upstream: true # Enables the proxy protocol to the upstream server
+      {{- if .Values.apisix.proxyProtocol.enabled }}
+      proxy_protocol:
+        listen_http_port: {{ .Values.apisix.proxyProtocol.listenHttpPort }}
+        listen_https_port: {{ .Values.apisix.proxyProtocol.listenHttpsPort }}
+        enable_tcp_pp: {{ .Values.apisix.proxyProtocol.enableTcpPP }}
+        enable_tcp_pp_to_upstream: {{ .Values.apisix.proxyProtocol.enableTcpPPToUpstream }}
+      {{- end }}
 
       proxy_cache:                         # Proxy Caching configuration
         cache_ttl: 10s                     # The default caching time if the upstream does not specify the cache time
@@ -124,7 +123,11 @@ data:
           {{- if gt (len .Values.service.stream.tcp) 0}}
           {{- range .Values.service.stream.tcp }}
           {{- if kindIs "map" . }}
+          {{- if .addr }}
           - addr: {{ .addr }}
+          {{- else }}
+          - addr: {{ .port }}
+          {{- end }}
           {{- if hasKey . "tls" }}
             tls: {{ .tls }}
           {{- end }}
@@ -214,10 +217,14 @@ data:
         client_body_timeout: 60s       # timeout for reading client request body, then 408 (Request Time-out) error is returned to the client
         send_timeout: 10s              # timeout for transmitting a response to the client.then the connection is closed
         underscores_in_headers: "on"   # default enables the use of underscores in client request header fields
-        real_ip_header: "X-Real-IP"    # http://nginx.org/en/docs/http/ngx_http_realip_module.html#real_ip_header
+        real_ip_header: {{ if .Values.apisix.proxyProtocol.enabled }}"proxy_protocol"{{ else }}"X-Real-IP"{{ end }}    # http://nginx.org/en/docs/http/ngx_http_realip_module.html#real_ip_header
         real_ip_from:                  # http://nginx.org/en/docs/http/ngx_http_realip_module.html#set_real_ip_from
+          {{- if .Values.apisix.proxyProtocol.enabled }}
+          - 0.0.0.0/0
+          {{- else }}
           - 127.0.0.1
           - 'unix:'
+          {{- end }}
         {{- if .Values.apisix.nginx.customLuaSharedDicts }}
         custom_lua_shared_dict:        # add custom shared cache to nginx.conf
         {{- range $dict := .Values.apisix.nginx.customLuaSharedDicts }}

--- a/charts/apisix/templates/deployment.yaml
+++ b/charts/apisix/templates/deployment.yaml
@@ -109,6 +109,14 @@ spec:
               containerPort: {{ .port }}
               protocol: TCP
             {{- end }}     
+            {{- if .Values.apisix.proxyProtocol.enabled }}
+            - name: pp-http
+              containerPort: {{ .Values.apisix.proxyProtocol.listenHttpPort }}
+              protocol: TCP
+            - name: pp-tls
+              containerPort: {{ .Values.apisix.proxyProtocol.listenHttpsPort }}
+              protocol: TCP
+            {{- end }}
             - name: tls
               containerPort: {{ .Values.apisix.ssl.containerPort }}
               protocol: TCP
@@ -138,7 +146,11 @@ spec:
             {{- range $index, $port := .tcp }}
             - name: proxy-tcp-{{ $index | toString }}
             {{- if kindIs "map" $port }}
+            {{- if $port.addr }}
               containerPort: {{ splitList ":" ($port.addr | toString) | last }}
+            {{- else }}
+              containerPort: {{ $port.port }}
+            {{- end }}
             {{- else }}
               containerPort: {{ $port }}
             {{- end }}

--- a/charts/apisix/templates/service-gateway.yaml
+++ b/charts/apisix/templates/service-gateway.yaml
@@ -62,6 +62,22 @@ spec:
     targetPort: {{ .port }}
     protocol: TCP
   {{- end }}
+  {{- if .Values.apisix.proxyProtocol.enabled }}
+  - name: apisix-gateway-pp-http
+    port: {{ .Values.apisix.proxyProtocol.listenHttpPort }}
+    targetPort: {{ .Values.apisix.proxyProtocol.listenHttpPort }}
+  {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.apisix.proxyProtocol.listenHttpNodePort))) }}
+    nodePort: {{ .Values.apisix.proxyProtocol.listenHttpNodePort }}
+  {{- end }}
+    protocol: TCP
+  - name: apisix-gateway-pp-tls
+    port: {{ .Values.apisix.proxyProtocol.listenHttpsPort }}
+    targetPort: {{ .Values.apisix.proxyProtocol.listenHttpsPort }}
+  {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.apisix.proxyProtocol.listenHttpsNodePort))) }}
+    nodePort: {{ .Values.apisix.proxyProtocol.listenHttpsNodePort }}
+  {{- end }}
+    protocol: TCP
+  {{- end }}
   {{- if or .Values.apisix.ssl.enabled }}
   - name: apisix-gateway-tls
     port: {{ .Values.service.tls.servicePort }}
@@ -82,8 +98,16 @@ spec:
   {{- range $index, $port := .tcp }}
   - name: proxy-tcp-{{ $index | toString }}
   {{- if kindIs "map" $port }}
+  {{- if $port.addr }}
     port: {{ splitList ":" ($port.addr | toString) | last }}
     targetPort: {{ splitList ":" ($port.addr | toString) | last }}
+  {{- else }}
+    port: {{ $port.port }}
+    targetPort: {{ $port.port }}
+  {{- end }}
+  {{- if (and (eq $.Values.service.type "NodePort") (not (empty $port.nodePort))) }}
+    nodePort: {{ $port.nodePort }}
+  {{- end }}
     protocol: TCP
   {{- else }}
     port: {{ $port }}

--- a/charts/apisix/values.yaml
+++ b/charts/apisix/values.yaml
@@ -305,6 +305,23 @@ apisix:
         # -- Filepath of the plugin code, for setting the mapping relationship between ConfigMap key and the lua module code path.
           path: ""
 
+  proxyProtocol:
+    # -- Enable Proxy Protocol. When enabled, dedicated listeners (listenHttpPort/listenHttpsPort)
+    # are added alongside the standard ports so internal cluster traffic continues to work.
+    enabled: false
+    # -- Listening port for HTTP with Proxy Protocol
+    listenHttpPort: 9181
+    # -- NodePort for HTTP Proxy Protocol listener (NodePort service type only)
+    listenHttpNodePort: ""
+    # -- Listening port for HTTPS with Proxy Protocol
+    listenHttpsPort: 9182
+    # -- NodePort for HTTPS Proxy Protocol listener (NodePort service type only)
+    listenHttpsNodePort: ""
+    # -- Enable Proxy Protocol for TCP stream proxy
+    enableTcpPP: false
+    # -- Enable Proxy Protocol to upstream servers
+    enableTcpPPToUpstream: false
+
   ssl:
     enabled: false
     containerPort: 9443


### PR DESCRIPTION
## What

Adds configurable Proxy Protocol v2 support via a new `apisix.proxyProtocol` section in `values.yaml`. Also extends `service.stream.tcp` to support a third entry format `{port, nodePort}` alongside the existing plain integer and `{addr}` formats, allowing fixed NodePort values to be assigned to TCP stream proxy ports in NodePort service deployments.

## Why

Cloud L4 load balancers (AWS NLB, GCP, OCI, etc.) send binary PPv2 headers. Without explicit PP listeners, APISIX cannot parse these headers and client IP information is lost.

Dedicated PP listeners (default: 9181/9182) are added **alongside the standard ports** rather than replacing their `targetPort`, so internal cluster traffic continues to work without PP headers.