### PR TITLE
feat(apisix-ingress-controller): make Gateway API CRDs optional via crds.gatewayAPI.enabled

### DIFF
--- a/charts/apisix-ingress-controller/Chart.yaml
+++ b/charts/apisix-ingress-controller/Chart.yaml
@@ -24,7 +24,7 @@ keywords:
   - nginx
   - crd
 type: application
-version: 1.3.1
+version: 1.4.0
 appVersion: 2.2.0
 sources:
   - https://github.com/apache/apisix-helm-chart

--- a/charts/apisix-ingress-controller/README.md
+++ b/charts/apisix-ingress-controller/README.md
@@ -129,6 +129,7 @@ The same for container level, you need to set:
 | config.provider.syncPeriod | string | `"1m"` |  |
 | config.provider.type | string | `"apisix"` |  |
 | config.secureMetrics | bool | `false` |  |
+| crds.gatewayAPI.enabled | bool | `true` | Enable or disable installing the Gateway API standard channel CRDs |
 | deployment.adcContainer | object | `{"config":{"logLevel":"info"},"image":{"repository":"ghcr.io/api7/adc","tag":"0.27.1"}}` | Set adc sidecar container configuration |
 | deployment.affinity | object | `{}` |  |
 | deployment.annotations | object | `{}` | Add annotations to Apache APISIX ingress controller resource |

--- a/charts/apisix-ingress-controller/gateway-api/standard-install.yaml
+++ b/charts/apisix-ingress-controller/gateway-api/standard-install.yaml
@@ -1,3 +1,24 @@
+# Copyright The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# Gateway API Standard channel install
+#
+---
+#
+# config/crd/standard/gateway.networking.k8s.io_backendtlspolicies.yaml
+#
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -1375,6 +1396,9 @@ spec:
     subresources:
       status: {}
 ---
+#
+# config/crd/standard/gateway.networking.k8s.io_gatewayclasses.yaml
+#
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -1888,6 +1912,9 @@ spec:
     subresources:
       status: {}
 ---
+#
+# config/crd/standard/gateway.networking.k8s.io_gateways.yaml
+#
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -5180,6 +5207,9 @@ spec:
     subresources:
       status: {}
 ---
+#
+# config/crd/standard/gateway.networking.k8s.io_grpcroutes.yaml
+#
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -7253,6 +7283,9 @@ spec:
     subresources:
       status: {}
 ---
+#
+# config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
+#
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -14173,6 +14206,9 @@ spec:
     subresources:
       status: {}
 ---
+#
+# config/crd/standard/gateway.networking.k8s.io_listenersets.yaml
+#
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -14948,6 +14984,9 @@ spec:
     subresources:
       status: {}
 ---
+#
+# config/crd/standard/gateway.networking.k8s.io_referencegrants.yaml
+#
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -15300,6 +15339,9 @@ spec:
     storage: true
     subresources: {}
 ---
+#
+# config/crd/standard/gateway.networking.k8s.io_tcproutes.yaml
+#
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -16593,6 +16635,9 @@ spec:
     subresources:
       status: {}
 ---
+#
+# config/crd/standard/gateway.networking.k8s.io_tlsroutes.yaml
+#
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -18717,6 +18762,9 @@ spec:
     subresources:
       status: {}
 ---
+#
+# config/crd/standard/gateway.networking.k8s.io_udproutes.yaml
+#
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -20010,49 +20058,46 @@ spec:
     subresources:
       status: {}
 ---
+#
+# config/crd/standard/gateway.networking.k8s.io_vap_safeupgrades.yaml
+#
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
 metadata:
   annotations:
     gateway.networking.k8s.io/bundle-version: v1.6.0
     gateway.networking.k8s.io/channel: standard
-  name: safe-upgrades.gateway.networking.k8s.io
+  name: "safe-upgrades.gateway.networking.k8s.io"
 spec:
   failurePolicy: Fail
   matchConstraints:
     resourceRules:
