### PR TITLE
chore: add GatewayProxy caBundle to ingress-controller CRDs, pin ADC 0.29.0

### DIFF
--- a/charts/apisix-ingress-controller/Chart.yaml
+++ b/charts/apisix-ingress-controller/Chart.yaml
@@ -24,7 +24,7 @@ keywords:
   - nginx
   - crd
 type: application
-version: 1.2.2
+version: 1.2.3
 appVersion: 2.1.0
 sources:
   - https://github.com/apache/apisix-helm-chart

--- a/charts/apisix-ingress-controller/README.md
+++ b/charts/apisix-ingress-controller/README.md
@@ -129,7 +129,7 @@ The same for container level, you need to set:
 | config.provider.syncPeriod | string | `"1m"` |  |
 | config.provider.type | string | `"apisix"` |  |
 | config.secureMetrics | bool | `false` |  |
-| deployment.adcContainer | object | `{"config":{"logLevel":"info"},"image":{"repository":"ghcr.io/api7/adc","tag":"0.27.1"}}` | Set adc sidecar container configuration |
+| deployment.adcContainer | object | `{"config":{"logLevel":"info"},"image":{"repository":"ghcr.io/api7/adc","tag":"0.29.0"}}` | Set adc sidecar container configuration |
 | deployment.affinity | object | `{}` |  |
 | deployment.annotations | object | `{}` | Add annotations to Apache APISIX ingress controller resource |
 | deployment.image.pullPolicy | string | `"IfNotPresent"` |  |

--- a/charts/apisix-ingress-controller/crds/apisixic-crds.yaml
+++ b/charts/apisix-ingress-controller/crds/apisixic-crds.yaml
@@ -3258,13 +3258,23 @@ spec:
                         - message: adminKey must be specified when type is AdminKey
                           rule: 'self.type == ''AdminKey'' ? has(self.adminKey) :
                             true'
-                      caBundle:
+                      caCert:
                         description: |-
-                          CaBundle is a PEM-encoded CA certificate (or bundle) used to verify the
-                          control plane's TLS certificate, in place of the system trust store.
+                          CaCert specifies the CA certificate used to verify the control plane's TLS
+                          certificate, in place of the system trust store.
                           Set it when the control plane uses a self-signed or private CA certificate.
                           It has no effect when tlsVerify is false.
-                        type: string
+                        properties:
+                          value:
+                            description: Value sets the PEM-encoded CA certificate
+                              (or bundle) explicitly.
+                            type: string
+                            x-kubernetes-validations:
+                            - message: value must be a PEM-encoded certificate
+                              rule: self.contains('-----BEGIN CERTIFICATE-----')
+                        required:
+                        - value
+                        type: object
                       endpoints:
                         description: Endpoints specifies the list of control plane
                           endpoints.
@@ -3303,9 +3313,6 @@ spec:
                     - message: mode is immutable
                       rule: oldSelf == null || (!has(self.mode) && !has(oldSelf.mode))
                         || self.mode == oldSelf.mode
-                    - message: caBundle must be a PEM-encoded certificate
-                      rule: '!has(self.caBundle) || self.caBundle.contains(''-----BEGIN
-                        CERTIFICATE-----'')'
                   type:
                     description: Type specifies the type of provider. Can only be
                       `ControlPlane`.

--- a/charts/apisix-ingress-controller/crds/apisixic-crds.yaml
+++ b/charts/apisix-ingress-controller/crds/apisixic-crds.yaml
@@ -3258,6 +3258,13 @@ spec:
                         - message: adminKey must be specified when type is AdminKey
                           rule: 'self.type == ''AdminKey'' ? has(self.adminKey) :
                             true'
+                      caBundle:
+                        description: |-
+                          CaBundle is a PEM-encoded CA certificate (or bundle) used to verify the
+                          control plane's TLS certificate, in place of the system trust store.
+                          Set it when the control plane uses a self-signed or private CA certificate.
+                          It has no effect when tlsVerify is false.
+                        type: string
                       endpoints:
                         description: Endpoints specifies the list of control plane
                           endpoints.
@@ -3296,6 +3303,9 @@ spec:
                     - message: mode is immutable
                       rule: oldSelf == null || (!has(self.mode) && !has(oldSelf.mode))
                         || self.mode == oldSelf.mode
+                    - message: caBundle must be a PEM-encoded certificate
+                      rule: '!has(self.caBundle) || self.caBundle.contains(''-----BEGIN
+                        CERTIFICATE-----'')'
                   type:
                     description: Type specifies the type of provider. Can only be
                       `ControlPlane`.

--- a/charts/apisix-ingress-controller/values.yaml
+++ b/charts/apisix-ingress-controller/values.yaml
@@ -73,7 +73,7 @@ deployment:
   adcContainer:
     image:
       repository: ghcr.io/api7/adc
-      tag: "0.27.1"
+      tag: "0.29.0"
     config:
       logLevel: "info"
 


### PR DESCRIPTION
## What this PR does

Paired chart change for apache/apisix-ingress-controller#2826, which adds an optional `caBundle` to `GatewayProxy.spec.provider.controlPlane` — a PEM-encoded CA used to verify the control plane in place of the system trust store, so `tlsVerify: true` can stay on when the control plane uses a self-signed or private CA.

Two things are needed here for that to work in a normal Helm install:

1. **`crds/apisixic-crds.yaml`** — the bundled CRD must carry the property, otherwise the API server prunes the unknown field and the controller never receives it.
2. **`values.yaml`** — the bundle reaches the ADC sidecar as `caCert`, which lands in **0.29.0** (api7/adc#552). Earlier sidecars accept the option and silently ignore it, so the field would be set while verification still fails.

Chart `version` goes 1.2.2 -> 1.2.3, following #992. `appVersion` is unchanged: the controller-side change is not released yet, and the CRD property is inert without it.

## Changes

- `crds/apisixic-crds.yaml`: `caBundle` on `controlPlane`, plus the CEL rule that rejects a non-PEM value at admission.
- `values.yaml`: `deployment.adcContainer.image.tag` 0.27.1 -> 0.29.0.
- `Chart.yaml`: `version` 1.2.2 -> 1.2.3.
- `README.md`: regenerated with `make helm-docs`.

## Verification

The CRD edit is not hand-written prose — the property and CEL blocks were lifted verbatim from `controller-gen` output so the chart cannot drift in wording or wrapping. Confirmed by parsing both and comparing:

```
provider subtree identical to generated CRD: True
whole GatewayProxy schema identical:         True
```

The sidecar bump was exercised against the real image rather than assumed. Running `ghcr.io/api7/adc:0.29.0` in ingress mode against an HTTPS backend whose certificate is signed by a private CA, replaying the exact request body the controller builds:

| request | result |
| --- | --- |
| `tlsSkipVerify: false`, no `caCert` | `Error: unable to verify the first certificate` |
| `tlsSkipVerify: false` + `caCert` | handshake succeeds, backend's own HTTP 404 surfaces |

Also:

```
helm lint charts/apisix-ingress-controller   1 chart(s) linted, 0 chart(s) failed
helm template ic charts/apisix-ingress-controller | grep api7/adc
  image: "ghcr.io/api7/adc:0.29.0"
```

Happy to split the ADC bump into its own PR if you would rather keep them separate (as in #987) — I kept them together because neither half delivers the feature alone.