### PR TITLE
feat: Add excludeResourceType config to apisix-ingress-controller chart

### DIFF
--- a/charts/apisix-ingress-controller/README.md
+++ b/charts/apisix-ingress-controller/README.md
@@ -125,6 +125,7 @@ The same for container level, you need to set:
 | config.logLevel | string | `"info"` |  |
 | config.metricsAddr | string | `":8080"` |  |
 | config.probeAddr | string | `":8081"` |  |
+| config.provider.excludeResourceType | list | `[]` |  |
 | config.provider.initSyncDelay | string | `"20m"` |  |
 | config.provider.syncPeriod | string | `"1m"` |  |
 | config.provider.type | string | `"apisix"` |  |

--- a/charts/apisix-ingress-controller/templates/configmap.yaml
+++ b/charts/apisix-ingress-controller/templates/configmap.yaml
@@ -40,6 +40,12 @@ data:
       type: {{ .Values.config.provider.type | default "apisix" }}
       sync_period: {{ .Values.config.provider.syncPeriod | default "1s" }}
       init_sync_delay: {{ .Values.config.provider.initSyncDelay | default "20m" }}
+      {{- if .Values.config.provider.excludeResourceType }}
+      exclude_resource_type:
+        {{- range .Values.config.provider.excludeResourceType }}
+        - {{ . }}
+        {{- end }}
+      {{- end }}
     {{- if .Values.webhook.enabled }}
     webhook:
       enable: true

--- a/charts/apisix-ingress-controller/values.yaml
+++ b/charts/apisix-ingress-controller/values.yaml
@@ -97,6 +97,7 @@ config:
     type: "apisix"
     syncPeriod: "1m"
     initSyncDelay: "20m"
+    excludeResourceType: []
   kubernetes:
     ingressClass: apisix
     defaultIngressClass: false


### PR DESCRIPTION
 What this PR does / why we need it

Adds config.provider.excludeResourceType to the apisix-ingress-controller chart, exposing the exclude_resource_type option introduced in [apache/apisix-ingress-controller#2794](https://github.com/apache/apisix-ingress-controller/pull/2794).

 ▎ Note: This chart change requires apache/apisix-ingress-controller#2794 to be merged and released before it takes effect.

 This allows users to configure resource types that should be excluded from ADC reconciliation sweeps, preventing the controller from deleting APISIX resources that are managed outside of  Kubernetes CRDs (e.g. consumers created via the Admin API).

  Changes:
  - values.yaml: adds config.provider.excludeResourceType: []
  - templates/configmap.yaml: renders exclude_resource_type when the list is non-empty
  - README.md: adds the new parameter to the values table

Implements
https://github.com/apache/apisix-helm-chart/issues/984