### PR TITLE
feat: expose rollout controls and the status endpoint in the apisix chart

### DIFF
--- a/charts/apisix/Chart.yaml
+++ b/charts/apisix/Chart.yaml
@@ -31,7 +31,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.17.0
+version: 2.18.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/apisix/README.md
+++ b/charts/apisix/README.md
@@ -179,6 +179,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | apisix.ssl.sslCiphers | string | `"ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES256-SHA256:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:DES-CBC3-SHA"` | TLS ciphers allowed to use. |
 | apisix.ssl.sslProtocols | string | `"TLSv1.2 TLSv1.3"` | TLS protocols allowed to use. |
 | apisix.ssl.sslSessionTickets | bool | `false` | Enable or disable TLS session tickets. Disabled by default because session tickets defeat Perfect Forward Secrecy (see https://github.com/mozilla/server-side-tls/issues/135) |
+| apisix.status.enabled | bool | `false` | Enable the status endpoint and probe `/status/ready` for readiness in every deployment mode, always enabled when `role_traditional.config_provider` is `yaml`. Requires APISIX >= 3.13.0 |
 | apisix.status.ip | string | `"0.0.0.0"` | The IP address on which the status endpoint (`/status`, `/status/ready`) listens |
 | apisix.status.port | int | `7085` | The port on which the status endpoint listens |
 | apisix.stream_plugins | list | `[]` | Customize the list of APISIX stream_plugins to enable. By default, APISIX's [default stream_plugins](https://github.com/apache/apisix/blob/master/apisix/cli/config.lua#L294) are automatically used. |
@@ -259,6 +260,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | ingress.tls | list | `[]` | Ingress TLS settings |
 | initContainer.image | string | `"busybox"` | Init container image |
 | initContainer.tag | float | `1.28` | Init container tag |
+| livenessProbe | object | `{}` | Override the liveness probe of the APISIX container, by default no liveness probe is set |
 | metrics | object | `{"serviceMonitor":{"annotations":{},"enabled":false,"interval":"15s","labels":{},"name":"","namespace":""}}` | Observability configuration. |
 | metrics.serviceMonitor.annotations | object | `{}` | @param serviceMonitor.annotations ServiceMonitor annotations |
 | metrics.serviceMonitor.enabled | bool | `false` | Enable or disable Apache APISIX serviceMonitor |
@@ -266,6 +268,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | metrics.serviceMonitor.labels | object | `{}` | @param serviceMonitor.labels ServiceMonitor extra labels |
 | metrics.serviceMonitor.name | string | `""` | name of the serviceMonitor, by default, it is the same as the apisix fullname |
 | metrics.serviceMonitor.namespace | string | `""` | namespace where the serviceMonitor is deployed, by default, it is the same as the namespace of the apisix |
+| minReadySeconds | int | `0` | Minimum number of seconds a new pod must stay Ready before it is considered available, `0` keeps the Kubernetes default |
 | nameOverride | string | `""` | String to partially override the chart fullname |
 | nodeSelector | object | `{}` | Node labels for Apache APISIX pod assignment |
 | podAnnotations | object | `{}` | Annotations to add to each pod |
@@ -275,7 +278,9 @@ The command removes all the Kubernetes components associated with the chart and 
 | podDisruptionBudget.minAvailable | string | `"90%"` | Set the `minAvailable` of podDisruptionBudget. You can specify only one of `maxUnavailable` and `minAvailable` in a single PodDisruptionBudget. See [Specifying a Disruption Budget for your Application](https://kubernetes.io/docs/tasks/run-application/configure-pdb/#specifying-a-poddisruptionbudget) for more details |
 | podSecurityContext | object | `{}` | Set the securityContext for Apache APISIX pods |
 | priorityClassName | string | `""` | Set [priorityClassName](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#pod-priority) for Apache APISIX pods |
+| progressDeadlineSeconds | int | `600` | Number of seconds a Deployment may make no rollout progress before it is reported as failed (Deployment only) |
 | rbac.create | bool | `false` | Whether RBAC resources (ClusterRole and ClusterRoleBinding) should be created |
+| readinessProbe | object | `{}` | Override the readiness probe of the APISIX container, the default probes `/status/ready` when the status endpoint is enabled and the proxy TCP port otherwise |
 | replicaCount | int | `1` | if useDaemonSet is true or autoscaling.enabled is true, replicaCount not become effective |
 | resources | object | `{}` | Set pod resource requests & limits |
 | securityContext | object | `{}` | Set the securityContext for Apache APISIX container |
@@ -297,6 +302,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | serviceAccount.annotations | object | `{}` | Annotations to add to the ServiceAccount |
 | serviceAccount.create | bool | `false` | Whether a ServiceAccount should be created for the APISIX pods |
 | serviceAccount.name | string | `""` | Name of the ServiceAccount to use. If not set and create is true, a name is generated from the chart fullname |
+| terminationGracePeriodSeconds | int | `30` | Number of seconds the pod is given to terminate gracefully, must cover the 30s `preStop` sleep plus `apisix.nginx.workerShutdownTimeout` when draining in-flight requests |
 | timezone | string | `""` | timezone is the timezone where apisix uses. For example: "UTC" or "Asia/Shanghai" This value will be set on apisix container's environment variable TZ. You may need to set the timezone to be consistent with your local time zone, otherwise the apisix's logs may used to retrieve event maybe in wrong timezone. |
 | tolerations | list | `[]` | List of node taints to tolerate |
 | topologySpreadConstraints | list | `[]` | Topology Spread Constraints for pod assignment spread across your cluster among failure-domains ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/#spread-constraints-for-pods |

--- a/charts/apisix/templates/configmap.yaml
+++ b/charts/apisix/templates/configmap.yaml
@@ -186,7 +186,7 @@ data:
         fallback_sni: {{ .Values.apisix.ssl.fallbackSNI | quote }}
         {{- end }}
       {{- $useTraditionalYaml := and (eq .Values.apisix.deployment.role "traditional") (eq .Values.apisix.deployment.role_traditional.config_provider "yaml") }}
-      {{- if $useTraditionalYaml }}
+      {{- if or $useTraditionalYaml .Values.apisix.status.enabled }}
       status:
         ip: {{ default "127.0.0.1" .Values.apisix.status.ip }}
         port: {{ default "7085" (.Values.apisix.status.port | toString) }}

--- a/charts/apisix/templates/deployment.yaml
+++ b/charts/apisix/templates/deployment.yaml
@@ -24,6 +24,12 @@ spec:
 {{- if and (not .Values.useDaemonSet) (not .Values.autoscaling.enabled) }}
   replicas: {{ .Values.replicaCount }}
 {{- end }}
+{{- if .Values.minReadySeconds }}
+  minReadySeconds: {{ .Values.minReadySeconds }}
+{{- end }}
+{{- if and (not .Values.useDaemonSet) .Values.progressDeadlineSeconds }}
+  progressDeadlineSeconds: {{ .Values.progressDeadlineSeconds }}
+{{- end }}
   selector:
     matchLabels:
       {{- include "apisix.selectorLabels" . | nindent 6 }}
@@ -50,6 +56,7 @@ spec:
         - name: {{ . }}
         {{- end }}
       {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       serviceAccountName: {{ include "apisix.serviceAccountName" . }}
       {{- with .Values.podSecurityContext }}
       securityContext: 
@@ -154,19 +161,27 @@ spec:
             {{- end }}
             {{- end }}
             {{- end }}
-            {{- if $useTraditionalYaml }}
+            {{- if or $useTraditionalYaml .Values.apisix.status.enabled }}
             - name: status
               containerPort: {{ default 7085 .Values.apisix.status.port }}
               protocol: TCP
             {{- end}}
 
+          {{- with .Values.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- else }}
           {{- if ne .Values.apisix.deployment.role "control_plane" }}
           readinessProbe:
             failureThreshold: 6
             initialDelaySeconds: 10
             periodSeconds: 10
             successThreshold: 1
-            {{- if $useTraditionalYaml }}
+            {{- if or $useTraditionalYaml .Values.apisix.status.enabled }}
             httpGet:
               path: /status/ready
               port: {{ default 7085 .Values.apisix.status.port }}
@@ -175,6 +190,7 @@ spec:
               port: {{ .Values.service.http.containerPort }}
             {{- end}}
             timeoutSeconds: 1
+          {{- end }}
           {{- end }}
           lifecycle:
             preStop:

--- a/charts/apisix/values.yaml
+++ b/charts/apisix/values.yaml
@@ -112,6 +112,21 @@ extraEnvVars: []
 updateStrategy: {}
   # type: RollingUpdate
 
+# -- Minimum number of seconds a new pod must stay Ready before it is considered available, `0` keeps the Kubernetes default
+minReadySeconds: 0
+
+# -- Number of seconds a Deployment may make no rollout progress before it is reported as failed (Deployment only)
+progressDeadlineSeconds: 600
+
+# -- Number of seconds the pod is given to terminate gracefully, must cover the 30s `preStop` sleep plus `apisix.nginx.workerShutdownTimeout` when draining in-flight requests
+terminationGracePeriodSeconds: 30
+
+# -- Override the liveness probe of the APISIX container, by default no liveness probe is set
+livenessProbe: {}
+
+# -- Override the readiness probe of the APISIX container, the default probes `/status/ready` when the status endpoint is enabled and the proxy TCP port otherwise
+readinessProbe: {}
+
 # -- Additional Kubernetes resources to deploy with the release.
 extraDeploy: []
 
@@ -789,6 +804,8 @@ apisix:
               path: "mount-path"
 
   status:
+    # -- Enable the status endpoint and probe `/status/ready` for readiness in every deployment mode, always enabled when `role_traditional.config_provider` is `yaml`. Requires APISIX >= 3.13.0
+    enabled: false
     # -- The IP address on which the status endpoint (`/status`, `/status/ready`) listens
     ip: "0.0.0.0"
     # -- The port on which the status endpoint listens


### PR DESCRIPTION
### Problem

During a rolling update in etcd mode, new pods receive traffic before they are ready. For a short time they answer 404. The cause: the readiness probe is only a TCP check on the proxy port. The pod becomes Ready when nginx starts to listen. At that moment, the workers have not loaded the routes from etcd yet.

APISIX already has a correct readiness endpoint: `/status/ready`. It returns 200 only after every worker has loaded the configuration. It works in etcd mode too, since APISIX 3.13.0 (apache/apisix#12200). But the chart enables this endpoint only for `role_traditional` + `config_provider: yaml`.

There is a second problem, at shutdown. The chart lets you configure a graceful drain (`apisix.nginx.workerShutdownTimeout`), but it does not let you configure `terminationGracePeriodSeconds`. So Kubernetes always kills a stopping pod after 30 seconds, even when the drain timeout is longer.

### Changes

- New value `apisix.status.enabled`: enables the status endpoint in every deployment mode. When it is on, the default readiness probe uses `httpGet /status/ready` instead of the TCP check.
- New values: `terminationGracePeriodSeconds`, `minReadySeconds`, `progressDeadlineSeconds`, and `livenessProbe` / `readinessProbe` overrides.
- Chart version 2.17.0 → 2.18.0. README regenerated with helm-docs.

### Related work

Closes #951. Issue #951 and PR #952 ask for a configurable `livenessProbe`. This PR includes one, as a full-map override value instead of a fixed-fields toggle, so users control every probe field. The new values live at the top level of values.yaml, next to the existing `updateStrategy`.

### No change for existing users

All defaults keep the current behavior. A render with default values is identical to master, except that `progressDeadlineSeconds: 600` and `terminationGracePeriodSeconds: 30` are now written explicitly — both are the Kubernetes defaults. Note: `terminationGracePeriodSeconds` is part of the pod template, so the first upgrade to this chart version restarts the APISIX pods one time. I verified the renders for the etcd, traditional yaml, DaemonSet, and control_plane modes. `ct lint` passes.
