### PR TITLE
chore: upgrade apisix to 3.18.0

### DIFF
--- a/charts/apisix/Chart.yaml
+++ b/charts/apisix/Chart.yaml
@@ -31,12 +31,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.16.1
+version: 2.17.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 3.17.0
+appVersion: 3.18.0
 sources:
   - https://github.com/apache/apisix-helm-chart
 

--- a/charts/apisix/README.md
+++ b/charts/apisix/README.md
@@ -248,7 +248,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | hostNetwork | bool | `false` | Use the host's network namespace |
 | image.pullPolicy | string | `"IfNotPresent"` | Apache APISIX image pull policy |
 | image.repository | string | `"apache/apisix"` | Apache APISIX image repository |
-| image.tag | string | `"3.17.0-ubuntu"` | Apache APISIX image tag Overrides the image tag whose default is the chart appVersion. |
+| image.tag | string | `"3.18.0-ubuntu"` | Apache APISIX image tag Overrides the image tag whose default is the chart appVersion. |
 | ingress | object | `{"annotations":{},"enabled":false,"hosts":[{"host":"apisix.local","paths":[]}],"servicePort":null,"tls":[]}` | Using ingress access Apache APISIX service |
 | ingress-controller | object | `{"enabled":false,"webhook":{"enabled":false}}` | Ingress controller configuration |
 | ingress-controller.enabled | bool | `false` | Enable the apisix-ingress-controller sub-chart |

--- a/charts/apisix/values.yaml
+++ b/charts/apisix/values.yaml
@@ -29,7 +29,7 @@ image:
   pullPolicy: IfNotPresent
   # -- Apache APISIX image tag
   # Overrides the image tag whose default is the chart appVersion.
-  tag: 3.17.0-ubuntu
+  tag: 3.18.0-ubuntu
 
 # -- set false to use `Deployment`, set true to use `DaemonSet`
 useDaemonSet: false


### PR DESCRIPTION
### Description

Upgrades the APISIX chart to the newly released [APISIX 3.18.0](https://github.com/apache/apisix/releases/tag/3.18.0).

- `Chart.yaml`: `appVersion` `3.17.0` -> `3.18.0`, chart `version` `2.16.1` -> `2.17.0`
- `values.yaml`: image `tag` `3.17.0-ubuntu` -> `3.18.0-ubuntu`
- `README.md`: regenerated via `make helm-docs`

The new plugins and config options in 3.18.0 flow through the existing value passthroughs (`apisix.plugins`, `luaSharedDicts`, `service.stream.tcp/udp`), so no template changes are required for this release.

> [!IMPORTANT]
> `apache/apisix:3.18.0-ubuntu` is **not on Docker Hub yet**, so `ct install` will fail to pull the image until it is. The images are published when apache/apisix-docker#631 merges and its push workflow runs. Please merge this one after that, and re-run CI.
