### PR TITLE
feat(apisix): render extraContainers through tpl

### DIFF
--- a/charts/apisix/Chart.yaml
+++ b/charts/apisix/Chart.yaml
@@ -31,7 +31,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.17.0
+version: 2.17.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/apisix/README.md
+++ b/charts/apisix/README.md
@@ -237,7 +237,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | externalEtcd.password | string | `""` | if etcd.enabled is false and externalEtcd.existingSecret is empty, externalEtcd.password is the passsword for external etcd. |
 | externalEtcd.secretPasswordKey | string | `"etcd-root-password"` | externalEtcd.secretPasswordKey Key inside the secret containing the external etcd password |
 | externalEtcd.user | string | `"root"` | if etcd.enabled is false, user for external etcd. Set empty to disable authentication |
-| extraContainers | list | `[]` | Additional `containers`, See [Kubernetes containers](https://kubernetes.io/docs/concepts/containers/) for the detail. |
+| extraContainers | list | `[]` | Additional `containers`, See [Kubernetes containers](https://kubernetes.io/docs/concepts/containers/) for the detail. Rendered through `tpl`, so entries may reference other values (e.g. `image: "{{ .Values.someRepository }}:{{ .Values.someTag }}"`). |
 | extraDeploy | list | `[]` | Additional Kubernetes resources to deploy with the release. |
 | extraEnvVars | list | `[]` | extraEnvVars An array to add extra env vars e.g: extraEnvVars:   - name: FOO     value: "bar"   - name: FOO2     valueFrom:       secretKeyRef:         name: SECRET_NAME         key: KEY |
 | extraInitContainers | list | `[]` | Additional `initContainers`, See [Kubernetes initContainers](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/) for the detail. |

--- a/charts/apisix/templates/deployment.yaml
+++ b/charts/apisix/templates/deployment.yaml
@@ -230,7 +230,7 @@ spec:
           resources:
           {{- toYaml .Values.resources | nindent 12 }}
         {{- if .Values.extraContainers }}
-        {{- toYaml .Values.extraContainers | nindent 8 }}
+        {{- tpl (toYaml .Values.extraContainers) . | nindent 8 }}
         {{- end }}
       {{- if .Values.hostNetwork }}
       hostNetwork: true

--- a/charts/apisix/values.yaml
+++ b/charts/apisix/values.yaml
@@ -132,7 +132,7 @@ extraInitContainers: []
 #   image: busybox:1.28
 #   command: ['sh', '-c', "until nslookup myservice.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for myservice; sleep 2; done"]
 
-# -- Additional `containers`, See [Kubernetes containers](https://kubernetes.io/docs/concepts/containers/) for the detail.
+# -- Additional `containers`, See [Kubernetes containers](https://kubernetes.io/docs/concepts/containers/) for the detail. Rendered through `tpl`, so entries may reference other values (e.g. `image: "{{ .Values.someRepository }}:{{ .Values.someTag }}"`).
 extraContainers: []
 
 initContainer:


### PR DESCRIPTION
extraContainers entries are raw container specs, so an image reference inside them cannot be composed from other values the way first-class image fields can. Rendering the list through `tpl` lets entries carry template expressions (e.g. `image: "{{ .Values.someRepository }}:{{ .Values.someTag }}"`), matching the common pattern for extra-container passthroughs. Plain specs render unchanged.

Verified with `helm template`: a templated entry expands correctly, and untemplated values render byte-identical to the current output. Chart version bumped 2.17.0 -> 2.17.1; values doc comment and README row updated.