### PR TITLE
fix(apisix-ingress-controller): pdb.yaml references undefined helpers, release 1.3.1

### DIFF
--- a/charts/apisix-ingress-controller/Chart.yaml
+++ b/charts/apisix-ingress-controller/Chart.yaml
@@ -24,7 +24,7 @@ keywords:
   - nginx
   - crd
 type: application
-version: 1.3.0
+version: 1.3.1
 appVersion: 2.2.0
 sources:
   - https://github.com/apache/apisix-helm-chart

--- a/charts/apisix-ingress-controller/templates/pdb.yaml
+++ b/charts/apisix-ingress-controller/templates/pdb.yaml
@@ -22,10 +22,10 @@ apiVersion: policy/v1
 {{- end }}
 kind: PodDisruptionBudget
 metadata:
-  name: {{ include "apisix-ingress-controller.fullname" . }}
+  name: {{ include "apisix-ingress-controller-manager.name.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "apisix-ingress-controller.labels" . | nindent 4 }}
+    {{- include "apisix-ingress-controller-manager.labels" . | nindent 4 }}
 spec:
 {{- if .Values.podDisruptionBudget.minAvailable }}
   minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
@@ -34,5 +34,5 @@ spec:
 {{- end }}
   selector:
     matchLabels:
-{{- include "apisix-ingress-controller.selectorLabels" . | nindent 6 }}
+{{- include "apisix-ingress-controller-manager.selectorLabels" . | nindent 6 }}
 {{- end }}


### PR DESCRIPTION
Closes #946. Carries the fix from #968 (commit kept with its author), plus a chart version bump so it ships.

`charts/apisix-ingress-controller/templates/pdb.yaml` includes `apisix-ingress-controller.{fullname,labels,selectorLabels}`, but `_helpers.tpl` only defines the `apisix-ingress-controller-manager.*` names, so `podDisruptionBudget.enabled=true` with more than one replica fails to render:

```
helm template t apisix-ingress-controller --repo https://apache.github.io/apisix-helm-chart \
  --set podDisruptionBudget.enabled=true --set deployment.replicas=2
# Error: ... no template "apisix-ingress-controller.fullname" associated with template "gotpl"
```

Changes:

- use the defined `apisix-ingress-controller-manager.*` helpers; the PDB selector now matches the Deployment's selector labels
- bump `apisix-ingress-controller` to 1.3.1 (chart-only fix, `appVersion` stays 2.2.0)

Verified locally: `ct lint` passes, and the PDB renders with the Deployment's selector labels.