-    - apiGroups:
-      - apiextensions.k8s.io
-      apiVersions:
-      - v1
-      operations:
-      - CREATE
-      - UPDATE
-      resources:
-      - '*'
+    - apiGroups:   ["apiextensions.k8s.io"]
+      apiVersions: ["v1"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["*"]
   validations:
-  - expression: object.spec.group != 'gateway.networking.k8s.io' || oldObject == null
-      || ( has(object.metadata.annotations) && object.metadata.annotations.exists(k,
-      k == 'gateway.networking.k8s.io/channel') && object.metadata.annotations['gateway.networking.k8s.io/channel']
-      == 'standard' ) || ( oldObject != null && has(oldObject.metadata.annotations)
-      && oldObject.metadata.annotations.exists(k, k == 'gateway.networking.k8s.io/channel')
-      && oldObject.metadata.annotations['gateway.networking.k8s.io/channel'] == 'experimental'
-      )
-    message: Installing experimental CRDs on top of standard channel CRDs is prohibited
-      by default. Uninstall ValidatingAdmissionPolicy safe-upgrades.gateway.networking.k8s.io
-      to install experimental CRDs on top of standard channel CRDs.
-    reason: Invalid
-  - expression: object.spec.group != 'gateway.networking.k8s.io' || (has(object.metadata.annotations)
-      && object.metadata.annotations.exists(k, k == 'gateway.networking.k8s.io/bundle-version')
-      && ( matches(object.metadata.annotations['gateway.networking.k8s.io/bundle-version'],
-      '-(rc)') || ( !matches(object.metadata.annotations['gateway.networking.k8s.io/bundle-version'],
-      'v1.[0-5].\\d+') && !matches(object.metadata.annotations['gateway.networking.k8s.io/bundle-version'],
-      'v0') ) ))
-    message: Installing CRDs with version before v1.5.0 is prohibited by default.
-      Uninstall ValidatingAdmissionPolicy safe-upgrades.gateway.networking.k8s.io
-      to install older versions.
-    reason: Invalid
+    - expression: "object.spec.group != 'gateway.networking.k8s.io' || oldObject == null || (
+        has(object.metadata.annotations) && object.metadata.annotations.exists(k, k == 'gateway.networking.k8s.io/channel') && 
+        object.metadata.annotations['gateway.networking.k8s.io/channel'] == 'standard' ) || (
+        oldObject != null && has(oldObject.metadata.annotations) && oldObject.metadata.annotations.exists(k, k == 'gateway.networking.k8s.io/channel') && 
+        oldObject.metadata.annotations['gateway.networking.k8s.io/channel'] == 'experimental' )"
+      message: "Installing experimental CRDs on top of standard channel CRDs is prohibited by default. Uninstall ValidatingAdmissionPolicy safe-upgrades.gateway.networking.k8s.io to install experimental CRDs on top of standard channel CRDs."
+      reason: Invalid
+    - expression: "object.spec.group != 'gateway.networking.k8s.io' ||
+        (has(object.metadata.annotations) && object.metadata.annotations.exists(k, k == 'gateway.networking.k8s.io/bundle-version') &&
+        (
+          matches(object.metadata.annotations['gateway.networking.k8s.io/bundle-version'], '-(rc)') ||
+          (
+            !matches(object.metadata.annotations['gateway.networking.k8s.io/bundle-version'], 'v1.[0-5].\\\\d+') &&
+            !matches(object.metadata.annotations['gateway.networking.k8s.io/bundle-version'], 'v0')
+          )
+        ))" #TODO Kubernetes 1.37: Migrate to kubernetes semver library
+      message: "Installing CRDs with version before v1.5.0 is prohibited by default. Uninstall ValidatingAdmissionPolicy safe-upgrades.gateway.networking.k8s.io to install older versions."
+      reason: Invalid
+
 ---
+
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicyBinding
 metadata:
@@ -20061,17 +20106,11 @@ metadata:
     gateway.networking.k8s.io/channel: standard
   name: safe-upgrades.gateway.networking.k8s.io
 spec:
+  policyName: safe-upgrades.gateway.networking.k8s.io
+  validationActions: [Deny]
   matchResources:
     resourceRules:
-    - apiGroups:
-      - apiextensions.k8s.io
-      apiVersions:
-      - v1
-      operations:
-      - CREATE
-      - UPDATE
-      resources:
-      - customresourcedefinitions
-  policyName: safe-upgrades.gateway.networking.k8s.io
-  validationActions:
-  - Deny
+    - apiGroups:   ["apiextensions.k8s.io"]
+      apiVersions: ["v1"]
+      resources:   ["customresourcedefinitions"]
+      operations:  ["CREATE", "UPDATE"]

