### PR TITLE
fix(ingress-controller): align listener port matching default

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,6 +39,9 @@ jobs:
                   --charts charts/apisix-dashboard \
                   --charts charts/apisix-ingress-controller'
 
+      - name: Test ingress controller rendered defaults
+        run: bash test/ingress-controller-config-defaults.sh
+
       - name: fix permissions
         run: |
           sudo mkdir -p $HOME/.kube

--- a/charts/apisix-ingress-controller/Chart.yaml
+++ b/charts/apisix-ingress-controller/Chart.yaml
@@ -24,7 +24,7 @@ keywords:
   - nginx
   - crd
 type: application
-version: 1.3.0
+version: 1.3.1
 appVersion: 2.2.0
 sources:
   - https://github.com/apache/apisix-helm-chart

--- a/charts/apisix-ingress-controller/README.md
+++ b/charts/apisix-ingress-controller/README.md
@@ -43,6 +43,8 @@ _See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall/) for command doc
 
 ## Upgrading Chart
 
+Chart 1.3.1 changes the default `config.listenerPortMatchMode` from `auto` to `off`, matching the APISIX Ingress Controller 2.2.0 default. This avoids adding `server_port` route predicates when Kubernetes Service ports differ from the ports on which APISIX accepts traffic. If your routes rely on listener-port matching, set `config.listenerPortMatchMode` to `auto` or `explicit` before upgrading.
+
 ```console
 helm upgrade [RELEASE_NAME] [CHART] --install
 ```
@@ -121,7 +123,7 @@ The same for container level, you need to set:
 | config.leaderElection.leaseDuration | string | `"15s"` |  |
 | config.leaderElection.renewDeadline | string | `"10s"` |  |
 | config.leaderElection.retryPeriod | string | `"2s"` |  |
-| config.listenerPortMatchMode | string | `"auto"` |  |
+| config.listenerPortMatchMode | string | `"off"` | Controls `server_port` route matching from Gateway listener ports. Supported values are `off`, `auto`, and `explicit`. |
 | config.logLevel | string | `"info"` |  |
 | config.metricsAddr | string | `":8080"` |  |
 | config.probeAddr | string | `":8081"` |  |

--- a/charts/apisix-ingress-controller/README.md.gotmpl
+++ b/charts/apisix-ingress-controller/README.md.gotmpl
@@ -43,6 +43,8 @@ _See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall/) for command doc
 
 ## Upgrading Chart
 
+Chart 1.3.1 changes the default `config.listenerPortMatchMode` from `auto` to `off`, matching the APISIX Ingress Controller 2.2.0 default. This avoids adding `server_port` route predicates when Kubernetes Service ports differ from the ports on which APISIX accepts traffic. If your routes rely on listener-port matching, set `config.listenerPortMatchMode` to `auto` or `explicit` before upgrading.
+
 ```console
 helm upgrade [RELEASE_NAME] [CHART] --install
 ```

--- a/charts/apisix-ingress-controller/templates/configmap.yaml
+++ b/charts/apisix-ingress-controller/templates/configmap.yaml
@@ -35,7 +35,7 @@ data:
     secure_metrics: {{ .Values.config.secureMetrics | default false }}
     exec_adc_timeout: {{ .Values.config.execADCTimeout | default "15s" }}
     disable_gateway_api: {{ .Values.config.disableGatewayAPI | default false }}
-    listener_port_match_mode: {{ .Values.config.listenerPortMatchMode | default "auto" }}
+    listener_port_match_mode: {{ .Values.config.listenerPortMatchMode | default "off" }}
     provider:
       type: {{ .Values.config.provider.type | default "apisix" }}
       sync_period: {{ .Values.config.provider.syncPeriod | default "1s" }}

--- a/charts/apisix-ingress-controller/values.yaml
+++ b/charts/apisix-ingress-controller/values.yaml
@@ -92,7 +92,8 @@ config:
   secureMetrics: false
   execADCTimeout: "15s"
   disableGatewayAPI: false
-  listenerPortMatchMode: "auto"
+  # -- Controls `server_port` route matching from Gateway listener ports. Supported values are `off`, `auto`, and `explicit`.
+  listenerPortMatchMode: "off"
   provider:
     type: "apisix"
     syncPeriod: "1m"

--- a/test/ingress-controller-config-defaults.sh
+++ b/test/ingress-controller-config-defaults.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+chart="charts/apisix-ingress-controller"
+
+default_config=$(helm template test "$chart" --show-only templates/configmap.yaml)
+grep -q '^    listener_port_match_mode: off$' <<<"$default_config"
+
+auto_config=$(helm template test "$chart" \
+  --show-only templates/configmap.yaml \
+  --set config.listenerPortMatchMode=auto)
+grep -q '^    listener_port_match_mode: auto$' <<<"$auto_config"


### PR DESCRIPTION
## Summary

- change the APISIX Ingress Controller chart default from `listenerPortMatchMode: auto` to `off`, matching the controller 2.2.0 safety default
- change the ConfigMap fallback to `off` and bump the chart to 1.3.1
- document the upgrade impact and how to retain `auto` or `explicit`
- add a rendered-config regression test for both the default and an explicit `auto` override
- regenerate the chart README and run the regression test in CI

## Why

APISIX Ingress Controller changed its omitted-field default to `off` in apache/apisix-ingress-controller#2804 after review reproduced a common mismatch: a Gateway listener declares port 80, Kubernetes maps Service port 80 to APISIX port 9080, and an injected `server_port == 80` predicate causes the route to miss.

Chart 1.3.0 still explicitly renders `auto`, so Helm users never receive the controller's safer fallback. This PR aligns the dedicated chart with the released controller contract.

Users who intentionally rely on listener-port matching can preserve the old chart behavior with:

```yaml
config:
  listenerPortMatchMode: auto
```

The APISIX umbrella chart still pins controller chart 1.3.0. Its dependency should be updated after 1.3.1 is published; it cannot safely reference the unpublished remote chart in this PR.

## Validation

- `bash -n test/ingress-controller-config-defaults.sh`
- `bash test/ingress-controller-config-defaults.sh`
- default, `auto`, and `explicit` `helm template` renders
- `helm package charts/apisix-ingress-controller`
- `helm-docs@v1.11.0` regeneration is idempotent
- upstream CI chart-testing image:
  ```shell
  ct lint --validate-maintainers=false \
    --charts charts/apisix-ingress-controller
  ```
  Result: 1 chart linted, 0 failed
- workflow YAML parse and `git diff --check`

Closes #1001.

Related: api7/api7-ingress-controller#462, #997.