### PR TITLE
feat(ingress-controller): support annotations on the webhook configuration

### DIFF
--- a/charts/apisix-ingress-controller/Chart.yaml
+++ b/charts/apisix-ingress-controller/Chart.yaml
@@ -24,7 +24,7 @@ keywords:
   - nginx
   - crd
 type: application
-version: 1.3.0
+version: 1.3.1
 appVersion: 2.2.0
 sources:
   - https://github.com/apache/apisix-helm-chart

--- a/charts/apisix-ingress-controller/README.md
+++ b/charts/apisix-ingress-controller/README.md
@@ -171,6 +171,7 @@ The same for container level, you need to set:
 | serviceMonitor.namespace | string | `"monitoring"` | @param serviceMonitor.namespace Namespace in which to create the ServiceMonitor |
 | webhook.certificate.provided | bool | `false` | Set to true if you want to provide your own certificate |
 | webhook.enabled | bool | `true` | Enable or disable admission webhook |
+| webhook.annotations | object | `{}` | Annotations for the ValidatingWebhookConfiguration, e.g. `cert-manager.io/inject-ca-from: <namespace>/<certificate>` so cert-manager's cainjector maintains the webhook caBundle. |
 | webhook.failurePolicy | string | `"Ignore"` | Failure policy for the webhook (Fail or Ignore) |
 | webhook.port | int | `9443` | The port for the webhook server to listen on |
 | webhook.timeoutSeconds | int | `10` | Timeout in seconds for the webhook |

--- a/charts/apisix-ingress-controller/templates/webhook.yaml
+++ b/charts/apisix-ingress-controller/templates/webhook.yaml
@@ -39,6 +39,10 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: {{ include "apisix-ingress-controller-manager.name.fullname" . }}-webhook
+  {{- with .Values.webhook.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "apisix-ingress-controller-manager.labels" . | nindent 4 }}
 webhooks:

--- a/charts/apisix-ingress-controller/values.yaml
+++ b/charts/apisix-ingress-controller/values.yaml
@@ -105,6 +105,10 @@ config:
 webhook:
   # -- Enable or disable admission webhook
   enabled: true
+  # -- Annotations for the ValidatingWebhookConfiguration, e.g.
+  # `cert-manager.io/inject-ca-from: <namespace>/<certificate>` so
+  # cert-manager's cainjector maintains the webhook caBundle.
+  annotations: {}
   # -- The port for the webhook server to listen on
   port: 9443
   # -- Failure policy for the webhook (Fail or Ignore)


### PR DESCRIPTION
The ValidatingWebhookConfiguration renders with no annotations, so external CA managers cannot attach to it. With `webhook.certificate.provided`, operators supply a serving certificate (commonly a cert-manager Certificate) but must hand-copy the CA into `webhook.certificate.caBundle` and re-copy it whenever it rotates.

An `webhook.annotations` knob lets cert-manager's cainjector own the caBundle instead (`cert-manager.io/inject-ca-from: <namespace>/<certificate>`) — the standard pattern for webhook trust management.

Verified with `helm template`: the annotation renders onto the webhook configuration when set; unset output is byte-identical to today. Chart version bumped 1.3.0 -> 1.3.1; values doc comment and README row updated.