--- a/charts/apisix-ingress-controller/templates/gateway-api-crds.yaml
+++ b/charts/apisix-ingress-controller/templates/gateway-api-crds.yaml
@@ -1,0 +1,39 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+{{- if .Values.crds.gatewayAPI.enabled }}
+{{- /* Render each CRD only when absent or owned by this release, and keep it on uninstall */}}
+{{- range $document := regexSplit "(?m)^---$" (.Files.Get "gateway-api/standard-install.yaml") -1 }}
+{{- $object := fromYaml $document }}
+{{- if $object.Error }}
+{{- fail (printf "gateway-api/standard-install.yaml: %s" $object.Error) }}
+{{- end }}
+{{- if $object.kind }}
+{{- $existing := lookup $object.apiVersion $object.kind "" $object.metadata.name }}
+{{- $existingAnnotations := dict }}
+{{- if $existing }}
+{{- $existingAnnotations = $existing.metadata.annotations | default dict }}
+{{- end }}
+{{- $ownedByRelease := and (eq (get $existingAnnotations "meta.helm.sh/release-name") $.Release.Name) (eq (get $existingAnnotations "meta.helm.sh/release-namespace") $.Release.Namespace) }}
+{{- if or (not $existing) $ownedByRelease }}
+{{- $annotations := merge (dict "helm.sh/resource-policy" "keep") ($object.metadata.annotations | default dict) }}
+{{- $_ := set $object.metadata "annotations" $annotations }}
+---
+{{ toYaml $object }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/apisix-ingress-controller/values.yaml
+++ b/charts/apisix-ingress-controller/values.yaml
@@ -188,6 +188,11 @@ gatewayProxy:
     # - "10.0.0.1"
     # - "10.0.0.2"
 
+crds:
+  gatewayAPI:
+    # -- Enable or disable installing the Gateway API standard channel CRDs
+    enabled: true
+
 apisix:
   adminService:
     namespace: apisix-ingress

--- a/docs/en/latest/apisix-ingress-controller.md
+++ b/docs/en/latest/apisix-ingress-controller.md
@@ -69,13 +69,13 @@ helm install apisix-ingress-controller apisix/apisix-ingress-controller --namesp
 
 ### CRD
 
-CRDs upgrading is special as helm chart will skip to apply these resources when they already exist.
-
-> With the arrival of Helm 3, we removed the old crd-install hooks for a more simple methodology. There is now a special directory called crds that you can create in your chart to hold your CRDs. These CRDs are not templated, but will be installed by default when running a helm install for the chart. If the CRD already exists, it will be skipped with a warning. If you wish to skip the CRD installation step, you can pass the --skip-crds flag.
-
-In such a case, you may need to apply these CRDs by yourself.
+Helm installs the APISIX CRDs in `crds/` on `helm install` only and skips them on `helm upgrade`, so apply them yourself when upgrading:
 
 ```shell
-cd /path/to/apisix-ingress-controller
-kubectl apply -k samples/deploy/crd/
+helm pull apisix/apisix-ingress-controller --untar
+kubectl apply --server-side -f apisix-ingress-controller/crds/apisixic-crds.yaml
 ```
+
+The Gateway API CRDs are chart-managed and controlled by `crds.gatewayAPI.enabled` (default `true`).
+CRDs not created by this release (for example by GKE or another chart) are left untouched, and chart-managed ones are kept on `helm uninstall`.
+Set `crds.gatewayAPI.enabled=false` when another component owns the CRDs and you render the chart with `helm template` or Argo CD.


### PR DESCRIPTION
Fixes #958. Alternative to #919.

### Why

The chart ships the Gateway API CRDs in `crds/`, which Helm installs once and never updates, cannot toggle, and cannot reconcile with CRDs that already exist in the cluster.
On GKE 1.35 the Gateway API CRDs are pre-installed and guarded by a `ValidatingAdmissionPolicy`, so users have to work around the chart with `--skip-crds` and manual `kubectl apply`, which also skips the APISIX CRDs.

### What

- Move the vendored Gateway API v1.6.0 standard bundle (unchanged content) from `crds/gwapi-crds.yaml` to `gateway-api/standard-install.yaml`, rendered by a template behind `crds.gatewayAPI.enabled` (default `true`).
- A CRD is rendered only when it does not exist yet or already belongs to this release, so CRDs installed by GKE, Istio, Cilium or an older chart version are left untouched and never adopted.
- Chart-managed CRDs carry `helm.sh/resource-policy: keep`, so `helm uninstall` and `crds.gatewayAPI.enabled=false` never delete them.
- APISIX CRDs stay in `crds/` and keep following `--skip-crds`.
- Chart 1.3.1 -> 1.4.0.

### Verified

kind, Helm 3.19 and 4.1: fresh install, pre-existing unowned CRDs (GKE-like), upgrade from chart 1.3.0, `helm upgrade` updating chart-owned CRDs, `enabled=false` and `helm uninstall` keeping CRDs, `helm template` without cluster access.
