### PR TITLE
chore: upgrade adc to 0.27.1 for ingress

### DIFF
--- a/charts/apisix-ingress-controller/Chart.yaml
+++ b/charts/apisix-ingress-controller/Chart.yaml
@@ -24,7 +24,7 @@ keywords:
   - nginx
   - crd
 type: application
-version: 1.2.0
+version: 1.2.1
 appVersion: 2.1.0
 sources:
   - https://github.com/apache/apisix-helm-chart

--- a/charts/apisix-ingress-controller/README.md
+++ b/charts/apisix-ingress-controller/README.md
@@ -129,7 +129,7 @@ The same for container level, you need to set:
 | config.provider.syncPeriod | string | `"1m"` |  |
 | config.provider.type | string | `"apisix"` |  |
 | config.secureMetrics | bool | `false` |  |
-| deployment.adcContainer | object | `{"config":{"logLevel":"info"},"image":{"repository":"ghcr.io/api7/adc","tag":"0.26.0"}}` | Set adc sidecar container configuration |
+| deployment.adcContainer | object | `{"config":{"logLevel":"info"},"image":{"repository":"ghcr.io/api7/adc","tag":"0.27.1"}}` | Set adc sidecar container configuration |
 | deployment.affinity | object | `{}` |  |
 | deployment.annotations | object | `{}` | Add annotations to Apache APISIX ingress controller resource |
 | deployment.image.pullPolicy | string | `"IfNotPresent"` |  |

--- a/charts/apisix-ingress-controller/values.yaml
+++ b/charts/apisix-ingress-controller/values.yaml
@@ -73,7 +73,7 @@ deployment:
   adcContainer:
     image:
       repository: ghcr.io/api7/adc
-      tag: "0.26.0"
+      tag: "0.27.1"
     config:
       logLevel: "info"
 


### PR DESCRIPTION
Upgrade the ADC sidecar image used by the `apisix-ingress-controller` chart from `0.26.0` to `0.27.1`.

### Changes

- `charts/apisix-ingress-controller/values.yaml`: `deployment.adcContainer.image.tag` `0.26.0` -> `0.27.1`
- `charts/apisix-ingress-controller/README.md`: regenerate the `deployment.adcContainer` default
- `charts/apisix-ingress-controller/Chart.yaml`: bump chart `version` `1.2.0` -> `1.2.1`

### Ingress-related fixes in this ADC bump

- Fix `global_rules` being re-created on every sync, which made the second sync fail with `400` and rejected the whole standalone config ([api7/adc#497](https://github.com/api7/adc/pull/497)).
- Standalone cache TTL + active invalidation, fixing stale-cache sync errors after leader re-election ([api7/adc#460](https://github.com/api7/adc/pull/460)).
