### PR TITLE
chore: allow L4 upstream schemes (tcp/tls/udp) in ingress-controller CRDs

### DIFF
--- a/charts/apisix-ingress-controller/Chart.yaml
+++ b/charts/apisix-ingress-controller/Chart.yaml
@@ -24,7 +24,7 @@ keywords:
   - nginx
   - crd
 type: application
-version: 1.2.1
+version: 1.2.2
 appVersion: 2.1.0
 sources:
   - https://github.com/apache/apisix-helm-chart

--- a/charts/apisix-ingress-controller/crds/apisixic-crds.yaml
+++ b/charts/apisix-ingress-controller/crds/apisixic-crds.yaml
@@ -2033,12 +2033,18 @@ spec:
                       description: |-
                         Scheme is the protocol used to communicate with the upstream.
                         Default is `http`.
-                        Can be `http`, `https`, `grpc`, or `grpcs`.
+                        For L7 proxy, it can be `http`, `https`, `grpc`, or `grpcs`.
+                        For L4 proxy, it can be `tcp`, `tls`, or `udp`.
+                        The L4 values apply to stream routes only; using them for an HTTP route
+                        makes the upstream unreachable.
                       enum:
                       - http
                       - https
                       - grpc
                       - grpcs
+                      - tcp
+                      - tls
+                      - udp
                       type: string
                     subsets:
                       description: |-
@@ -2112,12 +2118,18 @@ spec:
                 description: |-
                   Scheme is the protocol used to communicate with the upstream.
                   Default is `http`.
-                  Can be `http`, `https`, `grpc`, or `grpcs`.
+                  For L7 proxy, it can be `http`, `https`, `grpc`, or `grpcs`.
+                  For L4 proxy, it can be `tcp`, `tls`, or `udp`.
+                  The L4 values apply to stream routes only; using them for an HTTP route
+                  makes the upstream unreachable.
                 enum:
                 - http
                 - https
                 - grpc
                 - grpcs
+                - tcp
+                - tls
+                - udp
                 type: string
               subsets:
                 description: |-
@@ -2529,12 +2541,18 @@ spec:
                 description: |-
                   Scheme is the protocol used to communicate with the upstream.
                   Default is `http`.
-                  Can be `http`, `https`, `grpc`, or `grpcs`.
+                  For L7 proxy, it can be `http`, `https`, `grpc`, or `grpcs`.
+                  For L4 proxy, it can be `tcp`, `tls`, or `udp`.
+                  The L4 values apply to stream routes only; using them for an HTTP route
+                  makes the upstream unreachable.
                 enum:
                 - http
                 - https
                 - grpc
                 - grpcs
+                - tcp
+                - tls
+                - udp
                 type: string
               targetRefs:
                 description: |-


### PR DESCRIPTION
## Description

APISIX accepts `tcp`, `tls` and `udp` as upstream schemes for L4 proxying, and `scheme: tls` is what makes the gateway establish the TLS session with a stream upstream (plain TCP in from the client, TLS out to the backend). The CRDs bundled in this chart still restrict `ApisixUpstream.spec.scheme` and `BackendTrafficPolicy.spec.scheme` to the L7 set, so on a standard Helm installation the API server rejects `tcp`/`tls`/`udp` before the controller ever sees the resource.

Only the `scheme` blocks are touched; the rest of the bundle is left as-is and will be refreshed by the next release bump.
